### PR TITLE
Widgetstore

### DIFF
--- a/src/custom_layout.ts
+++ b/src/custom_layout.ts
@@ -1,23 +1,126 @@
-import { Widget, Layout, LayoutItem, PanelLayout } from '@lumino/widgets';
+import { Widget, Layout, LayoutItem } from '@lumino/widgets';
 
-import { ArrayExt, IIterator, map } from '@lumino/algorithm';
+import { IIterator, map, each } from '@lumino/algorithm';
 
 import { MessageLoop } from '@lumino/messaging';
 
 import { DashboardWidget } from './widget';
 
-/**
- * Layout for DashboardArea widget.
- */
-export class DashboardLayout extends PanelLayout {
-  _dropLocation: number[];
-  /**
-   * Construct a new dashboard layout.
-   *
-   * @param options - The options for initializing the layout.
-   */
-  constructor(options: DashboardLayout.IOptions = {}) {
+import { Message } from '@lumino/messaging';
+
+import { Widgetstore } from './widgetstore';
+
+import { WidgetTracker } from '@jupyterlab/apputils';
+
+export class DashboardLayout extends Layout {
+  constructor(options: DashboardLayout.IOptions) {
     super(options);
+    this._items = new Map<string, LayoutItem>();
+    this._store = options.store;
+    this._outputTracker = options.outputTracker;
+  }
+
+  /**
+   * Dispose of resources held by the layout.
+   */
+  dispose(): void {
+    this._items.forEach((item) => item.dispose());
+    this._outputTracker = null;
+    this._store = null;
+    super.dispose();
+  }
+
+  /**
+   * Perform layout initialization which requires the parent widget.
+   */
+  protected init(): void {
+    super.init();
+    each(this, (widget) => {
+      this.attachWidget(widget);
+    });
+    console.log('initialized');
+  }
+
+  /**
+   * Add a widget to Dashboard layout.
+   *
+   * @param widget - The widget to add to the layout.
+   *
+   */
+  addWidget(widget: DashboardWidget, pos: Widgetstore.WidgetPosition): void {
+    // Add the widget to the layout.
+    const item = new LayoutItem(widget);
+    this._items.set(widget.id, item);
+
+    // Attach the widget to the parent.
+    if (this.parent) {
+      this.attachWidget(widget);
+      this.moveWidget(widget, pos);
+      this._outputTracker.add(widget);
+    }
+  }
+
+  moveWidget(
+    widget: DashboardWidget,
+    pos: Widgetstore.WidgetPosition
+  ): boolean {
+    // Get the item from the map.
+    const item = this._items.get(widget.id);
+
+    // If the item doesn't exist, exit.
+    if (item === undefined) {
+      return false;
+    }
+
+    // Send an update request to the layout item.
+    const { left, top, width, height } = pos;
+    item.update(left, top, width, height);
+
+    return true;
+  }
+
+  removeWidget(widget: Widget): void {
+    void this.deleteWidget(widget);
+  }
+
+  /**
+   * Remove a widget from Dashboard layout.
+   *
+   * @param widget - The widget to remove from the layout.
+   *
+   */
+  deleteWidget(widget: Widget): boolean {
+    // Look up the widget in the _items map.
+    const item = this._items.get(widget.id);
+
+    // Bail if it's not there.
+    if (item === undefined) {
+      return false;
+    }
+
+    // Remove the item from the map.
+    this._items.delete(widget.id);
+
+    // Detach the widget from the parent.
+    if (this.parent) {
+      this.detachWidget(-1, widget);
+    }
+
+    // Dispose the layout item.
+    item.dispose();
+
+    return true;
+  }
+
+  /**
+   * Create an iterator over the widgets in the layout.
+   *
+   * @returns A new iterator over the widgets in the layout.
+   */
+  iter(): IIterator<Widget> {
+    // Is there a lazy way to iterate through the map?
+    const arr = Array.from(this._items.values());
+    return map(arr, (item) => item.widget);
   }
 
   /**
@@ -25,7 +128,7 @@ export class DashboardLayout extends PanelLayout {
    *
    * @param widget - The widget to attach to the parent.
    */
-  protected attachWidget(index: number, widget: Widget): void {
+  protected attachWidget(widget: Widget): void {
     // Send a `'before-attach'` message if the parent is attached.
     if (this.parent!.isAttached) {
       MessageLoop.sendMessage(widget, Widget.Msg.BeforeAttach);
@@ -44,58 +147,11 @@ export class DashboardLayout extends PanelLayout {
   }
 
   /**
-   * Add a widget to Dashboard layout.
-   *
-   * @param widget - The widget to add to the layout.
-   *
-   */
-  addWidget(widget: DashboardWidget): void {
-    // Add the widget to the layout.
-    const item = new LayoutItem(widget);
-    this._items.push(item);
-
-    // Attach the widget to the parent.
-    if (this.parent) {
-      this.attachWidget(-1, widget);
-
-      const numPos = this._dropLocation;
-      this._update(numPos, item);
-    }
-  }
-
-  /**
-   * Create an iterator over the widgets in the layout.
-   *
-   * @returns A new iterator over the widgets in the layout.
-   */
-  iter(): IIterator<Widget> {
-    return map(this._items, item => item.widget);
-  }
-
-  /**
-   * Update the item given postion in the layout.
-   *
-   */
-  private _update(pos: number[], item: LayoutItem) {
-    if (pos !== undefined) {
-      item.update(pos[0], pos[1], pos[2], pos[3]);
-    }
-  }
-
-  /**
-   * Insert a widget at position specified.
-   */
-  placeWidget(index: number, widget: DashboardWidget, pos: number[]): void {
-    this._dropLocation = pos;
-    this.addWidget(widget);
-  }
-
-  /**
    * Detach a widget from the parent's DOM node.
    *
    * @param widget - The widget to detach from the parent.
    */
-  protected detachWidget(index: number, widget: Widget): void {
+  protected detachWidget(_index: number, widget: Widget): void {
     // Send a `'before-detach'` message if the parent is attached.
     if (this.parent!.isAttached) {
       MessageLoop.sendMessage(widget, Widget.Msg.BeforeDetach);
@@ -113,35 +169,249 @@ export class DashboardLayout extends PanelLayout {
     this.parent!.fit();
   }
 
-  /**
-   * Remove a widget from Dashboard layout.
-   *
-   * @param widget - The widget to remove from the layout.
-   *
-   */
-  removeWidget(widget: Widget): void {
-    // Look up the index for the widget.
-    const i = ArrayExt.findFirstIndex(this._items, it => it.widget === widget);
-
-    // Bail if the widget is not in the layout.
-    if (i === -1) {
+  protected onUpdateRequest(msg: Message): void {
+    // Return if guard is set to prevent infinite looping.
+    if (this._updateGuard) {
       return;
     }
 
-    // Remove the widget from the layout.
-    const item = ArrayExt.removeAt(this._items, i)!;
+    // Set the guard.
+    this._updateGuard = true;
+    this._store.beginTransaction();
 
-    // Detach the widget from the parent.
-    if (this.parent) {
-      this.detachWidget(-1, widget);
-    }
+    // Process all changed widgets in the store.
+    each(this._store.getChangedWidgets(), (widgetInfo) => {
+      const item = this._items.get(widgetInfo.widgetId);
+      const pos = widgetInfo as Widgetstore.WidgetPosition;
+      let removed = false;
 
-    // Dispose the layout item.
-    item.dispose();
+      // Widget added for first time or was undeleted.
+      if (item === undefined) {
+        console.log('added widget');
+        const newWidget = this._store.createWidget(
+          widgetInfo as Widgetstore.WidgetInfo
+        );
+        this.addWidget(newWidget, pos);
+      }
+      // Widget was just deleted.
+      else if (widgetInfo.removed) {
+        console.log('deleted widget');
+        const widget = item.widget;
+        this.removeWidget(widget);
+        removed = true;
+      }
+      // Widget was moved or resized.
+      else {
+        console.log('moved widget');
+        this.moveWidget(item.widget as DashboardWidget, pos);
+      }
+
+      // Mark record as processed and removed if applicable.
+      this._store.updateRecord(
+        {
+          schema: Widgetstore.WIDGET_SCHEMA,
+          record: widgetInfo.widgetId,
+        },
+        {
+          changed: false,
+          removed,
+        }
+      );
+    });
+
+    this._store.endTransaction();
+
+    // Remove guard.
+    this._updateGuard = false;
   }
 
-  private _items: LayoutItem[] = [];
+  private _items: Map<string, LayoutItem>;
+  private _store: Widgetstore;
+  private _outputTracker: WidgetTracker<DashboardWidget>;
+  private _updateGuard = false;
 }
+
+// /**
+//  * Layout for DashboardArea widget.
+//  */
+// export class DashboardLayout extends PanelLayout {
+//   _dropLocation: number[];
+//   /**
+//    * Construct a new dashboard layout.
+//    *
+//    * @param options - The options for initializing the layout.
+//    */
+//   constructor(options: DashboardLayout.IOptions) {
+//     super(options);
+//     this._items = new Map<string, LayoutItem>();
+//     this._store = options.store;
+//     console.log(this._store);
+//   }
+
+//   /**
+//    * Attach a widget to the parent's DOM node.
+//    *
+//    * @param widget - The widget to attach to the parent.
+//    */
+//   protected attachWidget(index: number, widget: Widget): void {
+//     // Send a `'before-attach'` message if the parent is attached.
+//     if (this.parent!.isAttached) {
+//       MessageLoop.sendMessage(widget, Widget.Msg.BeforeAttach);
+//     }
+
+//     // Add the widget's node to the parent.
+//     this.parent!.node.appendChild(widget.node);
+
+//     // Send an `'after-attach'` message if the parent is attached.
+//     if (this.parent!.isAttached) {
+//       MessageLoop.sendMessage(widget, Widget.Msg.AfterAttach);
+//     }
+
+//     // Post a fit request for the parent widget.
+//     this.parent!.fit();
+//   }
+
+//   /**
+//    * Add a widget to Dashboard layout.
+//    *
+//    * @param widget - The widget to add to the layout.
+//    *
+//    */
+//   addWidget(widget: DashboardWidget): void {
+//     // Add the widget to the layout.
+//     const item = new LayoutItem(widget);
+//     this._items.set(widget.id, item);
+
+//     // Attach the widget to the parent.
+//     if (this.parent) {
+//       this.attachWidget(-1, widget);
+
+//       const numPos = this._dropLocation;
+//       this._update(numPos, item);
+//     }
+//   }
+
+//   /**
+//    * Create an iterator over the widgets in the layout.
+//    *
+//    * @returns A new iterator over the widgets in the layout.
+//    */
+//   iter(): IIterator<Widget> {
+//     // Is there a lazy way to iterate through the map?
+//     let arr = Array.from(this._items.values());
+//     return map(arr, item => item.widget);
+//   }
+
+//   /**
+//    * Update the item given postion in the layout.
+//    */
+//   private _update(pos: number[], item: LayoutItem) {
+//     if (pos !== undefined) {
+//       const [ left, top, width, height ] = pos;
+//       item.update(left, top, width, height);
+//     }
+//   }
+
+//   protected onUpdateRequest(msg: Message): void {
+
+//     console.log('update recieved');
+//     each(this._store.getChangedWidgets(),
+//       widgetInfo => {
+//         let item = this._items.get(widgetInfo.widgetId);
+//         let pos = [
+//           widgetInfo.left,
+//           widgetInfo.top,
+//           widgetInfo.width,
+//           widgetInfo.height
+//         ];
+
+//         // Widget added for first time or was undeleted.
+//         if (item === undefined) {
+//           console.log('widget added or undeleted', widgetInfo, item);
+//           let newWidget = this._store.createWidget(widgetInfo as Widgetstore.WidgetInfo);
+//           this.placeWidget(-1, newWidget, pos);
+//         }
+//         // Widget was just deleted.
+//         else if (widgetInfo.removed) {
+//           console.log('widget removed', widgetInfo, item);
+//           let widget = item.widget;
+//           this.removeWidget(widget);
+//         }
+//         // Widget was moved or resized.
+//         else {
+//           console.log('widget moved or resized', widgetInfo, item);
+//           this._update(pos, item);
+//         }
+//       }
+//     );
+
+//     super.onUpdateRequest(msg);
+
+//     this._store.markAllAsUnchanged();
+//   }
+
+//   /**
+//    * Insert a widget at position specified.
+//    */
+//   placeWidget(index: number, widget: DashboardWidget, pos: number[]): void {
+//     this._dropLocation = pos;
+//     this.addWidget(widget);
+//   }
+
+//   /**
+//    * Detach a widget from the parent's DOM node.
+//    *
+//    * @param widget - The widget to detach from the parent.
+//    */
+//   protected detachWidget(_index: number, widget: Widget): void {
+//     // Send a `'before-detach'` message if the parent is attached.
+//     if (this.parent!.isAttached) {
+//       MessageLoop.sendMessage(widget, Widget.Msg.BeforeDetach);
+//     }
+
+//     // Remove the widget's node from the parent.
+//     this.parent!.node.removeChild(widget.node);
+
+//     // Send an `'after-detach'` message if the parent is attached.
+//     if (this.parent!.isAttached) {
+//       MessageLoop.sendMessage(widget, Widget.Msg.AfterDetach);
+//     }
+
+//     // Post a fit request for the parent widget.
+//     this.parent!.fit();
+//   }
+
+//   /**
+//    * Remove a widget from Dashboard layout.
+//    *
+//    * @param widget - The widget to remove from the layout.
+//    *
+//    */
+//   removeWidget(widget: Widget): void {
+//     // Look up the widget in the _items map.
+//     const item = this._items.get(widget.id)
+
+//     // Bail if it's not there.
+//     if (item === undefined) {
+//       return;
+//     }
+
+//     // Remove the item from the map.
+//     this._items.delete(widget.id);
+
+//     // Detach the widget from the parent.
+//     if (this.parent) {
+//       this.detachWidget(-1, widget);
+//     }
+
+//     // Dispose the layout item.
+//     item.dispose();
+
+//   }
+
+//   private _items: Map<string, LayoutItem>;
+//   private _store: Widgetstore;
+// }
 
 /**
  * The namespace for the `DashboardLayout` class statics.
@@ -151,5 +421,15 @@ export namespace DashboardLayout {
    * An options object for initializing a Dashboard layout.
    */
 
-  export type IOptions = Layout.IOptions;
+  export interface IOptions extends Layout.IOptions {
+    /**
+     * The tracker to handle deleting and widget focus.
+     */
+    outputTracker: WidgetTracker<DashboardWidget>;
+
+    /**
+     * The widgetstore to update from.
+     */
+    store: Widgetstore;
+  }
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,0 +1,74 @@
+/**
+ * A type that's serialized to create a dashboard file.
+ */
+export type DashboardFile = {
+  /**
+   * The dashboard spec version.
+   */
+  version: number;
+
+  /**
+   * Information about the dashboard grid.
+   */
+  gridSpec: {
+    /**
+     * Unit width of the grid.
+     */
+    width: number;
+
+    /**
+     * Unit height of the grid.
+     */
+    height: number;
+
+    /**
+     * Default width padding.
+     */
+    padX: number;
+
+    /**
+     * Default height padding.
+     */
+    padY: number;
+  };
+
+  /**
+   * A map from notebook paths to IDs.
+   */
+  paths: { [notebookPath: string]: string };
+
+  /**
+   * A map from notebook IDs to an array of widgets used from that notebook.
+   */
+  outputs: { [notebookId: string]: WidgetInfo[] };
+};
+
+/**
+ * A type to hold information to recreate a dashboard widget.
+ */
+export type WidgetInfo = {
+  /**
+   * The cell ID the widget is created from.
+   */
+  id: string;
+
+  /**
+   * The top edge position of the widget.
+   */
+  top: number;
+
+  /**
+   * The left edge position of the widget.
+   */
+  left: number;
+
+  /**
+   * The width of the widget.
+   */
+  width: number;
+
+  /**
+   * The height of the widget.
+   */
+  height: number;
+};

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -12,27 +12,27 @@ import greyDashboardOutlineSvgstr from '../style/icons/dashboard_icon_outline_gr
 export namespace Icons {
   export const whiteDashboard = new LabIcon({
     name: 'pr-icons:white-dashboard',
-    svgstr: whiteDashboardSvgstr
+    svgstr: whiteDashboardSvgstr,
   });
 
   export const greyDashboard = new LabIcon({
     name: 'pr-icons:grey-dashboard',
-    svgstr: greyDashboardSvgstr
+    svgstr: greyDashboardSvgstr,
   });
 
   export const blueDashboard = new LabIcon({
     name: 'pr-icons:blue-dashboard',
-    svgstr: blueDashboardSvgstr
+    svgstr: blueDashboardSvgstr,
   });
 
   export const whiteDashboardOutline = new LabIcon({
     name: 'pr-icons:white-dashboard-icon',
-    svgstr: whiteDashboardOutlineSvgstr
+    svgstr: whiteDashboardOutlineSvgstr,
   });
 
   export const greyDashboardOutline = new LabIcon({
     name: 'pr-icons:grey-dashboard-outline',
-    svgstr: greyDashboardOutlineSvgstr
+    svgstr: greyDashboardOutlineSvgstr,
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,7 @@ import {
   JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 
-import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
-
-import { CodeCell } from '@jupyterlab/cells';
+import { INotebookTracker } from '@jupyterlab/notebook';
 
 import {
   WidgetTracker,
@@ -14,8 +12,6 @@ import {
   showErrorMessage,
 } from '@jupyterlab/apputils';
 
-import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
-
 import { Widget } from '@lumino/widgets';
 
 import { Dashboard } from './dashboard';
@@ -23,8 +19,6 @@ import { Dashboard } from './dashboard';
 import { DashboardWidget } from './widget';
 
 import { DashboardButton } from './button';
-
-import { Widgetstore } from './widgetstore';
 
 // HTML element classes
 
@@ -45,6 +39,10 @@ namespace CommandIDs {
   export const deleteOutput = 'dashboard:delete-dashboard-widget';
 
   export const insert = 'dashboard:insert';
+
+  export const undo = 'dashboard:undo';
+
+  export const redo = 'dashboard:redo';
 }
 
 const extension: JupyterFrontEndPlugin<void> = {
@@ -80,23 +78,23 @@ const extension: JupyterFrontEndPlugin<void> = {
       rank: 13,
     });
 
-    app.contextMenu.addItem({
-      type: 'separator',
-      selector: '.jp-Notebook .jp-CodeCell',
-      rank: 11.9,
-    });
+    // app.contextMenu.addItem({
+    //   type: 'separator',
+    //   selector: '.jp-Notebook .jp-CodeCell',
+    //   rank: 11.9,
+    // });
 
-    app.contextMenu.addItem({
-      command: CommandIDs.addToDashboard,
-      selector: '.jp-Notebook .jp-CodeCell',
-      rank: 11.9,
-    });
+    // app.contextMenu.addItem({
+    //   command: CommandIDs.addToDashboard,
+    //   selector: '.jp-Notebook .jp-CodeCell',
+    //   rank: 11.9,
+    // });
 
-    app.contextMenu.addItem({
-      type: 'separator',
-      selector: '.jp-Notebook .jp-CodeCell',
-      rank: 11.9,
-    });
+    // app.contextMenu.addItem({
+    //   type: 'separator',
+    //   selector: '.jp-Notebook .jp-CodeCell',
+    //   rank: 11.9,
+    // });
 
     app.contextMenu.addItem({
       command: CommandIDs.renameDashboard,
@@ -105,27 +103,21 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     app.contextMenu.addItem({
+      command: CommandIDs.undo,
+      selector: '.pr-JupyterDashboard',
+      rank: 1,
+    });
+
+    app.contextMenu.addItem({
+      command: CommandIDs.redo,
+      selector: '.pr-JupyterDashboard',
+      rank: 2,
+    });
+
+    app.contextMenu.addItem({
       command: CommandIDs.deleteOutput,
       selector: '.pr-DashboardWidget',
       rank: 0,
-    });
-
-    app.contextMenu.addItem({
-      command: CommandIDs.insert,
-      selector: '.jp-Notebook .jp-CodeCell',
-      rank: 15,
-    });
-
-    app.contextMenu.addItem({
-      command: 'cellTest',
-      selector: '.jp-Notebook .jp-Cell',
-      rank: 100,
-    });
-
-    app.contextMenu.addItem({
-      command: 'addID',
-      selector: '.jp-Notebook',
-      rank: 100,
     });
 
     // Add commands to key bindings
@@ -155,109 +147,76 @@ function addCommands(
    * Get the current widget and activate unless the args specify otherwise.
    * jupyterlab/packages/notebook-extension/src/index.ts
    */
-  function getCurrentNotebook(
-    args: ReadonlyPartialJSONObject
-  ): NotebookPanel | null {
-    const widget = tracker.currentWidget;
-    const activate = args['activate'] !== false;
+  // function getCurrentNotebook(
+  //   args: ReadonlyPartialJSONObject
+  // ): NotebookPanel | null {
+  //   const widget = tracker.currentWidget;
+  //   const activate = args['activate'] !== false;
 
-    if (activate && widget) {
-      shell.activateById(widget.id);
-    }
+  //   if (activate && widget) {
+  //     shell.activateById(widget.id);
+  //   }
 
-    return widget;
-  }
+  //   return widget;
+  // }
 
   /**
    * Get the current notebook output wrapped in a DashboardWidget.
    */
-  function getCurrentWidget(currentNotebook: NotebookPanel): DashboardWidget {
-    if (!currentNotebook) {
-      return;
-    }
-    const cell = currentNotebook.content.activeCell as CodeCell;
-    const index = currentNotebook.content.activeCellIndex;
+  // function getCurrentWidget(currentNotebook: NotebookPanel): DashboardWidget {
+  //   if (!currentNotebook) {
+  //     return;
+  //   }
+  //   const cell = currentNotebook.content.activeCell as CodeCell;
+  //   const index = currentNotebook.content.activeCellIndex;
 
-    return new DashboardWidget({
-      notebook: currentNotebook,
-      cell,
-      index,
-    });
-  }
+  //   return new DashboardWidget({
+  //     notebook: currentNotebook,
+  //     cell,
+  //     index,
+  //   });
+  // }
 
   /**
    * Get the current Dashboard.
    */
-  function getCurrentDashboard(): Dashboard {
-    return dashboardTracker.currentWidget;
-  }
+  // function getCurrentDashboard(): Dashboard {
+  //   return dashboardTracker.currentWidget;
+  // }
+
+  // function createDashboard(): void {
+  //   const panel = getCurrentNotebook({ activate: false });
+  //   const dashboard = new Dashboard({ outputTracker, panel, notebookTracker: tracker});
+  //   panel.context.addSibling(dashboard, {
+  //     ref: panel.id,
+  //     mode: 'split-bottom',
+  //   });
+  //   dashboardTracker.add(dashboard);
+  // }
 
   /**
    * Inserts a widget into a dashboard.
-   * If dashboard isn't defined, it's the most recently focused or added Dashboard.
-   * If widget isn't defined, it's a widget created from the most recently focused code cell.
-   * If index isn't defined, it's -1 (inserted at the end of the dashboard).
    */
-  async function insertWidget(
-    options: DashboardInsert.IOptions
-  ): Promise<void> {
-    let dashboard =
-      options.dashboard !== undefined
-        ? options.dashboard
-        : getCurrentDashboard();
+  // async function addWidget(
+  //   dashboard: Dashboard,
+  //   notebook: NotebookPanel,
+  //   cell: Cell
+  // ): Promise<void> {
 
-    if (!dashboard && !options.createNew) {
-      return;
-    }
+  //   const info: Widgetstore.WidgetInfo = {
+  //     widgetId: DashboardWidget.createDashboardWidgetId(),
+  //     notebookId: addNotebookId(notebook),
+  //     cellId: addCellId(cell),
+  //     top: 0,
+  //     left: 0,
+  //     width: Widgetstore.DEFAULT_WIDTH,
+  //     height: Widgetstore.DEFAULT_HEIGHT,
+  //     changed: true,
+  //     removed: false
+  //   }
 
-    const currentNotebook:
-      | NotebookPanel
-      | undefined
-      | null = getCurrentNotebook({ activate: false });
-
-    const widget =
-      options.widget !== undefined
-        ? options.widget
-        : getCurrentWidget(currentNotebook);
-
-    if (!widget) {
-      return;
-    }
-
-    const index = options.index !== undefined ? options.index : -1;
-
-    if (options.createNew) {
-      // Create a new dashboard and add the widget.
-      const panel = currentNotebook;
-      dashboard = new Dashboard({ outputTracker, panel });
-      dashboard.insertWidget(-1, widget);
-      currentNotebook.context.addSibling(dashboard, {
-        ref: currentNotebook.id,
-        mode: 'split-bottom',
-      });
-
-      // Add the new dashboard to the tracker.
-      void dashboardTracker.add(dashboard);
-    } else {
-      dashboard.insertWidget(index, widget);
-      dashboard.update();
-    }
-
-    const updateOutputs = (): void => {
-      void outputTracker.save(widget);
-    };
-
-    currentNotebook.context.pathChanged.connect(updateOutputs);
-    currentNotebook.context.model.cells.changed.connect(updateOutputs);
-
-    // Close the output when the parent notebook is closed.
-    // FIXME: This doesn't work!
-    currentNotebook.content.disposed.connect(() => {
-      currentNotebook!.context.pathChanged.disconnect(updateOutputs);
-      currentNotebook!.context.model.cells.changed.disconnect(updateOutputs);
-      widget.dispose;
-    });
-  }
+  //   dashboard.addWidget(info);
+  // }
 
   /**
    * Whether there is an active notebook.
@@ -295,65 +254,32 @@ function addCommands(
    */
   commands.addCommand(CommandIDs.deleteOutput, {
     label: 'Delete Output',
-    execute: (args) => outputTracker.currentWidget.dispose(),
-  });
-
-  commands.addCommand('addID', {
-    label: 'Test Notebook ID Tools',
     execute: (args) => {
-      const currentNotebook = getCurrentNotebook({ activate: false });
-      console.log('added', Widgetstore.addNotebookId(currentNotebook));
-      const id = Widgetstore.getNotebookId(currentNotebook);
-      console.log('read', id);
-      console.log('notebook', Widgetstore.getNotebookById(id, tracker));
-    },
-  });
-
-  commands.addCommand('cellTest', {
-    label: 'Test Cell ID Tools',
-    execute: (args) => {
-      const currentNotebook = getCurrentNotebook({ activate: false });
-      const currentCell = currentNotebook.content.activeCell;
-      console.log('added', Widgetstore.addCellId(currentCell));
-      const id = Widgetstore.getCellId(currentCell);
-      console.log('read', id);
-      console.log('cell', Widgetstore.getCellById(id, tracker));
+      const widget = outputTracker.currentWidget;
+      dashboardTracker.currentWidget.deleteWidget(widget);
     },
   });
 
   /**
-   * Brings up a dialog box for the user to enter an index to insert the selected widget at.
+   * Undo the last change to a dashboard.
    */
-  commands.addCommand(CommandIDs.insert, {
-    label: 'Insert in Dashboard',
-    execute: (args) => {
-      showDialog({
-        title: 'Insert at index',
-        body: new Private.InsertHandler(),
-        focusNodeSelector: 'input',
-        buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Insert' })],
-      }).then((result) => {
-        const value = +result.value;
-        if (isNaN(value)) {
-          void showErrorMessage(
-            'Not A Number',
-            Error(`"${result.value}" cannot be converted to a number.`)
-          );
-          return;
-        }
-        if (value < 0) {
-          void showErrorMessage(
-            'Index Error',
-            Error(`"${result.value}" is less than zero.`)
-          );
-          return;
-        }
-        insertWidget({ index: +result.value });
-      });
-    },
+  commands.addCommand(CommandIDs.undo, {
+    label: 'Undo',
+    execute: (args) => dashboardTracker.currentWidget.undo(),
     isEnabled: () =>
-      isEnabledAndSingleSelected() && !!dashboardTracker.currentWidget,
-    isVisible: () => false,
+      dashboardTracker.currentWidget &&
+      dashboardTracker.currentWidget.store.hasUndo(),
+  });
+
+  /**
+   * Redo the last undo to a dashboard.
+   */
+  commands.addCommand(CommandIDs.redo, {
+    label: 'Redo',
+    execute: (args) => dashboardTracker.currentWidget.redo(),
+    isEnabled: () =>
+      dashboardTracker.currentWidget &&
+      dashboardTracker.currentWidget.store.hasRedo(),
   });
 
   /**
@@ -385,8 +311,7 @@ function addCommands(
             );
             return;
           }
-          // Need to cast value to string for some reason. Makes me feel sus.
-          dashboardTracker.currentWidget.rename(result.value as string);
+          dashboardTracker.currentWidget.setName(result.value as string);
           dashboardTracker.currentWidget.update();
         });
       }
@@ -409,47 +334,18 @@ function addCommands(
    * Adds the currently selected cell's output to the dashboard.
    * Currently only supports a single dashboard view at a time.
    */
-  commands.addCommand(CommandIDs.addToDashboard, {
-    label: 'Add to Dashboard',
-    execute: (args) => {
-      if (!getCurrentDashboard()) {
-        insertWidget({ createNew: true });
-      } else {
-        insertWidget({});
-      }
-    },
-    isEnabled: isEnabledAndSingleSelected,
-  });
-}
-
-/**
- * Namespace for inserting dashboard widgets.
- */
-namespace DashboardInsert {
-  export interface IOptions {
-    dashboard?: Dashboard;
-
-    widget?: DashboardWidget;
-
-    index?: number;
-
-    createNew?: boolean;
-  }
-}
-
-/**
- * Namespace for inserting dashboard widgets.
- */
-namespace DashboardInsert {
-  export interface IOptions {
-    dashboard?: Dashboard;
-
-    widget?: DashboardWidget;
-
-    index?: number;
-
-    createNew?: boolean;
-  }
+  //   commands.addCommand(CommandIDs.addToDashboard, {
+  //     label: 'Add to Dashboard',
+  //     execute: (args) => {
+  //       if (!getCurrentDashboard()) {
+  //         insertWidget({ createNew: true });
+  //       } else {
+  //         insertWidget({});
+  //       }
+  //     },
+  //     isEnabled: isEnabledAndSingleSelected,
+  //   });
+  // }
 }
 
 /**
@@ -489,31 +385,6 @@ namespace Private {
     /**
      * Get the value of the widget.
      */
-    getValue(): string {
-      return this.inputNode.value;
-    }
-  }
-
-  /**
-   * A widget used to get an index for inserting widgets into a Dashboard.
-   */
-  export class InsertHandler extends Widget {
-    constructor() {
-      const node = document.createElement('div');
-      const nameTitle = document.createElement('label');
-      nameTitle.textContent = 'Index';
-      const index = document.createElement('input');
-
-      node.appendChild(nameTitle);
-      node.appendChild(index);
-
-      super({ node });
-    }
-
-    get inputNode(): HTMLInputElement {
-      return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
-    }
-
     getValue(): string {
       return this.inputNode.value;
     }

--- a/src/litestore.ts
+++ b/src/litestore.ts
@@ -154,6 +154,20 @@ export class TransactionStore {
     return this.get(id);
   }
 
+  /**
+   * Whether there is a transaction to undo in the store.
+   */
+  hasUndo(): boolean {
+    return this._undoStack.length > 0;
+  }
+
+  /**
+   * Whether there is a transaction to redo in the store.
+   */
+  hasRedo(): boolean {
+    return this._redoStack.length > 0;
+  }
+
   private _order: string[];
   private _transactions: { [id: string]: Datastore.Transaction };
   private _cemetery: { [id: string]: number } = {};
@@ -704,6 +718,20 @@ export class Litestore implements IDisposable, IIterable<Table<Schema>> {
    */
   withTransaction(update: (id: string) => void): string {
     return Datastore.withTransaction(this._dataStore, update);
+  }
+
+  /**
+   * Whether there is a transaction to undo in the store.
+   */
+  hasUndo(): boolean {
+    return this._transactionStore.hasUndo();
+  }
+
+  /**
+   * Whether there is a transaction to redo in the store.
+   */
+  hasRedo(): boolean {
+    return this._transactionStore.hasRedo();
   }
 
   private _transactionStore: TransactionStore | null;

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -22,37 +22,30 @@ export function createSaveButton(
 ): Widget {
   const button = new ToolbarButton({
     icon: saveIcon,
-    onClick: () => {
+    onClick: (): void => {
       const widgets = dashboard.content.children().iter();
       let widget = widgets.next() as DashboardWidget;
       let cell: Cell;
       let newPos = [];
-      let pos: (number[])[];
+      let pos: number[][];
       while (widget) {
         cell = widget.cell as Cell;
-        // cell.model.metadata.set('pos', pos);
         newPos = [];
-        // pos.push("left");
         newPos.push(Number(widget.node.style.left.split('p')[0]));
-        // pos.push("top");
         newPos.push(Number(widget.node.style.top.split('p')[0]));
-        // pos.push("width");
         newPos.push(Number(widget.node.style.width.split('p')[0]));
-        // pos.push("height");
         newPos.push(Number(widget.node.style.height.split('p')[0]));
-        pos = cell.model.metadata.get(dashboard.name) as (number[])[];
+        pos = cell.model.metadata.get(dashboard.getName()) as number[][];
         if (pos === undefined) {
           pos = [];
         }
         pos.push(newPos);
-        // console.log("pos", pos);
-        cell.model.metadata.set(dashboard.name, pos);
-        // console.log("metadata", cell.model.metadata.get("pos"));
+        cell.model.metadata.set(dashboard.getName(), pos);
         widget = widgets.next() as DashboardWidget;
       }
       //saving the cell metadata needs to save notebook?
     },
-    tooltip: 'Save Dashboard'
+    tooltip: 'Save Dashboard',
   });
   return button;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,84 @@
+import { NotebookPanel, INotebookTracker } from '@jupyterlab/notebook';
+
+import { Cell } from '@jupyterlab/cells';
+
+import { UUID } from '@lumino/coreutils';
+
+import { ArrayExt, toArray } from '@lumino/algorithm';
+
+export function addNotebookId(notebook: NotebookPanel): string {
+  const metadata: any | undefined = notebook.model.metadata.get('presto');
+  let id: string;
+
+  if (metadata !== undefined) {
+    if (metadata.id !== undefined) {
+      return metadata.id;
+    }
+    id = UUID.uuid4();
+    notebook.model.metadata.set('presto', { ...metadata, id });
+  } else {
+    id = UUID.uuid4();
+    notebook.model.metadata.set('presto', { id });
+  }
+
+  return id;
+}
+
+export function getNotebookId(notebook: NotebookPanel): string | undefined {
+  const metadata: any | undefined = notebook.model.metadata.get('presto');
+  if (metadata === undefined || metadata.id === undefined) {
+    return undefined;
+  }
+  return metadata.id;
+}
+
+export function getNotebookById(
+  id: string,
+  tracker: INotebookTracker
+): NotebookPanel | undefined {
+  return tracker.find((notebook) => getNotebookId(notebook) === id);
+}
+
+export function addCellId(cell: Cell): string {
+  const metadata: any | undefined = cell.model.metadata.get('presto');
+  let id: string;
+
+  if (metadata !== undefined) {
+    if (metadata.id !== undefined) {
+      return metadata.id;
+    }
+    id = UUID.uuid4();
+    cell.model.metadata.set('presto', { ...metadata, id });
+  } else {
+    id = UUID.uuid4();
+    cell.model.metadata.set('presto', { id });
+  }
+
+  return id;
+}
+
+export function getCellId(cell: Cell): string | undefined {
+  const metadata: any | undefined = cell.model.metadata.get('presto');
+  if (metadata === undefined || metadata.id === undefined) {
+    return undefined;
+  }
+  return metadata.id;
+}
+
+export function getCellById(
+  id: string,
+  tracker: INotebookTracker
+): Cell | undefined {
+  const notebooks = toArray(tracker.filter(() => true));
+  for (const notebook of notebooks) {
+    const cells = notebook.content.widgets;
+    const value = ArrayExt.findFirstValue(
+      cells,
+      (cell) => getCellId(cell) === id
+    );
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What's new
- Added integration with Litestore/Widgetstore (adding, deleting, and moving).
- Fixed drag image.
- Fixed widget not displaying once moved.

## Todo/issues
- Undo/redo not currently working.

This is because adding/deleting/moving a widget starts a new transaction that adds a record to the Widgetstore with the changed flag active. A listener detects this change and updates the dashboard with the new information, then starts another transaction to mark all the changed widgets as unchanged. The undo and redo methods undo/redo the last transaction, which is the one where the widget is marked as unchanged instead of the add/delete/move.