### PR TITLE
resizing

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -6,6 +6,8 @@ import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
 
 import { Widget } from '@lumino/widgets';
 
+// import { max, map } from '@lumino/algorithm';
+
 import { Message } from '@lumino/messaging';
 
 import { IDragEvent } from '@lumino/dragdrop';
@@ -185,7 +187,12 @@ export class Dashboard extends MainAreaWidget<Widget> {
 
     const dashboardArea = new DashboardArea({
       outputTracker,
-      layout: new DashboardLayout({ store, outputTracker }),
+      layout: new DashboardLayout({
+        store,
+        outputTracker,
+        width: 1000,
+        height: 1000,
+      }),
     });
     super({
       ...options,

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,3 +1,5 @@
+export const DASHBOARD_VERSION = 1;
+
 /**
  * A type that's serialized to create a dashboard file.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,13 @@ import {
 
 import { Widget } from '@lumino/widgets';
 
-import { Dashboard } from './dashboard';
+import { Dashboard, DashboardArea } from './dashboard';
 
 import { DashboardWidget } from './widget';
 
 import { DashboardButton } from './button';
+
+import { MessageLoop } from '@lumino/messaging';
 
 // HTML element classes
 
@@ -78,24 +80,6 @@ const extension: JupyterFrontEndPlugin<void> = {
       rank: 13,
     });
 
-    // app.contextMenu.addItem({
-    //   type: 'separator',
-    //   selector: '.jp-Notebook .jp-CodeCell',
-    //   rank: 11.9,
-    // });
-
-    // app.contextMenu.addItem({
-    //   command: CommandIDs.addToDashboard,
-    //   selector: '.jp-Notebook .jp-CodeCell',
-    //   rank: 11.9,
-    // });
-
-    // app.contextMenu.addItem({
-    //   type: 'separator',
-    //   selector: '.jp-Notebook .jp-CodeCell',
-    //   rank: 11.9,
-    // });
-
     app.contextMenu.addItem({
       command: CommandIDs.renameDashboard,
       selector: '.pr-JupyterDashboard',
@@ -118,6 +102,18 @@ const extension: JupyterFrontEndPlugin<void> = {
       command: CommandIDs.deleteOutput,
       selector: '.pr-DashboardWidget',
       rank: 0,
+    });
+
+    app.contextMenu.addItem({
+      command: 'printFile',
+      selector: '.pr-JupyterDashboard',
+      rank: 5,
+    });
+
+    app.contextMenu.addItem({
+      command: 'resize',
+      selector: '.pr-JupyterDashboard',
+      rank: 6,
     });
 
     // Add commands to key bindings
@@ -348,6 +344,20 @@ function addCommands(
     },
     isEnabled: isEnabledAndSingleSelected,
     isVisible: () => false,
+  });
+
+  commands.addCommand('printFile', {
+    label: 'Print File',
+    execute: (args) => dashboardTracker.currentWidget.store.save('myPath'),
+  });
+
+  commands.addCommand('resize', {
+    label: 'Resize',
+    execute: (args) => {
+      const msg = new Widget.ResizeMessage(1920, 1080);
+      const widget = dashboardTracker.currentWidget.content as DashboardArea;
+      MessageLoop.sendMessage(widget, msg);
+    },
   });
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,6 +83,14 @@ export function getCellById(
   return undefined;
 }
 
+/**
+ * Should eventually return a file path to a notebook given its id.
+ * For now, just returns a random string.
+ */
+export function getPathFromNotebookId(id: string): string {
+  return `DUMMY_PATH_${UUID.uuid4()}`;
+}
+
 export function toHex(str: string): string {
   return str
     .split('')

--- a/style/index.css
+++ b/style/index.css
@@ -1,9 +1,12 @@
 .pr-DashboardWidget {
     border: var(--jp-border-width) solid var(--jp-layout-color0);
-    overflow: auto;
 }
 
 .pr-DashboardWidget:focus {
+    border: var(--jp-border-width) solid var(--jp-brand-color1);
+}
+
+.pr-DashboardWidget:hover {
     border: var(--jp-border-width) solid var(--jp-brand-color1);
 }
 
@@ -18,4 +21,23 @@
 .pr-JupyterDashboard.pr-DropTarget {
     border: var(--jp-border-width) solid var(--jp-input-active-border-color);
     box-shadow: var(--jp-input-box-shadow);
+}
+
+.pr-DashboardArea {
+    overflow: auto;
+}
+
+.pr-Resizer {
+    display: none;
+    width: 10px;
+    height: 10px;
+    right: 0;
+    bottom: 0;
+    cursor: se-resize;
+    position: absolute;
+    background: var(--jp-input-active-border-color);
+}
+
+.pr-DashboardWidget:hover .pr-Resizer {
+    display: block;
 }


### PR DESCRIPTION
## What's new
- Added ability to resize dashboard widgets.
- Improved dragging widgets (transparent preview, invisible source).
- Added ability to set fixed dashboard width/height.
- Started working on saving state of widgetstore to schema.

## Todo/issues
- Center the drag image on where the user initiated the drag on the widget instead of its top left corner.
- Moving a widget beyond the edge of the dashboard area still sets its position in the datastore as being beyond the border. The constraining only happens when the layout renders the dashboard from the datastore.
- Show some sort of visual indication of the dashboard dimensions.

## Notes
- Dashboard is default constrained to 1000x1000 px for testing purposes.
- The Lumino Drag object doesn't allow setting the drag image anywhere but the top left corner, so a drag image will have to be created/attached through other means.