### PR TITLE
overlap handling fixes

### DIFF
--- a/src/widgetstore.ts
+++ b/src/widgetstore.ts
@@ -76,11 +76,6 @@ export class Widgetstore extends Litestore {
   private _handleChanges(changes: IDashboardChange[]): void {
     this.startBatch();
 
-    console.log(
-      'changes to apply',
-      changes.filter((change) => !change.ignore)
-    );
-
     for (const change of changes) {
       const { widgetId, pos, ignore } = change;
 
@@ -253,7 +248,6 @@ export class Widgetstore extends Litestore {
     if (this._inBatch) {
       return;
     }
-    console.log('starting batch in widgetstore');
     this._inBatch = true;
     this.beginTransaction();
   }
@@ -265,7 +259,6 @@ export class Widgetstore extends Litestore {
     if (!this._inBatch) {
       return;
     }
-    console.log('ending batch in widgetstore');
     this._inBatch = false;
     this.endTransaction();
   }

--- a/style/index.css
+++ b/style/index.css
@@ -5,7 +5,7 @@
 .pr-DashboardWidget {
     border-width: 2px;
     border-radius: 3px;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
 }
@@ -46,9 +46,7 @@
 }
 
 .pr-DashboardWidgetChild {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: inline-flex;
     object-fit: scale-down;
 }
 
@@ -58,8 +56,6 @@
 
 .pr-Canvas {
     pointer-events: none;
-    padding-bottom: 80px;
-    padding-right: 80px;
 }
 
 .pr-Canvas.pr-FreeLayout {


### PR DESCRIPTION
## Fixed
- Bug preventing canvas from expanding downward to handle an overlap.
- Bug causing newly placed widgets to trigger the overlap handler if the widget would have overlapped a widget if it was the default width/height.
- Made console quieter.