### PR TITLE
move functionality to layout

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
+    'no-inner-declarations': 'off',
     '@typescript-eslint/interface-name-prefix': [
       'error',
       { prefixWithI: 'always' }

--- a/src/button.ts
+++ b/src/button.ts
@@ -86,11 +86,12 @@ export class DashboardButton
               changed: true,
               removed: false,
             };
-            dashboard.addWidget(info);
+            dashboard.updateWidgetInfo(info);
           });
         }
       }
       dashboard.update();
+      dashboard.updateLayoutFromWidgetstore();
       void this._dashboardTracker.add(dashboard);
     };
     const button = new ToolbarButton({

--- a/src/custom_layout.ts
+++ b/src/custom_layout.ts
@@ -1,35 +1,40 @@
 import { Widget, Layout, LayoutItem } from '@lumino/widgets';
 
+import { Record } from '@lumino/datastore';
+
 import { IIterator, map, each } from '@lumino/algorithm';
 
 import { MessageLoop } from '@lumino/messaging';
 
 import { DashboardWidget } from './widget';
 
-import { Message } from '@lumino/messaging';
-
-import { Widgetstore } from './widgetstore';
+import { Widgetstore, WidgetSchema } from './widgetstore';
 
 import { WidgetTracker } from '@jupyterlab/apputils';
+
+import { getCellId, getNotebookId } from './utils';
 
 export class DashboardLayout extends Layout {
   constructor(options: DashboardLayout.IOptions) {
     super(options);
+
     this._items = new Map<string, LayoutItem>();
     this._store = options.store;
     this._outputTracker = options.outputTracker;
 
-    // Puts a dummy widget in the bottom right corner of the
-    // dashboard to create an area with set width/height.
-    const corner = new Widget();
     this._width = options.width || 0;
     this._height = options.height || 0;
-    corner.node.style.left = `${this._width}px`;
-    corner.node.style.top = `${this._height}px`;
-    corner.node.style.width = '1px';
-    corner.node.style.height = '1px';
-    corner.node.style.position = 'absolute';
-    this._corner = corner;
+
+    this._corner = DashboardLayout.makeCorner(this._width, this._height);
+  }
+
+  /**
+   * Perform initilization that requires a parent.
+   */
+  init(): void {
+    super.init();
+    each(this, (widget) => this.attachWidget(widget));
+    this.attachWidget(this._corner);
   }
 
   /**
@@ -37,105 +42,16 @@ export class DashboardLayout extends Layout {
    */
   dispose(): void {
     this._items.forEach((item) => item.dispose());
+    this._corner.dispose();
     this._outputTracker = null;
     this._store = null;
-    this._corner.dispose();
     super.dispose();
-  }
-
-  /**
-   * Perform layout initialization which requires the parent widget.
-   */
-  protected init(): void {
-    super.init();
-    each(this, (widget) => {
-      this.attachWidget(widget);
-    });
-    this.attachWidget(this._corner);
-  }
-
-  /**
-   * Add a widget to Dashboard layout.
-   *
-   * @param widget - The widget to add to the layout.
-   *
-   */
-  addWidget(widget: DashboardWidget, pos: Widgetstore.WidgetPosition): void {
-    // Add the widget to the layout.
-    const item = new LayoutItem(widget);
-    this._items.set(widget.id, item);
-
-    // Attach the widget to the parent.
-    if (this.parent) {
-      this.attachWidget(widget);
-      this.moveWidget(widget, pos);
-      this._outputTracker.add(widget);
-    }
-  }
-
-  moveWidget(
-    widget: DashboardWidget,
-    pos: Widgetstore.WidgetPosition
-  ): boolean {
-    // Get the item from the map.
-    const item = this._items.get(widget.id);
-
-    // If the item doesn't exist, exit.
-    if (item === undefined) {
-      return false;
-    }
-
-    // Send an update request to the layout item.
-    let { left, top } = pos;
-    const { width, height } = pos;
-    if (this._width !== 0 && left + width > this._width) {
-      left = this._width - width;
-    }
-    if (this._height !== 0 && top + height > this._height) {
-      top = this._height - height;
-    }
-    item.update(left, top, width, height);
-
-    return true;
-  }
-
-  removeWidget(widget: Widget): void {
-    void this.deleteWidget(widget);
-  }
-
-  /**
-   * Remove a widget from Dashboard layout.
-   *
-   * @param widget - The widget to remove from the layout.
-   *
-   */
-  deleteWidget(widget: Widget): boolean {
-    // Look up the widget in the _items map.
-    const item = this._items.get(widget.id);
-
-    // Bail if it's not there.
-    if (item === undefined) {
-      return false;
-    }
-
-    // Remove the item from the map.
-    this._items.delete(widget.id);
-
-    // Detach the widget from the parent.
-    if (this.parent) {
-      this.detachWidget(-1, widget);
-    }
-
-    // Dispose the layout item.
-    item.dispose();
-
-    return true;
   }
 
   /**
    * Create an iterator over the widgets in the layout.
    *
-   * @returns A new iterator over the widgets in the layout.
+   * @returns a new iterator over the widgets in the layout.
    */
   iter(): IIterator<Widget> {
     // Is there a lazy way to iterate through the map?
@@ -194,57 +110,257 @@ export class DashboardLayout extends Layout {
     this.parent!.fit();
   }
 
-  protected onUpdateRequest(msg: Message): void {
-    console.log('got update request');
+  /**
+   * Add a widget to the layout.
+   *
+   * @param widget - the widget to add.
+   */
+  addWidget(widget: DashboardWidget, pos: Widgetstore.WidgetPosition): void {
+    // Add the widget to the layout.
+    const item = new LayoutItem(widget);
+    this._items.set(widget.id, item);
 
-    // Process all changed widgets in the store.
-    each(this._store.getWidgets(), (widgetInfo) => {
-      const item = this._items.get(widgetInfo.$id);
-      const pos = widgetInfo as Widgetstore.WidgetPosition;
+    // Attach the widget to the parent.
+    if (this.parent) {
+      this.attachWidget(widget);
+      this.updateWidget(widget, pos);
+      this._outputTracker.add(widget);
+    }
+  }
 
-      console.log('updating widget', widgetInfo.$id);
+  updateWidget(
+    widget: DashboardWidget,
+    pos: Widgetstore.WidgetPosition
+  ): boolean {
+    // Get the item from the map.
+    const item = this._items.get(widget.id);
 
-      if (widgetInfo.widgetId === '') {
-        if (item === undefined) {
-          // Item has already been removed; ignore.
-          console.log('\talready un-added; ignoring');
-          return;
-        }
-        // Widget is empty; remove it.
-        console.log('\twidget empty; removing');
-        this.removeWidget(item.widget);
-      } else if (item === undefined) {
-        if (widgetInfo.removed) {
-          console.log('\talready removed; ignoring');
-          // Widget was already removed; ignore.
-          return;
-        } else {
-          // Widget was newly added or undeleted.
-          console.log('\tadding');
-          const newWidget = this._store.createWidget(
-            widgetInfo as Widgetstore.WidgetInfo
-          );
-          this.addWidget(newWidget, pos);
-        }
-      } else {
-        if (widgetInfo.removed) {
-          // Widget was deleted.
-          console.log('\tremoving');
-          this.deleteWidget(item.widget);
-        } else {
-          // Widget was moved.
-          console.log('\tmoving');
-          this.moveWidget(item.widget as DashboardWidget, pos);
-        }
-      }
+    // If the item doesn't exist, exit.
+    if (item === undefined) {
+      return false;
+    }
+
+    let { left, top } = pos;
+    const { width, height } = pos;
+
+    // Constrain the widget to the dashboard dimensions.
+    if (this._width !== 0 && left + width > this._width) {
+      left = this._width - width;
+    }
+    if (this._height !== 0 && top + height > this._height) {
+      top = this._height - height;
+    }
+
+    // Update the widget's position.
+    item.update(left, top, width, height);
+
+    return true;
+  }
+
+  /**
+   * Remove a widget from the layout.
+   *
+   * @param widget - the widget to remove.
+   *
+   * ### Notes
+   * This is basically the same as deleteWidget but fulfills the type
+   * signature requirements of the extended class.
+   */
+  removeWidget(widget: DashboardWidget): void {
+    void this.deleteWidget(widget);
+  }
+
+  /**
+   * Remove a widget from the layout.
+   *
+   * @param widget - the widget to remove.
+   *
+   */
+  deleteWidget(widget: DashboardWidget): boolean {
+    // Look up the widget in the _items map.
+    const item = this._items.get(widget.id);
+
+    // Bail if it's not there.
+    if (item === undefined) {
+      return false;
+    }
+
+    // Remove the item from the map.
+    this._items.delete(widget.id);
+
+    // Detach the widget from the parent.
+    if (this.parent) {
+      this.detachWidget(-1, widget);
+    }
+
+    // Dispose the layout item.
+    item.dispose();
+
+    return true;
+  }
+
+  /**
+   * Adds a dashboard widget's information to the widgetstore.
+   *
+   * @param info - the information to add to the widgetstore.
+   */
+  updateWidgetInfo(info: Widgetstore.WidgetInfo): void {
+    this._store.addWidget(info);
+  }
+
+  /**
+   * Gets information from a widget.
+   *
+   * @param widget - the widget to collect information from.
+   */
+  getWidgetInfo(widget: DashboardWidget): Widgetstore.WidgetInfo {
+    const info: Widgetstore.WidgetInfo = {
+      widgetId: widget.id,
+      notebookId: getNotebookId(widget.notebook),
+      cellId: getCellId(widget.cell),
+      left: parseInt(widget.node.style.left),
+      top: parseInt(widget.node.style.top),
+      width: parseInt(widget.node.style.width),
+      height: parseInt(widget.node.style.height),
+      removed: false,
+    };
+    console.log('got widget info', info);
+    return info;
+  }
+
+  /**
+   * Mark a widget as deleted in the widgetstore.
+   *
+   * @param widget - the widget to mark as deleted.
+   */
+  deleteWidgetInfo(widget: DashboardWidget): void {
+    const info = this.getWidgetInfo(widget);
+    this.updateWidgetInfo({
+      ...info,
+      removed: true,
     });
   }
 
+  /**
+   * Update a widgetstore entry for a widget given that widget.
+   *
+   * @param widget - the widget to update from.
+   */
+  updateInfoFromWidget(widget: DashboardWidget): void {
+    const info = this.getWidgetInfo(widget);
+    this.updateWidgetInfo(info);
+  }
+
+  /**
+   * Update the layout from a widgetstore record.
+   *
+   * @param record - the record to update from.
+   */
+  private _updateLayoutFromRecord(record: Record<WidgetSchema>): void {
+    const item = this._items.get(record.$id);
+    const pos = record as Widgetstore.WidgetPosition;
+
+    if (record.widgetId === '') {
+      // Widget has already been removed; ignore.
+      if (item === undefined) {
+        return;
+      }
+
+      // Widget is empty; remove.
+      this.deleteWidget(item.widget as DashboardWidget);
+    } else if (item === undefined) {
+      // Widget has already been removed; ignore.
+      if (record.removed) {
+        return;
+      }
+
+      // Widget is newly added or undeleted; add.
+      const newWidget = this._store.createWidget(
+        record as Widgetstore.WidgetInfo
+      );
+      this.addWidget(newWidget, pos);
+    } else {
+      // Widget was just removed; delete.
+      if (record.removed) {
+        this.deleteWidget(item.widget as DashboardWidget);
+      }
+
+      // Widget was moved or resized; update.
+      this.updateWidget(item.widget as DashboardWidget, pos);
+    }
+  }
+
+  /**
+   * Updates the layout based on the state of the datastore.
+   */
+  updateLayoutFromWidgetstore(): void {
+    const records = this._store.getWidgets();
+    each(records, (record) => this._updateLayoutFromRecord(record));
+  }
+
+  /**
+   * Undo the last change to the layout.
+   */
+  undo(): void {
+    this._store.undo();
+    this.updateLayoutFromWidgetstore();
+  }
+
+  /**
+   * Redo the last change to the layout.
+   */
+  redo(): void {
+    this._store.redo();
+    this.updateLayoutFromWidgetstore();
+  }
+
+  get width(): number {
+    return this._width;
+  }
+  set width(newWidth: number) {
+    if (newWidth < 0) {
+      return;
+    }
+    this._width = newWidth;
+    this._corner.node.style.width = `${newWidth}px`;
+  }
+
+  get height(): number {
+    return this._height;
+  }
+  set height(newHeight: number) {
+    if (newHeight < 0) {
+      return;
+    }
+    this._height = newHeight;
+    this._corner.node.style.height = `${newHeight}px`;
+  }
+
+  /**
+   * Creates a dashboard widget from a widgetinfo object.
+   *
+   * @param info - info to create widget from.
+   *
+   * @returns - the created widget.
+   *
+   * @throws - an error if a notebook or cell isn't found from the ids in the
+   * widgetinfo object.
+   */
+  createWidget(info: Widgetstore.WidgetInfo): DashboardWidget {
+    return this._store.createWidget(info);
+  }
+
+  // Map from widget ids to LayoutItems
   private _items: Map<string, LayoutItem>;
+  // Datastore widgets are rendered from / saved to.
   private _store: Widgetstore;
+  // Output tracker to add new widgets to.
   private _outputTracker: WidgetTracker<DashboardWidget>;
+  // Dummy corner widget to set dimensions of dashboard.
   private _corner: Widget;
+  // Dashboard width (zero if unconstrained).
   private _width: number;
+  // Dashboard height (zero if unconstrained).
   private _height: number;
 }
 
@@ -276,5 +392,22 @@ export namespace DashboardLayout {
      * The static height of the dashboard area.
      */
     height?: number;
+  }
+
+  /**
+   * Create a widget to put in the corner of a layout to set the length/width.
+   *
+   * @param x - width.
+   *
+   * @param y - height.
+   */
+  export function makeCorner(x: number, y: number): Widget {
+    const corner = new Widget();
+    corner.node.style.width = '1px';
+    corner.node.style.height = '1px';
+    corner.node.style.left = `${x}px`;
+    corner.node.style.top = `${y}px`;
+    corner.node.style.position = 'absolute';
+    return corner;
   }
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -6,8 +6,6 @@ import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
 
 import { Widget } from '@lumino/widgets';
 
-// import { max, map } from '@lumino/algorithm';
-
 import { Message } from '@lumino/messaging';
 
 import { IDragEvent } from '@lumino/dragdrop';
@@ -60,6 +58,7 @@ export class DashboardArea extends Widget {
   constructor(options: DashboardArea.IOptions) {
     super(options);
     this.layout = options.layout;
+    this._dbLayout = options.layout as DashboardLayout;
     this.addClass(DASHBOARD_AREA_CLASS);
   }
 
@@ -127,8 +126,8 @@ export class DashboardArea extends Widget {
         height: widget.node.offsetHeight,
       };
 
-      // Should probably try to avoid calling methods of the parent.
-      (this.parent as Dashboard).moveWidget(widget, pos);
+      this._dbLayout.updateWidget(widget, pos);
+      this._dbLayout.updateInfoFromWidget(widget);
 
       // dragging from notebook -> dashboard.
     } else if (event.proposedAction === 'copy') {
@@ -143,12 +142,12 @@ export class DashboardArea extends Widget {
         top: event.offsetY,
         width: Widgetstore.DEFAULT_WIDTH,
         height: Widgetstore.DEFAULT_HEIGHT,
-        changed: true,
         removed: false,
       };
 
-      // Should probably try to avoid calling methods of the parent.
-      (this.parent as Dashboard).addWidget(info);
+      const widget = this._dbLayout.createWidget(info);
+      this._dbLayout.addWidget(widget, info);
+      this._dbLayout.updateWidgetInfo(info);
     } else {
       return;
     }
@@ -174,6 +173,106 @@ export class DashboardArea extends Widget {
         break;
     }
   }
+
+  /**
+   * Add a widget to the layout.
+   *
+   * @param widget - the widget to add.
+   */
+  addWidget(widget: DashboardWidget, pos: Widgetstore.WidgetPosition): void {
+    this._dbLayout.addWidget(widget, pos);
+  }
+
+  updateWidget(
+    widget: DashboardWidget,
+    pos: Widgetstore.WidgetPosition
+  ): boolean {
+    return this._dbLayout.updateWidget(widget, pos);
+  }
+
+  /**
+   * Remove a widget from the layout.
+   *
+   * @param widget - the widget to remove.
+   *
+   * ### Notes
+   * This is basically the same as deleteWidget but fulfills the type
+   * signature requirements of the extended class.
+   */
+  removeWidget(widget: DashboardWidget): void {
+    this._dbLayout.removeWidget(widget);
+  }
+
+  /**
+   * Remove a widget from the layout.
+   *
+   * @param widget - the widget to remove.
+   *
+   */
+  deleteWidget(widget: DashboardWidget): boolean {
+    return this._dbLayout.deleteWidget(widget);
+  }
+
+  /**
+   * Adds a dashboard widget's information to the widgetstore.
+   *
+   * @param info - the information to add to the widgetstore.
+   */
+  updateWidgetInfo(info: Widgetstore.WidgetInfo): void {
+    this._dbLayout.updateWidgetInfo(info);
+  }
+
+  /**
+   * Gets information from a widget.
+   *
+   * @param widget - the widget to collect information from.
+   */
+  getWidgetInfo(widget: DashboardWidget): Widgetstore.WidgetInfo {
+    return this._dbLayout.getWidgetInfo(widget);
+  }
+
+  /**
+   * Mark a widget as deleted in the widgetstore.
+   *
+   * @param widget - the widget to mark as deleted.
+   */
+  deleteWidgetInfo(widget: DashboardWidget): void {
+    this._dbLayout.deleteWidgetInfo(widget);
+  }
+
+  /**
+   * Update a widgetstore entry for a widget given that widget.
+   *
+   * @param widget - the widget to update from.
+   */
+  updateInfoFromWidget(widget: DashboardWidget): void {
+    this._dbLayout.updateInfoFromWidget(widget);
+  }
+
+  /**
+   * Updates the layout based on the state of the datastore.
+   */
+  updateLayoutFromWidgetstore(): void {
+    this._dbLayout.updateLayoutFromWidgetstore();
+  }
+
+  /**
+   * Undo the last change to the layout.
+   */
+  undo(): void {
+    this._dbLayout.undo();
+  }
+
+  /**
+   * Redo the last change to the layout.
+   */
+  redo(): void {
+    this._dbLayout.redo();
+  }
+
+  // Convenient alias for layout so I don't have to type
+  // (this.layout as DashboardLayout) every time.
+  private _dbLayout: DashboardLayout;
 }
 
 /**
@@ -198,6 +297,7 @@ export class Dashboard extends MainAreaWidget<Widget> {
       ...options,
       content: content || dashboardArea,
     });
+    this._dbArea = this.content as DashboardArea;
 
     // Having all widgetstores across dashboards have the same id might cause issues.
     this._store = store;
@@ -226,78 +326,99 @@ export class Dashboard extends MainAreaWidget<Widget> {
   }
 
   /**
-   * Adds a dashboard widget to the widgetstore.
+   * Add a widget to the layout.
    *
-   * @param info - the information to add to the widgetstore.
+   * @param widget - the widget to add.
    */
-  addWidget(info: Widgetstore.WidgetInfo): void {
-    this._store.addWidget(info);
-    this.update();
+  addWidget(widget: DashboardWidget, pos: Widgetstore.WidgetPosition): void {
+    this._dbArea.addWidget(widget, pos);
   }
 
-  /**
-   * Updates the position of a widget already in the widgetstore.
-   *
-   * @param widget - the widget to update.
-   *
-   * @param pos - the new widget position.
-   *
-   * @returns whether the update was successful.
-   *
-   * ### Notes
-   * The update will be unsuccesful if the widget isn't in the store or was
-   * previously removed.
-   */
-  moveWidget(
+  updateWidget(
     widget: DashboardWidget,
     pos: Widgetstore.WidgetPosition
   ): boolean {
-    const success = this._store.moveWidget(widget, pos);
-    this.update();
-    return success;
+    return this._dbArea.updateWidget(widget, pos);
   }
 
   /**
-   * Mark a widget as removed.
+   * Remove a widget from the layout.
    *
-   * @param widget - widget to delete.
+   * @param widget - the widget to remove.
    *
-   * @returns whether the deletion was successful.
+   * ### Notes
+   * This is basically the same as deleteWidget but fulfills the type
+   * signature requirements of the extended class.
+   */
+  removeWidget(widget: DashboardWidget): void {
+    this._dbArea.removeWidget(widget);
+  }
+
+  /**
+   * Remove a widget from the layout.
+   *
+   * @param widget - the widget to remove.
+   *
    */
   deleteWidget(widget: DashboardWidget): boolean {
-    const success = this._store.deleteWidget(widget);
-    this.update();
-    return success;
+    return this._dbArea.deleteWidget(widget);
   }
 
   /**
-   * Undo a dashboard change.
+   * Adds a dashboard widget's information to the widgetstore.
    *
-   * @param transactionId - the ID of the transaction to undo, or undefined
-   * to undo the last transaction.
+   * @param info - the information to add to the widgetstore.
+   */
+  updateWidgetInfo(info: Widgetstore.WidgetInfo): void {
+    this._dbArea.updateWidgetInfo(info);
+  }
+
+  /**
+   * Gets information from a widget.
    *
-   * @returns - a promise which resolves when the action is complete.
+   * @param widget - the widget to collect information from.
+   */
+  getWidgetInfo(widget: DashboardWidget): Widgetstore.WidgetInfo {
+    return this._dbArea.getWidgetInfo(widget);
+  }
+
+  /**
+   * Mark a widget as deleted in the widgetstore.
    *
-   * @throws - an exception if `undo` is called during a transaction.
+   * @param widget - the widget to mark as deleted.
+   */
+  deleteWidgetInfo(widget: DashboardWidget): void {
+    this._dbArea.deleteWidgetInfo(widget);
+  }
+
+  /**
+   * Update a widgetstore entry for a widget given that widget.
+   *
+   * @param widget - the widget to update from.
+   */
+  updateInfoFromWidget(widget: DashboardWidget): void {
+    this._dbArea.updateInfoFromWidget(widget);
+  }
+
+  /**
+   * Updates the layout based on the state of the datastore.
+   */
+  updateLayoutFromWidgetstore(): void {
+    this._dbArea.updateLayoutFromWidgetstore();
+  }
+
+  /**
+   * Undo the last change to the layout.
    */
   undo(): void {
-    this._store.undo();
-    this.update();
+    this._dbArea.undo();
   }
 
   /**
-   * Redo a dashboard change.
-   *
-   * @param transactionId - the ID of the transaction to redo, or undefined
-   * to redo the last transaction.
-   *
-   * @returns - a promise which resolves when the action is complete.
-   *
-   * @throws - an exception if `undo` is called during a transaction.
+   * Redo the last change to the layout.
    */
   redo(): void {
-    this._store.redo();
-    this.update();
+    this._dbArea.redo();
   }
 
   get store(): Widgetstore {
@@ -320,6 +441,9 @@ export class Dashboard extends MainAreaWidget<Widget> {
 
   private _name: string;
   private _store: Widgetstore;
+  // Convenient alias so I don't have to type
+  // (this.content as DashboardArea) every time.
+  private _dbArea: DashboardArea;
 }
 
 export namespace Dashboard {

--- a/src/file.ts
+++ b/src/file.ts
@@ -3,36 +3,21 @@ export const DASHBOARD_VERSION = 1;
 /**
  * A type that's serialized to create a dashboard file.
  */
-export type DashboardFile = {
+export type DashboardSpec = {
   /**
    * The dashboard spec version.
    */
   version: number;
 
   /**
-   * Information about the dashboard grid.
+   * The width of the dashboad in pixels (0 if unconstrained).
    */
-  gridSpec: {
-    /**
-     * Unit width of the grid.
-     */
-    width: number;
+  dashboardWidth: number;
 
-    /**
-     * Unit height of the grid.
-     */
-    height: number;
-
-    /**
-     * Default width padding.
-     */
-    padX: number;
-
-    /**
-     * Default height padding.
-     */
-    padY: number;
-  };
+  /**
+   * The height of the dashboard in pixels (0 if unconstrained).
+   */
+  dashboardHeight: number;
 
   /**
    * A map from notebook paths to IDs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,7 @@ function addCommands(
     execute: (args) => {
       const widget = outputTracker.currentWidget;
       dashboardTracker.currentWidget.deleteWidget(widget);
+      dashboardTracker.currentWidget.deleteWidgetInfo(widget);
     },
   });
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -20,7 +20,7 @@ import { Drag } from '@lumino/dragdrop';
 
 import { shouldStartDrag } from './widgetdragutils';
 
-import { Dashboard } from './dashboard';
+import { DashboardArea } from './dashboard';
 
 // HTML element classes
 
@@ -33,8 +33,6 @@ const DASHBOARD_WIDGET_MIME = 'pr-DashboardWidgetMine';
 
 /**
  * Widget to wrap delete/move/etc functionality of widgets in a dashboard (future).
- * Currently just a slight modification of ClonedOutpuArea.
- * jupyterlab/packages/notebook-extension/src/index.ts
  */
 export class DashboardWidget extends Panel {
   /**
@@ -240,7 +238,10 @@ export class DashboardWidget extends Panel {
 
     this.node.style.width = `${newWidth}px`;
     this.node.style.height = `${newHeight}px`;
-    // Hacky way to clamp dimmensions to child widget dimmensions.
+  }
+
+  fitContent(): void {
+    // Hacky way to clamp dimensions to child widget dimensions.
     this.node.style.width = `${this.widgets[0].node.clientWidth}px`;
     this.node.style.height = `${this.widgets[0].node.clientHeight}px`;
   }
@@ -300,7 +301,8 @@ export class DashboardWidget extends Panel {
           height: parseInt(this.node.style.height, 10),
         };
         // FIXME: There has to be a better solution than this!
-        (this.parent.parent as Dashboard).moveWidget(this, pos);
+        (this.parent as DashboardArea).updateWidget(this, pos);
+        (this.parent as DashboardArea).updateInfoFromWidget(this);
         break;
       }
       default:

--- a/src/widgetstore.ts
+++ b/src/widgetstore.ts
@@ -12,7 +12,7 @@ import { Cell, CodeCell } from '@jupyterlab/cells';
 
 import { getNotebookById, getCellById, getPathFromNotebookId } from './utils';
 
-import { DashboardFile, WidgetInfo, DASHBOARD_VERSION } from './file';
+import { DashboardSpec, WidgetInfo, DASHBOARD_VERSION } from './file';
 
 /**
  * Alias for widget schema type.
@@ -224,6 +224,10 @@ export class Widgetstore extends Litestore {
     }
     const widget = new DashboardWidget({ notebook, cell });
     widget.id = info.widgetId;
+    widget.node.style.left = `${info.left}px`;
+    widget.node.style.top = `${info.top}px`;
+    widget.node.style.width = `${info.width}px`;
+    widget.node.style.height = `${info.height}px`;
 
     return widget;
   }
@@ -267,14 +271,10 @@ export class Widgetstore extends Litestore {
       (widget) => widget.widgetId && !widget.removed
     );
 
-    const file: DashboardFile = {
+    const file: DashboardSpec = {
       version: DASHBOARD_VERSION,
-      gridSpec: {
-        width: 0,
-        height: 0,
-        padX: 0,
-        padY: 0,
-      },
+      dashboardWidth: 0,
+      dashboardHeight: 0,
       paths: {},
       outputs: {},
     };


### PR DESCRIPTION
## What's new
- Moved functions that update the datastore down into the layout. This is to avoid calling methods of object's parents.
- Removed table update listener. Now adding/deleting/moving/resizing widgets involves a call to update the datastore, then update the layout. The 'auto updating' from the datastore has been moved into the `.updateLayoutFromWidgetstore()` method of the dashboard layout.

## Fixed
- typos

## Notes
The removal of the table update listener adds a little bit of typing but has several benefits.
1. Resizing had to follow the "resize on dashboard, then reflect in datastore" pattern, even before this update. Now, all dashboard changes follow a consistent pattern.
2. Makes it easier to batch changes in the future (selecting multiple widgets and moving/copying/pasting/deleting them).
3. Allows interacting with the cloned output area contained in the dashboard output before it's displayed, which allows for things like selecting initial width/height to fit the content.