### PR TITLE
undo/redo

### DIFF
--- a/src/custom_layout.ts
+++ b/src/custom_layout.ts
@@ -170,248 +170,55 @@ export class DashboardLayout extends Layout {
   }
 
   protected onUpdateRequest(msg: Message): void {
-    // Return if guard is set to prevent infinite looping.
-    if (this._updateGuard) {
-      return;
-    }
-
-    // Set the guard.
-    this._updateGuard = true;
-    this._store.beginTransaction();
+    console.log('got update request');
 
     // Process all changed widgets in the store.
-    each(this._store.getChangedWidgets(), (widgetInfo) => {
-      const item = this._items.get(widgetInfo.widgetId);
+    each(this._store.getWidgets(), (widgetInfo) => {
+      const item = this._items.get(widgetInfo.$id);
       const pos = widgetInfo as Widgetstore.WidgetPosition;
-      let removed = false;
 
-      // Widget added for first time or was undeleted.
-      if (item === undefined) {
-        console.log('added widget');
-        const newWidget = this._store.createWidget(
-          widgetInfo as Widgetstore.WidgetInfo
-        );
-        this.addWidget(newWidget, pos);
-      }
-      // Widget was just deleted.
-      else if (widgetInfo.removed) {
-        console.log('deleted widget');
-        const widget = item.widget;
-        this.removeWidget(widget);
-        removed = true;
-      }
-      // Widget was moved or resized.
-      else {
-        console.log('moved widget');
-        this.moveWidget(item.widget as DashboardWidget, pos);
-      }
+      console.log('updating widget', widgetInfo.$id);
 
-      // Mark record as processed and removed if applicable.
-      this._store.updateRecord(
-        {
-          schema: Widgetstore.WIDGET_SCHEMA,
-          record: widgetInfo.widgetId,
-        },
-        {
-          changed: false,
-          removed,
+      if (widgetInfo.widgetId === '') {
+        if (item === undefined) {
+          // Item has already been removed; ignore.
+          console.log('\talready un-added; ignoring');
+          return;
         }
-      );
+        // Widget is empty; remove it.
+        console.log('\twidget empty; removing');
+        this.removeWidget(item.widget);
+      } else if (item === undefined) {
+        if (widgetInfo.removed) {
+          console.log('\talready removed; ignoring');
+          // Widget was already removed; ignore.
+          return;
+        } else {
+          // Widget was newly added or undeleted.
+          console.log('\tadding');
+          const newWidget = this._store.createWidget(
+            widgetInfo as Widgetstore.WidgetInfo
+          );
+          this.addWidget(newWidget, pos);
+        }
+      } else {
+        if (widgetInfo.removed) {
+          // Widget was deleted.
+          console.log('\tremoving');
+          this.deleteWidget(item.widget);
+        } else {
+          // Widget was moved.
+          console.log('\tmoving');
+          this.moveWidget(item.widget as DashboardWidget, pos);
+        }
+      }
     });
-
-    this._store.endTransaction();
-
-    // Remove guard.
-    this._updateGuard = false;
   }
 
   private _items: Map<string, LayoutItem>;
   private _store: Widgetstore;
   private _outputTracker: WidgetTracker<DashboardWidget>;
-  private _updateGuard = false;
 }
-
-// /**
-//  * Layout for DashboardArea widget.
-//  */
-// export class DashboardLayout extends PanelLayout {
-//   _dropLocation: number[];
-//   /**
-//    * Construct a new dashboard layout.
-//    *
-//    * @param options - The options for initializing the layout.
-//    */
-//   constructor(options: DashboardLayout.IOptions) {
-//     super(options);
-//     this._items = new Map<string, LayoutItem>();
-//     this._store = options.store;
-//     console.log(this._store);
-//   }
-
-//   /**
-//    * Attach a widget to the parent's DOM node.
-//    *
-//    * @param widget - The widget to attach to the parent.
-//    */
-//   protected attachWidget(index: number, widget: Widget): void {
-//     // Send a `'before-attach'` message if the parent is attached.
-//     if (this.parent!.isAttached) {
-//       MessageLoop.sendMessage(widget, Widget.Msg.BeforeAttach);
-//     }
-
-//     // Add the widget's node to the parent.
-//     this.parent!.node.appendChild(widget.node);
-
-//     // Send an `'after-attach'` message if the parent is attached.
-//     if (this.parent!.isAttached) {
-//       MessageLoop.sendMessage(widget, Widget.Msg.AfterAttach);
-//     }
-
-//     // Post a fit request for the parent widget.
-//     this.parent!.fit();
-//   }
-
-//   /**
-//    * Add a widget to Dashboard layout.
-//    *
-//    * @param widget - The widget to add to the layout.
-//    *
-//    */
-//   addWidget(widget: DashboardWidget): void {
-//     // Add the widget to the layout.
-//     const item = new LayoutItem(widget);
-//     this._items.set(widget.id, item);
-
-//     // Attach the widget to the parent.
-//     if (this.parent) {
-//       this.attachWidget(-1, widget);
-
-//       const numPos = this._dropLocation;
-//       this._update(numPos, item);
-//     }
-//   }
-
-//   /**
-//    * Create an iterator over the widgets in the layout.
-//    *
-//    * @returns A new iterator over the widgets in the layout.
-//    */
-//   iter(): IIterator<Widget> {
-//     // Is there a lazy way to iterate through the map?
-//     let arr = Array.from(this._items.values());
-//     return map(arr, item => item.widget);
-//   }
-
-//   /**
-//    * Update the item given postion in the layout.
-//    */
-//   private _update(pos: number[], item: LayoutItem) {
-//     if (pos !== undefined) {
-//       const [ left, top, width, height ] = pos;
-//       item.update(left, top, width, height);
-//     }
-//   }
-
-//   protected onUpdateRequest(msg: Message): void {
-
-//     console.log('update recieved');
-//     each(this._store.getChangedWidgets(),
-//       widgetInfo => {
-//         let item = this._items.get(widgetInfo.widgetId);
-//         let pos = [
-//           widgetInfo.left,
-//           widgetInfo.top,
-//           widgetInfo.width,
-//           widgetInfo.height
-//         ];
-
-//         // Widget added for first time or was undeleted.
-//         if (item === undefined) {
-//           console.log('widget added or undeleted', widgetInfo, item);
-//           let newWidget = this._store.createWidget(widgetInfo as Widgetstore.WidgetInfo);
-//           this.placeWidget(-1, newWidget, pos);
-//         }
-//         // Widget was just deleted.
-//         else if (widgetInfo.removed) {
-//           console.log('widget removed', widgetInfo, item);
-//           let widget = item.widget;
-//           this.removeWidget(widget);
-//         }
-//         // Widget was moved or resized.
-//         else {
-//           console.log('widget moved or resized', widgetInfo, item);
-//           this._update(pos, item);
-//         }
-//       }
-//     );
-
-//     super.onUpdateRequest(msg);
-
-//     this._store.markAllAsUnchanged();
-//   }
-
-//   /**
-//    * Insert a widget at position specified.
-//    */
-//   placeWidget(index: number, widget: DashboardWidget, pos: number[]): void {
-//     this._dropLocation = pos;
-//     this.addWidget(widget);
-//   }
-
-//   /**
-//    * Detach a widget from the parent's DOM node.
-//    *
-//    * @param widget - The widget to detach from the parent.
-//    */
-//   protected detachWidget(_index: number, widget: Widget): void {
-//     // Send a `'before-detach'` message if the parent is attached.
-//     if (this.parent!.isAttached) {
-//       MessageLoop.sendMessage(widget, Widget.Msg.BeforeDetach);
-//     }
-
-//     // Remove the widget's node from the parent.
-//     this.parent!.node.removeChild(widget.node);
-
-//     // Send an `'after-detach'` message if the parent is attached.
-//     if (this.parent!.isAttached) {
-//       MessageLoop.sendMessage(widget, Widget.Msg.AfterDetach);
-//     }
-
-//     // Post a fit request for the parent widget.
-//     this.parent!.fit();
-//   }
-
-//   /**
-//    * Remove a widget from Dashboard layout.
-//    *
-//    * @param widget - The widget to remove from the layout.
-//    *
-//    */
-//   removeWidget(widget: Widget): void {
-//     // Look up the widget in the _items map.
-//     const item = this._items.get(widget.id)
-
-//     // Bail if it's not there.
-//     if (item === undefined) {
-//       return;
-//     }
-
-//     // Remove the item from the map.
-//     this._items.delete(widget.id);
-
-//     // Detach the widget from the parent.
-//     if (this.parent) {
-//       this.detachWidget(-1, widget);
-//     }
-
-//     // Dispose the layout item.
-//     item.dispose();
-
-//   }
-
-//   private _items: Map<string, LayoutItem>;
-//   private _store: Widgetstore;
-// }
 
 /**
  * The namespace for the `DashboardLayout` class statics.

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -61,10 +61,6 @@ export class DashboardArea extends Widget {
     this.addClass(DASHBOARD_AREA_CLASS);
   }
 
-  onUpdateRequest(msg: Message): void {
-    this.layout.processParentMessage(msg);
-  }
-
   /**
    * Create click listeners on attach
    */
@@ -210,12 +206,16 @@ export class Dashboard extends MainAreaWidget<Widget> {
     // Adds save button to dashboard toolbar.
     this.toolbar.addItem('save', createSaveButton(this, panel));
 
-    // Add a listener to update the layout whenever the widgetstore changes.
-    this._store.listenTable(
-      { schema: Widgetstore.WIDGET_SCHEMA },
-      this.update,
-      this
-    );
+    // TODO: Figure out if this is worth it. Right now it's disabled to prevent
+    // double updating, and I figure manually calling this.update() whenever the
+    // widgetstore is modified isn't so bad.
+    //
+    // Attach listener to update on table changes.
+    // this._store.listenTable(
+    //   { schema: Widgetstore.WIDGET_SCHEMA },
+    //   this.update,
+    //   this
+    // );
   }
 
   /**
@@ -225,6 +225,7 @@ export class Dashboard extends MainAreaWidget<Widget> {
    */
   addWidget(info: Widgetstore.WidgetInfo): void {
     this._store.addWidget(info);
+    this.update();
   }
 
   /**
@@ -244,7 +245,9 @@ export class Dashboard extends MainAreaWidget<Widget> {
     widget: DashboardWidget,
     pos: Widgetstore.WidgetPosition
   ): boolean {
-    return this._store.moveWidget(widget, pos);
+    const success = this._store.moveWidget(widget, pos);
+    this.update();
+    return success;
   }
 
   /**
@@ -255,7 +258,9 @@ export class Dashboard extends MainAreaWidget<Widget> {
    * @returns whether the deletion was successful.
    */
   deleteWidget(widget: DashboardWidget): boolean {
-    return this._store.deleteWidget(widget);
+    const success = this._store.deleteWidget(widget);
+    this.update();
+    return success;
   }
 
   /**
@@ -268,8 +273,9 @@ export class Dashboard extends MainAreaWidget<Widget> {
    *
    * @throws - an exception if `undo` is called during a transaction.
    */
-  undo(transactionId?: string): Promise<void> {
-    return this._store.undo(transactionId);
+  undo(): void {
+    this._store.undo();
+    this.update();
   }
 
   /**
@@ -282,8 +288,9 @@ export class Dashboard extends MainAreaWidget<Widget> {
    *
    * @throws - an exception if `undo` is called during a transaction.
    */
-  redo(transactionId?: string): Promise<void> {
-    return this._store.redo(transactionId);
+  redo(): void {
+    this._store.redo();
+    this.update();
   }
 
   get store(): Widgetstore {

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,20 @@ const extension: JupyterFrontEndPlugin<void> = {
       selector: '.pr-DashboardWidget',
     });
 
+    app.commands.addKeyBinding({
+      command: CommandIDs.undo,
+      args: {},
+      keys: ['Z'],
+      selector: '.pr-JupyterDashboard',
+    });
+
+    app.commands.addKeyBinding({
+      command: CommandIDs.redo,
+      args: {},
+      keys: ['Shift Z'],
+      selector: '.pr-JupyterDashboard',
+    });
+
     app.docRegistry.addWidgetExtension(
       'Notebook',
       new DashboardButton(app, outputTracker, dashboardTracker, tracker)
@@ -265,7 +279,10 @@ function addCommands(
    */
   commands.addCommand(CommandIDs.undo, {
     label: 'Undo',
-    execute: (args) => dashboardTracker.currentWidget.undo(),
+    execute: (args) => {
+      dashboardTracker.currentWidget.undo();
+      console.log('undo');
+    },
     isEnabled: () =>
       dashboardTracker.currentWidget &&
       dashboardTracker.currentWidget.store.hasUndo(),
@@ -276,7 +293,10 @@ function addCommands(
    */
   commands.addCommand(CommandIDs.redo, {
     label: 'Redo',
-    execute: (args) => dashboardTracker.currentWidget.redo(),
+    execute: (args) => {
+      dashboardTracker.currentWidget.redo();
+      console.log('redo');
+    },
     isEnabled: () =>
       dashboardTracker.currentWidget &&
       dashboardTracker.currentWidget.store.hasRedo(),

--- a/src/litestore.ts
+++ b/src/litestore.ts
@@ -14,6 +14,8 @@ import { ISignal } from '@lumino/signaling';
 
 import { Message } from '@lumino/messaging';
 
+import { toHex } from './utils';
+
 export type DatastoreFn = ((transaction: Datastore.Transaction) => void) | null;
 
 /**
@@ -449,6 +451,8 @@ export class Litestore implements IDisposable, IIterable<Table<Schema>> {
     if (transaction === undefined) {
       return undefined;
     }
+    console.log('new transaction', transaction);
+
     return transaction.id;
   }
 
@@ -516,8 +520,10 @@ export class Litestore implements IDisposable, IIterable<Table<Schema>> {
         return;
       }
       promise = this._dataStore.undo(lastTransaction.id);
+      console.log('undoing', toHex(lastTransaction.id));
     } else {
       promise = this._dataStore.undo(transactionId);
+      console.log('undoing', toHex(transactionId));
     }
     return promise;
   }
@@ -544,8 +550,10 @@ export class Litestore implements IDisposable, IIterable<Table<Schema>> {
         return;
       }
       promise = this._dataStore.redo(lastUndo.id);
+      console.log('redoing', toHex(lastUndo.id));
     } else {
       promise = this._dataStore.redo(transactionId);
+      console.log('redoing', toHex(transactionId));
     }
     return promise;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,3 +82,10 @@ export function getCellById(
   }
   return undefined;
 }
+
+export function toHex(str: string): string {
+  return str
+    .split('')
+    .map((c) => c.charCodeAt(0).toString(16))
+    .join('');
+}

--- a/src/widgetstore.ts
+++ b/src/widgetstore.ts
@@ -182,6 +182,11 @@ export class Widgetstore extends Litestore {
     return changed;
   }
 
+  getWidgets(): IIterator<Record<WidgetSchema>> {
+    const table = this.get(Widgetstore.WIDGET_SCHEMA);
+    return filter(table, (record) => true);
+  }
+
   /**
    * Gets a cell by id using the instances' notebook tracker.
    */


### PR DESCRIPTION
## What's new
- Undo/redo for dashboards.

## Fixed
- Issue causing double updating.

## Todo/issues
- Add undo/redo support for dashboard metadata modifying actions like renaming.
- Possibly remove 'changed' field in WIDGET_SCHEMA (see Notes).

## Notes
Dashboard now updates every widget on change instead of just widgets marked  'changed'. Creating another transaction to mark widgets as changed drastically complicates undo/redo, so it's removed for now. If performance becomes an issue it might be worth returning to.