### PR TITLE
Saveload

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -83,8 +83,8 @@ export class DashboardButton
               notebookId: addNotebookId(panel),
               cellId: addCellId(cell),
               ...p,
-              changed: true,
               removed: false,
+              missing: false,
             };
             dashboard.updateWidgetInfo(info);
           });

--- a/src/custom_layout.ts
+++ b/src/custom_layout.ts
@@ -142,6 +142,7 @@ export class DashboardLayout extends Layout {
 
     let { left, top } = pos;
     const { width, height } = pos;
+    console.log('new pos', pos);
 
     // Constrain the widget to the dashboard dimensions.
     if (this._width !== 0 && left + width > this._width) {
@@ -150,6 +151,9 @@ export class DashboardLayout extends Layout {
     if (this._height !== 0 && top + height > this._height) {
       top = this._height - height;
     }
+
+    console.log('new left', left);
+    console.log('new top', top);
 
     // Update the widget's position.
     item.update(left, top, width, height);
@@ -214,10 +218,16 @@ export class DashboardLayout extends Layout {
    * @param widget - the widget to collect information from.
    */
   getWidgetInfo(widget: DashboardWidget): Widgetstore.WidgetInfo {
+    const notebookId =
+      widget.notebookId !== undefined
+        ? widget.notebookId
+        : getNotebookId(widget.notebook);
+    const cellId =
+      widget.cellId !== undefined ? widget.cellId : getCellId(widget.cell);
     const info: Widgetstore.WidgetInfo = {
       widgetId: widget.id,
-      notebookId: getNotebookId(widget.notebook),
-      cellId: getCellId(widget.cell),
+      notebookId: notebookId,
+      cellId: cellId,
       left: parseInt(widget.node.style.left, 10),
       top: parseInt(widget.node.style.top, 10),
       width: parseInt(widget.node.style.width, 10),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2,6 +2,8 @@ import { NotebookPanel, INotebookTracker } from '@jupyterlab/notebook';
 
 import { CodeCell } from '@jupyterlab/cells';
 
+import { filter, each } from '@lumino/algorithm';
+
 import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
 
 import { Widget } from '@lumino/widgets';
@@ -24,14 +26,13 @@ import { createSaveButton } from './toolbar';
 
 import { Widgetstore } from './widgetstore';
 
-import {
-  addCellId,
-  addNotebookId,
-  loadFileAsString,
-  getPathFromNotebookId,
-} from './utils';
+import { getPathFromNotebookId } from './utils';
 
-import { DashboardSpec, DASHBOARD_VERSION, WidgetInfo } from './file';
+import { dashboard2file, renameDashboardFile } from './fsutils';
+
+import { addCellId, addNotebookId, getCellById } from './utils';
+
+import { DASHBOARD_VERSION, WidgetInfo, DashboardSpec } from './file';
 
 import { newfile } from './fsutils';
 
@@ -281,17 +282,6 @@ export class DashboardArea extends Widget {
     this._dbLayout.redo();
   }
 
-  /**
-   * Saves the dashboard to file.
-   *
-   * @param path - file path to save the dashboard to.
-   *
-   * @throws an error if saving fails.
-   */
-  save(path: string): void {
-    this._dbLayout.save(path);
-  }
-
   // Convenient alias for layout so I don't have to type
   // (this.layout as DashboardLayout) every time.
   private _dbLayout: DashboardLayout;
@@ -304,6 +294,7 @@ export class Dashboard extends MainAreaWidget<Widget> {
   // Generics??? Would love to further constrain this to DashboardWidgets but idk how
   constructor(options: Dashboard.IOptions) {
     const { notebookTracker, content, outputTracker, panel } = options;
+    const restore = options.store !== undefined;
     const store = options.store || new Widgetstore({ id: 0, notebookTracker });
     const contents = new ContentsManager();
 
@@ -322,11 +313,13 @@ export class Dashboard extends MainAreaWidget<Widget> {
     });
     this._dbArea = this.content as DashboardArea;
 
-    //creates and attachs a new untitled .dashboard file to dashboard
-    newfile(contents).then((f) => {
-      this._file = f;
-      this._path = this._file.path;
-    });
+    if (!restore) {
+      //creates and attachs a new untitled .dashboard file to dashboard
+      newfile(contents).then((f) => {
+        this._file = f;
+        this._path = this._file.path;
+      });
+    }
 
     // Having all widgetstores across dashboards have the same id might cause issues.
     this._store = store;
@@ -343,16 +336,9 @@ export class Dashboard extends MainAreaWidget<Widget> {
     // Adds save button to dashboard toolbar.
     this.toolbar.addItem('save', createSaveButton(this, panel));
 
-    // TODO: Figure out if this is worth it. Right now it's disabled to prevent
-    // double updating, and I figure manually calling this.update() whenever the
-    // widgetstore is modified isn't so bad.
-    //
-    // Attach listener to update on table changes.
-    // this._store.listenTable(
-    //   { schema: Widgetstore.WIDGET_SCHEMA },
-    //   this.update,
-    //   this
-    // );
+    if (restore) {
+      this.updateLayoutFromWidgetstore();
+    }
   }
 
   /**
@@ -377,7 +363,7 @@ export class Dashboard extends MainAreaWidget<Widget> {
    *
    */
   public set path(v: string) {
-    this.path = v;
+    this._path = v;
   }
 
   /**
@@ -501,29 +487,89 @@ export class Dashboard extends MainAreaWidget<Widget> {
    *
    * @throws an error if saving fails.
    */
-  save(path: string): void {
-    this._dbArea.save(path);
+  save(notebookTracker: INotebookTracker): void {
+    // Get all widgets that haven't been removed.
+    const records = filter(
+      this._store.getWidgets(),
+      (widget) => widget.widgetId && !widget.removed
+    );
+
+    const file: DashboardSpec = {
+      version: DASHBOARD_VERSION,
+      dashboardHeight: (this._dbArea.layout as DashboardLayout).height,
+      dashboardWidth: (this._dbArea.layout as DashboardLayout).width,
+      paths: {},
+      outputs: {},
+    };
+
+    each(records, (record) => {
+      const notebookId = record.notebookId;
+      const path = getPathFromNotebookId(notebookId, notebookTracker);
+
+      if (path === undefined) {
+        throw new Error(
+          `Notebook path for notebook with id ${notebookId} not found`
+        );
+      }
+
+      if (file.paths[path] !== undefined && file.paths[path] !== notebookId) {
+        throw new Error(`Conflicting paths for same notebook id ${notebookId}`);
+      }
+
+      file.paths[path] = notebookId;
+
+      if (file.outputs[notebookId] === undefined) {
+        file.outputs[notebookId] = [];
+      }
+
+      file.outputs[notebookId].push({
+        cellId: record.cellId,
+        top: record.top,
+        left: record.left,
+        width: record.width,
+        height: record.height,
+      });
+    });
+
+    const fileName = this._name;
+    renameDashboardFile(fileName, this);
+    dashboard2file(this, file);
   }
 
   /**
    * Load a dashboard from a file.
    *
-   * UNFINISHED!!
+   * @param path - the path to save to.
+   *
+   * @param notebookTracker - the current NotebookTracker.
+   *
+   * @param outputTracker - the current outputTracker.
+   *
+   * @returns - the created Dashboard.
+   *
+   * @throws - an error if the dashboard file is not well-formated, notebooks
+   * are missing, or there is an issue reading them.
    */
-  static load(
+  static async load(
     path: string,
     notebookTracker: INotebookTracker,
-    outputTracker: WidgetTracker<DashboardWidget>,
-    panel: NotebookPanel
-  ): Dashboard {
-    const fileText = loadFileAsString(path);
+    outputTracker: WidgetTracker<DashboardWidget>
+  ): Promise<Dashboard> {
+    // Create the contentsManager for opening/reading the dashboard file.
+    const contentsManager = new ContentsManager();
+
+    // Promise containing the file text.
+    const filePromise = await contentsManager.get(path);
+    const fileText = filePromise.content as string;
 
     if (fileText === undefined) {
       throw new Error(`Error reading file at ${path}`);
     }
 
+    // File text as a JSOn object.
     const parsed = JSON.parse(fileText);
 
+    // Validate version information.
     if (parsed.version === undefined) {
       throw new Error("Dashboard file missing required field 'version'");
     } else if (isNaN(+parsed.version)) {
@@ -534,69 +580,95 @@ export class Dashboard extends MainAreaWidget<Widget> {
       );
     }
 
+    // Validate notebook paths.
     if (parsed.paths === undefined) {
       throw new Error("Dashboard file missing required field 'paths'");
-    } else if (!Array.isArray(parsed.paths)) {
-      throw new Error('Paths field is not an array');
     }
 
-    for (const [notebookPath, notebookId] of Object.entries(parsed.paths)) {
-      if (notebookId === undefined) {
-        throw new Error(`No notebook id for notebook at ${notebookPath}`);
-      }
+    // for (const [notebookPath, notebookId] of Object.entries(parsed.paths)) {
+    //   if (notebookId === undefined) {
+    //     throw new Error(`No notebook id for notebook at ${notebookPath}`);
+    //   }
 
-      const maybeNotebook = loadFileAsString(path);
+    //   const maybeNotebook = loadFileAsString(path);
 
-      if (maybeNotebook === undefined) {
-        // TODO: Replace with file picker.
-        throw new Error(`Error reading notebook at ${notebookPath}`);
-      }
+    //   if (maybeNotebook === undefined) {
+    //     // TODO: Replace with file picker.
+    //     throw new Error(`Error reading notebook at ${notebookPath}`);
+    //   }
 
-      const parsedMaybeNotebook = JSON.parse(maybeNotebook);
+    //   const parsedMaybeNotebook = JSON.parse(maybeNotebook);
 
-      const maybeNotebookId = parsedMaybeNotebook.metadata?.presto.id;
+    //   const maybeNotebookId = parsedMaybeNotebook.metadata?.presto.id;
 
-      if (maybeNotebookId === undefined) {
-        throw new Error(`No notebook id found for ${notebookPath}`);
-      }
+    //   if (maybeNotebookId === undefined) {
+    //     throw new Error(`No notebook id found for ${notebookPath}`);
+    //   }
 
-      if (maybeNotebookId !== notebookId) {
-        throw new Error(
-          `Notebook id of ${notebookPath} (${maybeNotebookId}) does not match dashboard file notebook id (${notebookId})`
-        );
-      }
-    }
+    //   if (maybeNotebookId !== notebookId) {
+    //     throw new Error(
+    //       `Notebook id of ${notebookPath} (${maybeNotebookId}) does not match dashboard file notebook id (${notebookId})`
+    //     );
+    //   }
+    // }
 
     const paths = parsed.paths;
 
-    for (const notebookPath of paths) {
+    // Open required notebooks.
+    for (const [notebookPath, notebookId] of Object.entries(paths)) {
       // Replace this with code to open a notebook.
-      console.log('opening notebook at ', notebookPath);
+      console.log('opening notebook at ', notebookPath, notebookId);
     }
 
+    // Validate outputs field
     if (parsed.outputs === undefined) {
       throw new Error("Dashboard file missing required field 'outputs'");
     }
 
+    // Create a new widgetstore.
     const store = new Widgetstore({ id: 0, notebookTracker });
 
     for (const [notebookId, outputs] of Object.entries(parsed.outputs)) {
+      // Make sure each id corresponds to an array of outputs.
       if (!Array.isArray(outputs)) {
         throw new Error(`Outputs for notebook ${notebookId} are not an array`);
       }
-      for (const output of outputs) {
-        Dashboard.verifyOutput(notebookId, output);
-        const info: Widgetstore.WidgetInfo = {
-          ...output,
-          notebookId,
-          widgetId: DashboardWidget.createDashboardWidgetId(),
-        };
+      for (const _output of outputs) {
+        const output: WidgetInfo = _output;
+
+        // Validate output information
+        Dashboard.validateOutput(notebookId, output);
+        let info: Widgetstore.WidgetInfo;
+
+        const cell = getCellById(output.cellId, notebookTracker);
+        // Check if cell id exists in the given notebook.
+        if (cell === undefined) {
+          // If cell id doesn't exist, create a red "placeholder" widget in its spot.
+          info = {
+            ...output,
+            notebookId,
+            widgetId: DashboardWidget.createDashboardWidgetId(),
+            missing: true,
+          };
+        } else {
+          // Create widget based on position, notebookId, and cellId.
+          info = {
+            ...output,
+            notebookId,
+            widgetId: DashboardWidget.createDashboardWidgetId(),
+          };
+        }
+        // Add the widget to the widgetstore.
         store.addWidget(info);
       }
     }
 
     const name = parsed.name;
+    const panel = notebookTracker.currentWidget;
 
+    contentsManager.dispose();
+
+    // Create and return a notebook based on the contents of the widgetstore.
     return new Dashboard({
       name,
       notebookTracker,
@@ -606,7 +678,16 @@ export class Dashboard extends MainAreaWidget<Widget> {
     });
   }
 
-  static verifyOutput(notebookId: string, output: any): void {
+  /**
+   * Makes sure an output entry from a dashboard file is well-formated.
+   *
+   * @param notebookId - id of output's notebook for error messages.
+   *
+   * @param output - output to verify.
+   *
+   * @throws - an error if the entry is not well-formated.
+   */
+  static validateOutput(notebookId: string, output: any): void {
     if (output.left === undefined) {
       throw new Error(
         `Output of notebook ${notebookId} is missing the 'left' field`

--- a/src/file.ts
+++ b/src/file.ts
@@ -37,7 +37,7 @@ export type WidgetInfo = {
   /**
    * The cell ID the widget is created from.
    */
-  id: string;
+  cellId: string;
 
   /**
    * The top edge position of the widget.

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -36,8 +36,8 @@ export function dashboard2file(dashboard: Dashboard, content: any) {
  *
  * @param dashboard - dashboard with its path to be renamed
  */
-export function renameDashboardFile(dashboard: Dashboard) {
-  const newPath = '/' + dashboard.getName() + '.dashboard';
+export function renameDashboardFile(name: string, dashboard: Dashboard) {
+  const newPath = '/' + name + '.dashboard';
   dashboard.contents.rename(dashboard.path, newPath);
   dashboard.path = newPath;
 }

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -6,7 +6,9 @@ import { Dashboard } from './dashboard';
  *
  * @return file created
  */
-export async function newfile(contents: ContentsManager) {
+export async function newfile(
+  contents: ContentsManager
+): Promise<Contents.IModel> {
   const file = await contents.newUntitled({
     path: '/',
     type: 'file',
@@ -20,7 +22,7 @@ export async function newfile(contents: ContentsManager) {
  * @param content - content of any type to save as a string
  * @param dashboard - dashboard with its path to be saved
  */
-export function dashboard2file(dashboard: Dashboard, content: any) {
+export function dashboard2file(dashboard: Dashboard, content: any): void {
   const DASHBOARD: Partial<Contents.IModel> = {
     path: dashboard.path,
     type: 'file',
@@ -36,7 +38,7 @@ export function dashboard2file(dashboard: Dashboard, content: any) {
  *
  * @param dashboard - dashboard with its path to be renamed
  */
-export function renameDashboardFile(name: string, dashboard: Dashboard) {
+export function renameDashboardFile(name: string, dashboard: Dashboard): void {
   const newPath = '/' + name + '.dashboard';
   dashboard.contents.rename(dashboard.path, newPath);
   dashboard.path = newPath;
@@ -48,7 +50,7 @@ export function renameDashboardFile(name: string, dashboard: Dashboard) {
  * But new dashboard is not saved later
  * @param dashboard - dashboard with its path to be deleted
  */
-export function deleteDashboardFile(dashboard: Dashboard) {
+export function deleteDashboardFile(dashboard: Dashboard): void {
   dashboard.contents.delete(dashboard.path);
 }
 
@@ -58,7 +60,7 @@ export function deleteDashboardFile(dashboard: Dashboard) {
  * @param dashboard - dashboard whose .dashboard file to be read
  * @return content of .dashboard file
  */
-export async function readDashboardFile(dashboard: Dashboard) {
+export async function readDashboardFile(dashboard: Dashboard): Promise<string> {
   const content = await dashboard.contents.get(dashboard.path);
   return content.content as string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,8 +266,8 @@ function addCommands(
     label: 'Delete Output',
     execute: (args) => {
       const widget = outputTracker.currentWidget;
-      dashboardTracker.currentWidget.deleteWidget(widget);
       dashboardTracker.currentWidget.deleteWidgetInfo(widget);
+      dashboardTracker.currentWidget.deleteWidget(widget);
     },
   });
 
@@ -349,7 +349,7 @@ function addCommands(
 
   commands.addCommand('printFile', {
     label: 'Print File',
-    execute: (args) => dashboardTracker.currentWidget.store.save('myPath'),
+    execute: (args) => dashboardTracker.currentWidget.save('myPath'),
   });
 
   commands.addCommand('resize', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,11 @@ import {
 
 import { Widget } from '@lumino/widgets';
 
-import { Dashboard, DashboardArea } from './dashboard';
+import { Dashboard } from './dashboard';
 
 import { DashboardWidget } from './widget';
 
 import { DashboardButton } from './button';
-
-import { MessageLoop } from '@lumino/messaging';
 
 // HTML element classes
 
@@ -45,6 +43,10 @@ namespace CommandIDs {
   export const undo = 'dashboard:undo';
 
   export const redo = 'dashboard:redo';
+
+  export const save = 'dashboard:save';
+
+  export const load = 'dashboard:load';
 }
 
 const extension: JupyterFrontEndPlugin<void> = {
@@ -81,6 +83,18 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     app.contextMenu.addItem({
+      command: CommandIDs.save,
+      selector: '.pr-JupyterDashboard',
+      rank: 3,
+    });
+
+    app.contextMenu.addItem({
+      command: CommandIDs.load,
+      selector: '.jp-Notebook',
+      rank: 15,
+    });
+
+    app.contextMenu.addItem({
       command: CommandIDs.renameDashboard,
       selector: '.pr-JupyterDashboard',
       rank: 0,
@@ -102,18 +116,6 @@ const extension: JupyterFrontEndPlugin<void> = {
       command: CommandIDs.deleteOutput,
       selector: '.pr-DashboardWidget',
       rank: 0,
-    });
-
-    app.contextMenu.addItem({
-      command: 'printFile',
-      selector: '.pr-JupyterDashboard',
-      rank: 5,
-    });
-
-    app.contextMenu.addItem({
-      command: 'resize',
-      selector: '.pr-JupyterDashboard',
-      rank: 6,
     });
 
     // Add commands to key bindings
@@ -154,81 +156,6 @@ function addCommands(
   const { commands, shell } = app;
 
   /**
-   * Get the current widget and activate unless the args specify otherwise.
-   * jupyterlab/packages/notebook-extension/src/index.ts
-   */
-  // function getCurrentNotebook(
-  //   args: ReadonlyPartialJSONObject
-  // ): NotebookPanel | null {
-  //   const widget = tracker.currentWidget;
-  //   const activate = args['activate'] !== false;
-
-  //   if (activate && widget) {
-  //     shell.activateById(widget.id);
-  //   }
-
-  //   return widget;
-  // }
-
-  /**
-   * Get the current notebook output wrapped in a DashboardWidget.
-   */
-  // function getCurrentWidget(currentNotebook: NotebookPanel): DashboardWidget {
-  //   if (!currentNotebook) {
-  //     return;
-  //   }
-  //   const cell = currentNotebook.content.activeCell as CodeCell;
-  //   const index = currentNotebook.content.activeCellIndex;
-
-  //   return new DashboardWidget({
-  //     notebook: currentNotebook,
-  //     cell,
-  //     index,
-  //   });
-  // }
-
-  /**
-   * Get the current Dashboard.
-   */
-  // function getCurrentDashboard(): Dashboard {
-  //   return dashboardTracker.currentWidget;
-  // }
-
-  // function createDashboard(): void {
-  //   const panel = getCurrentNotebook({ activate: false });
-  //   const dashboard = new Dashboard({ outputTracker, panel, notebookTracker: tracker});
-  //   panel.context.addSibling(dashboard, {
-  //     ref: panel.id,
-  //     mode: 'split-bottom',
-  //   });
-  //   dashboardTracker.add(dashboard);
-  // }
-
-  /**
-   * Inserts a widget into a dashboard.
-   */
-  // async function addWidget(
-  //   dashboard: Dashboard,
-  //   notebook: NotebookPanel,
-  //   cell: Cell
-  // ): Promise<void> {
-
-  //   const info: Widgetstore.WidgetInfo = {
-  //     widgetId: DashboardWidget.createDashboardWidgetId(),
-  //     notebookId: addNotebookId(notebook),
-  //     cellId: addCellId(cell),
-  //     top: 0,
-  //     left: 0,
-  //     width: Widgetstore.DEFAULT_WIDTH,
-  //     height: Widgetstore.DEFAULT_HEIGHT,
-  //     changed: true,
-  //     removed: false
-  //   }
-
-  //   dashboard.addWidget(info);
-  // }
-
-  /**
    * Whether there is an active notebook.
    * jupyterlab/packages/notebook-extension/src/index.ts
    */
@@ -257,6 +184,18 @@ function addCommands(
       }
     }
     return true;
+  }
+
+  async function getPath(): Promise<string> {
+    const path = await showDialog({
+      title: 'Load Path',
+      body: new Private.PathHandler(),
+      focusNodeSelector: 'input',
+      buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Load' })],
+    }).then((result) => {
+      return result.value;
+    });
+    return path;
   }
 
   /**
@@ -347,17 +286,25 @@ function addCommands(
     isVisible: () => false,
   });
 
-  commands.addCommand('printFile', {
-    label: 'Print File',
-    execute: (args) => dashboardTracker.currentWidget.save('myPath'),
+  commands.addCommand(CommandIDs.save, {
+    label: 'Save Dashboard',
+    execute: (args) => dashboardTracker.currentWidget.save(tracker),
   });
 
-  commands.addCommand('resize', {
-    label: 'Resize',
-    execute: (args) => {
-      const msg = new Widget.ResizeMessage(1920, 1080);
-      const widget = dashboardTracker.currentWidget.content as DashboardArea;
-      MessageLoop.sendMessage(widget, msg);
+  commands.addCommand(CommandIDs.load, {
+    label: 'Load Dashboard',
+    execute: async (args) => {
+      const path = await getPath();
+      if (path === undefined) {
+        console.log('invalid path');
+        return;
+      }
+      const dashboard = await Dashboard.load(path, tracker, outputTracker);
+      const currentNotebook = tracker.currentWidget;
+      currentNotebook.context.addSibling(dashboard, {
+        ref: currentNotebook.id,
+        mode: 'split-bottom',
+      });
     },
   });
 
@@ -383,6 +330,35 @@ function addCommands(
  * A namespace for private data.
  */
 namespace Private {
+  export class PathHandler extends Widget {
+    constructor() {
+      const node = document.createElement('div');
+
+      const nameTitle = document.createElement('label');
+      nameTitle.textContent = 'Load Path';
+      const path = document.createElement('input');
+
+      node.appendChild(nameTitle);
+      node.appendChild(path);
+
+      super({ node });
+    }
+
+    /**
+     * Get the input text node.
+     */
+    get inputNode(): HTMLInputElement {
+      return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
+    }
+
+    /**
+     * Get the value of the widget.
+     */
+    getValue(): string {
+      return this.inputNode.value;
+    }
+  }
+
   /**
    * A widget used to rename dashboards.
    * jupyterlab/packages/docmanager/src/dialog.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,7 @@ function addCommands(
         ref: currentNotebook.id,
         mode: 'split-bottom',
       });
+      dashboardTracker.add(dashboard);
     },
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import { Cell } from '@jupyterlab/cells';
 import { UUID } from '@lumino/coreutils';
 
 import { ArrayExt, toArray } from '@lumino/algorithm';
+import { DashboardSpec } from './file';
 
 export function addNotebookId(notebook: NotebookPanel): string {
   const metadata: any | undefined = notebook.model.metadata.get('presto');
@@ -96,4 +97,8 @@ export function toHex(str: string): string {
     .split('')
     .map((c) => c.charCodeAt(0).toString(16))
     .join('');
+}
+
+export function loadFileAsString(path: string): string | undefined {
+  return '{}';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,6 @@ import { Cell } from '@jupyterlab/cells';
 import { UUID } from '@lumino/coreutils';
 
 import { ArrayExt, toArray } from '@lumino/algorithm';
-import { DashboardSpec } from './file';
 
 export function addNotebookId(notebook: NotebookPanel): string {
   const metadata: any | undefined = notebook.model.metadata.get('presto');
@@ -88,8 +87,17 @@ export function getCellById(
  * Should eventually return a file path to a notebook given its id.
  * For now, just returns a random string.
  */
-export function getPathFromNotebookId(id: string): string {
-  return `DUMMY_PATH_${UUID.uuid4()}`;
+export function getPathFromNotebookId(
+  id: string,
+  notebookTracker: INotebookTracker
+): string | undefined {
+  const notebook = notebookTracker.find(
+    (notebook) => getNotebookId(notebook) === id
+  );
+  if (notebook === undefined) {
+    return undefined;
+  }
+  return notebook.context.path;
 }
 
 export function toHex(str: string): string {
@@ -97,8 +105,4 @@ export function toHex(str: string): string {
     .split('')
     .map((c) => c.charCodeAt(0).toString(16))
     .join('');
-}
-
-export function loadFileAsString(path: string): string | undefined {
-  return '{}';
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -22,6 +22,8 @@ import { shouldStartDrag } from './widgetdragutils';
 
 import { DashboardArea } from './dashboard';
 
+import { getNotebookId, getCellId } from './utils';
+
 // HTML element classes
 
 const DASHBOARD_WIDGET_CLASS = 'pr-DashboardWidget';
@@ -52,8 +54,11 @@ export class DashboardWidget extends Panel {
     this.node.setAttribute('tabindex', '-1');
 
     if (options.placeholder) {
-      console.log('creating placeholder');
       this.node.style.background = 'red';
+      if (options.cellId === undefined) {
+        console.warn('DashboardWidget has no cell or cellId');
+      }
+      this._cellId = options.cellId;
     } else {
       // Wait for the notebook to be loaded before cloning the output area.
       void this._notebook.context.ready.then(() => {
@@ -67,7 +72,17 @@ export class DashboardWidget extends Panel {
         const clone = this._cell.cloneOutputArea();
         this.addWidget(clone);
       });
+
+      // Might have weird interactions where options.cellId !== actual cellId
+      this._cellId =
+        options.cellId !== undefined ? options.cellId : getCellId(options.cell);
     }
+
+    // Might have weird interactions where options.notebookId !== actual notebookId
+    this._notebookId =
+      options.notebookId !== undefined
+        ? options.notebookId
+        : getNotebookId(options.notebook);
 
     const resizer = document.createElement('div');
     resizer.classList.add('pr-Resizer');
@@ -322,6 +337,14 @@ export class DashboardWidget extends Panel {
     window.removeEventListener('mousemove', this);
   }
 
+  get cellId(): string {
+    return this._cellId;
+  }
+
+  get notebookId(): string {
+    return this._notebookId;
+  }
+
   static createDashboardWidgetId(): string {
     return `DashboardWidget-${UUID.uuid4()}`;
   }
@@ -339,6 +362,8 @@ export class DashboardWidget extends Panel {
   } | null = null;
   private _drag: Drag | null = null;
   private _mouseMode: DashboardWidget.MouseMode = 'none';
+  private _cellId: string;
+  private _notebookId: string;
 }
 
 /**
@@ -366,47 +391,19 @@ namespace DashboardWidget {
      * Whether the widget is a placeholder for a missing cell.
      */
     placeholder?: boolean;
+
+    /**
+     * An optional cell id used for placeholder widgets.
+     */
+    cellId?: string;
+
+    /**
+     * An optional notebook id used for placeholder widgets.
+     */
+    notebookId?: string;
   }
 
   export type MouseMode = 'drag' | 'resize' | 'none';
 }
-
-/**
- * A namespace for private functionality.
- */
-// namespace Private {
-//   export type ResizerOrientation = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-
-//   export function createResizer(orientation: ResizerOrientation): HTMLElement {
-//     const resizer = document.createElement('div');
-//     resizer.classList.add('pr-Resizer');
-//     resizer.setAttribute('orientation', orientation);
-
-//     switch (orientation) {
-//       case 'top-left':
-//         resizer.style.top = '0';
-//         resizer.style.left = '0';
-//         resizer.style.cursor = 'nw-resize';
-//         break;
-//       case 'top-right':
-//         resizer.style.top = '0';
-//         resizer.style.right = '0';
-//         resizer.style.cursor = 'ne-resize';
-//         break;
-//       case 'bottom-left':
-//         resizer.style.bottom = '0';
-//         resizer.style.left = '0';
-//         resizer.style.cursor = 'sw-resize';
-//         break;
-//       case 'bottom-right':
-//         resizer.style.bottom = '0';
-//         resizer.style.right = '0';
-//         resizer.style.cursor = 'se-resize';
-//         break;
-//     }
-
-//     return resizer;
-//   }
-// }
 
 export default DashboardWidget;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -51,18 +51,23 @@ export class DashboardWidget extends Panel {
     // Makes widget focusable for WidgetTracker
     this.node.setAttribute('tabindex', '-1');
 
-    // Wait for the notebook to be loaded before cloning the output area.
-    void this._notebook.context.ready.then(() => {
-      if (!this._cell) {
-        this._cell = this._notebook.content.widgets[this._index] as CodeCell;
-      }
-      if (!this._cell || this._cell.model.type !== 'code') {
-        this.dispose();
-        return;
-      }
-      const clone = this._cell.cloneOutputArea();
-      this.addWidget(clone);
-    });
+    if (options.placeholder) {
+      console.log('creating placeholder');
+      this.node.style.background = 'red';
+    } else {
+      // Wait for the notebook to be loaded before cloning the output area.
+      void this._notebook.context.ready.then(() => {
+        if (!this._cell) {
+          this._cell = this._notebook.content.widgets[this._index] as CodeCell;
+        }
+        if (!this._cell || this._cell.model.type !== 'code') {
+          this.dispose();
+          return;
+        }
+        const clone = this._cell.cloneOutputArea();
+        this.addWidget(clone);
+      });
+    }
 
     const resizer = document.createElement('div');
     resizer.classList.add('pr-Resizer');
@@ -356,7 +361,13 @@ namespace DashboardWidget {
      * of the cell for when the notebook is loaded.
      */
     index?: number;
+
+    /**
+     * Whether the widget is a placeholder for a missing cell.
+     */
+    placeholder?: boolean;
   }
+
   export type MouseMode = 'drag' | 'resize' | 'none';
 }
 

--- a/src/widgetstore.ts
+++ b/src/widgetstore.ts
@@ -1,4 +1,4 @@
-import { filter, IIterator, each } from '@lumino/algorithm';
+import { filter, IIterator } from '@lumino/algorithm';
 
 import { Litestore } from './litestore';
 
@@ -10,9 +10,7 @@ import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 
 import { Cell, CodeCell } from '@jupyterlab/cells';
 
-import { getNotebookById, getCellById, getPathFromNotebookId } from './utils';
-
-import { DashboardSpec, WidgetInfo, DASHBOARD_VERSION } from './file';
+import { getNotebookById, getCellById } from './utils';
 
 /**
  * Alias for widget schema type.
@@ -253,50 +251,6 @@ export class Widgetstore extends Litestore {
     }
     this._inBatch = false;
     this.endTransaction();
-  }
-
-  /**
-   * Saves the store to file.
-   *
-   * @param path - file path to save the store to.
-   *
-   * @throws an error if saving fails.
-   */
-  save(path: string): void {
-    console.log('saving to', path);
-
-    // Get all widgets that haven't been removed or un-added.
-    const widgets = filter(
-      this.getWidgets(),
-      (widget) => widget.widgetId && !widget.removed
-    );
-
-    const file: DashboardSpec = {
-      version: DASHBOARD_VERSION,
-      dashboardWidth: 0,
-      dashboardHeight: 0,
-      paths: {},
-      outputs: {},
-    };
-
-    each(widgets, (widget) => {
-      // Currently just returns a dummy path.
-      const widgetInfo: WidgetInfo = {
-        id: widget.cellId,
-        left: widget.left,
-        top: widget.top,
-        width: widget.width,
-        height: widget.height,
-      };
-      const path = getPathFromNotebookId(widget.notebookId);
-      file.paths[path] = widget.notebookId;
-      if (file.outputs[widget.notebookId] === undefined) {
-        file.outputs[widget.notebookId] = [];
-      }
-      file.outputs[widget.notebookId].push(widgetInfo);
-    });
-
-    console.log(file);
   }
 
   private _notebookTracker: INotebookTracker;

--- a/src/widgetstore.ts
+++ b/src/widgetstore.ts
@@ -198,15 +198,18 @@ export class Widgetstore extends Litestore {
    * widgetinfo object.
    */
   createWidget(info: Widgetstore.WidgetInfo): DashboardWidget {
-    const notebook = this.getNotebookById(info.notebookId);
+    const { notebookId, cellId } = info;
+
+    const notebook = this.getNotebookById(notebookId);
     if (notebook === undefined) {
       throw new Error('notebook not found');
     }
-    const cell = this.getCellById(info.cellId) as CodeCell;
+    const cell = this.getCellById(cellId) as CodeCell;
     if (cell === undefined) {
       throw new Error('cell not found');
     }
-    const widget = new DashboardWidget({ notebook, cell });
+    const widget = new DashboardWidget({ notebook, cell, notebookId, cellId });
+
     widget.id = info.widgetId;
     widget.node.style.left = `${info.left}px`;
     widget.node.style.top = `${info.top}px`;
@@ -217,11 +220,18 @@ export class Widgetstore extends Litestore {
   }
 
   createPlaceholderWidget(info: Widgetstore.WidgetInfo): DashboardWidget {
+    const { notebookId, cellId } = info;
+
     const notebook = this.getNotebookById(info.notebookId);
     if (notebook === undefined) {
       throw new Error('notebook not found');
     }
-    const widget = new DashboardWidget({ notebook, placeholder: true });
+    const widget = new DashboardWidget({
+      notebook,
+      notebookId,
+      cellId,
+      placeholder: true,
+    });
 
     widget.id = info.widgetId;
     widget.node.style.left = `${info.left}px`;


### PR DESCRIPTION
## What's new
- Started save/load functionality.
- Can save a dashboard file through dashboard context menu (saves in root directory as [DASHBOARD NAME].dashboard).
- Can load a dashboard file through notebook context menu (load from typed path).
- Red placeholder widgets for outputs generated from missing cells.
- Removed inner declarations check (eslint).

## Fixed
- Bug causing all deleted widgets to be restored on undo.
- Bug causing dimensions of widget returned from `getInfoFromWidget` to be NaN.

## Todo/issues
- Issue #36 
- 'Save as' for dashboards.
- Integration with document registry to open .dashboard file with a click.
- Better placeholder widgets (better look, include optional debug information).
- Open dashboard without requiring used notebooks to be open beforehand.
- Save/load dashboard in File menu.
- Clean up automatically created Untitled.dashboard files.
