### PR TITLE
Metadata dashboards

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
       { avoidEscape: true, allowTemplateLiterals: false }
     ],
     curly: ['error', 'all'],
-    eqeqeq: 'error',
+    eqeqeq: ['error', 'smart'],
     'prefer-arrow-callback': 'error'
   }
 };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,4 +21,7 @@ export namespace CommandIDs {
   export const setTileSize = 'dashboard:set-tile-size';
   export const saveToMetadata = 'dashboard:save-to-metadata';
   export const openFromMetadata = 'dashboard:open-from-metadata';
+  export const toggleWidgetMode = 'dashboard:toggle-widget-mode';
+  export const toggleInfiniteScroll = 'dashboard:toggle-infinite-scroll';
+  export const trimDashboard = 'dashboard:trim-dashboard';
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,4 +19,6 @@ export namespace CommandIDs {
   export const startFullscreen = 'dashboard:start-fullscreen';
   export const createNew = 'dashboard:create-new';
   export const setTileSize = 'dashboard:set-tile-size';
+  export const saveToMetadata = 'dashboard:save-to-metadata';
+  export const openFromMetadata = 'dashboard:open-from-metadata';
 }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -146,7 +146,7 @@ export class Dashboard extends Widget {
     event.dropAction = 'copy';
     const source = event.source as DashboardWidget;
     const pos = source?.pos;
-    if (pos) {
+    if (pos && source.mode === 'grid-edit') {
       pos.left = event.offsetX + this.node.scrollLeft;
       pos.top = event.offsetY + this.node.scrollTop;
       (this.layout as DashboardLayout).drawDropZone(pos, '#2b98f0');
@@ -243,7 +243,7 @@ export class Dashboard extends Widget {
 
   private _evtScroll(_event: Event): void {
     const model = this.model;
-
+    
     if (model.scrollMode !== 'infinite') {
       return;
     }
@@ -421,7 +421,7 @@ export class Dashboard extends Widget {
  * Namespace for DashboardArea options.
  */
 export namespace Dashboard {
-  export type Mode = 'edit' | 'present' | 'grid';
+  export type Mode = 'free-edit' | 'present' | 'grid-edit';
 
   export type ScrollMode = 'infinite' | 'constrained';
 
@@ -589,9 +589,9 @@ export namespace DashboardDocument {
           value={value}
           aria-label={'Mode'}
         >
-          <option value="present">Present</option>
-          <option value="edit">Free Layout</option>
-          <option value="grid">Tile Layout</option>
+          <option value='present'>Present</option>
+          {/* <option value="free-edit">Free Layout</option> */}
+          <option value='grid-edit'>Edit</option>
         </HTMLSelect>
       );
     }

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -137,8 +137,8 @@ export class Drag implements IDisposable {
     this.proposedAction = options.proposedAction || 'copy';
     this.supportedActions = options.supportedActions || 'all';
     this.source = options.source || null;
-    this._widgetX = options.widgetX || 0;
-    this._widgetY = options.widgetY || 0;
+    this._dragAdjustX = options.dragAdjustX || 0;
+    this._dragAdjustY = options.dragAdjustY || 0;
   }
 
   /**
@@ -228,8 +228,8 @@ export class Drag implements IDisposable {
       return this._promise;
     }
 
-    this._deltaX = this._widgetX - clientX;
-    this._deltaY = this._widgetY - clientY;
+    this._dragOffsetX = this._dragAdjustX - clientX;
+    this._dragOffsetY = this._dragAdjustY - clientY;
 
     // Install the document listeners for the drag object.
     this._addListeners();
@@ -295,7 +295,7 @@ export class Drag implements IDisposable {
 
     // Move the drag image to the specified client position. This is
     // performed *after* dispatching to prevent unnecessary reflows.
-    this._moveDragImage(event.clientX, event.clientY);
+    this.moveDragImage(event.clientX, event.clientY);
   }
 
   /**
@@ -416,8 +416,8 @@ export class Drag implements IDisposable {
 
     // Find the current indicated element at the given position.
     const currElems = document.elementsFromPoint(
-      event.clientX + this._deltaX,
-      event.clientY + this._deltaY
+      event.clientX + this._dragOffsetX,
+      event.clientY + this._dragOffsetY
     );
 
     let currElem = currElems.find((elem) =>
@@ -470,8 +470,8 @@ export class Drag implements IDisposable {
     const style = this.dragImage.style;
     style.pointerEvents = 'none';
     style.position = 'fixed';
-    style.top = `${clientY + this._deltaY}px`;
-    style.left = `${clientX + this._deltaX}px`;
+    style.top = `${clientY + this._dragOffsetY}px`;
+    style.left = `${clientX + this._dragOffsetX}px`;
     document.body.appendChild(this.dragImage);
   }
 
@@ -480,13 +480,13 @@ export class Drag implements IDisposable {
    *
    * This is a no-op if there is no drag image element.
    */
-  private _moveDragImage(clientX: number, clientY: number): void {
+  protected moveDragImage(clientX: number, clientY: number): void {
     if (!this.dragImage) {
       return;
     }
     const style = this.dragImage.style;
-    style.top = `${clientY + this._deltaY}px`;
-    style.left = `${clientX + this._deltaX}px`;
+    style.top = `${clientY + this.dragOffsetY}px`;
+    style.left = `${clientX + this.dragOffsetX}px`;
   }
 
   /**
@@ -607,12 +607,12 @@ export class Drag implements IDisposable {
     requestAnimationFrame(this._onScrollFrame);
   };
 
-  get deltaX(): number {
-    return this._deltaX;
+  get dragOffsetX(): number {
+    return this._dragOffsetX;
   }
 
-  get deltaY(): number {
-    return this._deltaY;
+  get dragOffsetY(): number {
+    return this._dragOffsetY;
   }
 
   private _disposed = false;
@@ -623,10 +623,10 @@ export class Drag implements IDisposable {
   private _promise: Promise<DropAction> | null = null;
   private _scrollTarget: Private.IScrollTarget | null = null;
   private _resolve: ((value: DropAction) => void) | null = null;
-  private _widgetX: number;
-  private _widgetY: number;
-  private _deltaX: number;
-  private _deltaY: number;
+  private _dragAdjustX: number;
+  private _dragAdjustY: number;
+  private _dragOffsetX: number;
+  private _dragOffsetY: number;
 }
 
 /**
@@ -702,14 +702,14 @@ export namespace Drag {
      *
      * The default value is 0.
      */
-    widgetX?: number;
+    dragAdjustX?: number;
 
     /**
      * How many pixels to offset the drag/image in the y direction.
      *
      * The default value is 0.
      */
-    widgetY?: number;
+    dragAdjustY?: number;
   }
 
   /**
@@ -842,8 +842,8 @@ namespace Private {
     drag: Drag
   ): IScrollTarget | null {
     // Look up the client mouse position.
-    const x = event.clientX + drag.deltaX;
-    const y = event.clientY + drag.deltaY;
+    const x = event.clientX + drag.dragOffsetX;
+    const y = event.clientY + drag.dragOffsetY;
 
     // Get the element under the mouse.
     let element: Element | null = document.elementFromPoint(x, y);
@@ -1199,10 +1199,10 @@ namespace Private {
       true,
       window,
       0,
-      event.screenX + drag.deltaX,
-      event.screenY + drag.deltaY,
-      event.clientX + drag.deltaX,
-      event.clientY + drag.deltaY,
+      event.screenX + drag.dragOffsetX,
+      event.screenY + drag.dragOffsetY,
+      event.clientX + drag.dragOffsetX,
+      event.clientY + drag.dragOffsetY,
       event.ctrlKey,
       event.altKey,
       event.shiftKey,

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -56,9 +56,9 @@ export class DashboardLayout extends Layout {
 
     this._canvas = DashboardLayout.makeCanvas(this._width, this._height);
 
-    if (mode === 'edit') {
+    if (mode === 'free-edit') {
       this._canvas.classList.add(FREE_LAYOUT_CLASS);
-    } else if (mode === 'grid') {
+    } else if (mode === 'grid-edit') {
       this._canvas.classList.add(TILED_LAYOUT_CLASS);
     }
 
@@ -122,6 +122,9 @@ export class DashboardLayout extends Layout {
   onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this._dashboard = this.parent as Dashboard;
+    if (this.mode === 'grid-edit') {
+      this.setTileSize(this.tileSize);
+    }
   }
 
   /**
@@ -364,7 +367,7 @@ export class DashboardLayout extends Layout {
     top = Math.max(top, 0);
 
     // Snap to grid if in grid mode.
-    if (this._mode === 'grid') {
+    if (widget.mode === 'grid-edit') {
       left = Private.mround(left, this._tileSize);
       top = Private.mround(top, this._tileSize);
       width = Math.max(Private.mround(width, this._tileSize), this._tileSize);
@@ -747,13 +750,13 @@ export class DashboardLayout extends Layout {
         this._canvas.classList.remove(FREE_LAYOUT_CLASS);
         this._canvas.classList.remove(TILED_LAYOUT_CLASS);
         break;
-      case 'edit':
+      case 'free-edit':
         this.canvas.style.backgroundPosition = null;
         this.canvas.style.backgroundSize = null;
         this._canvas.classList.remove(TILED_LAYOUT_CLASS);
         this._canvas.classList.add(FREE_LAYOUT_CLASS);
         break;
-      case 'grid':
+      case 'grid-edit':
         this.setTileSize(this._tileSize);
         this._canvas.classList.remove(FREE_LAYOUT_CLASS);
         this.canvas.classList.add(TILED_LAYOUT_CLASS);
@@ -848,7 +851,7 @@ export class DashboardLayout extends Layout {
 
     let { left, top, width, height } = pos;
 
-    if (this.mode === 'grid') {
+    if (this.mode === 'grid-edit') {
       width = Math.max(Private.mround(width, this._tileSize), this._tileSize);
       height = Math.max(Private.mround(height, this._tileSize), this._tileSize);
       left = Private.mround(left, this._tileSize);
@@ -892,7 +895,7 @@ export class DashboardLayout extends Layout {
    * contain all the widgets ("trims" excess dashboard to the right and
    * bottom of the content).
    */
-  trimCanvas(): void {
+  trimDashboard(): void {
     const model = (this.parent as Dashboard).model;
     let maxWidth = 0;
     let maxHeight = 0;
@@ -1007,7 +1010,7 @@ export namespace DashboardLayout {
   /**
    * The default size of a single tile in tiled layout.
    */
-  export const DEFAULT_TILE_SIZE = 50;
+  export const DEFAULT_TILE_SIZE = 32;
 }
 
 /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -366,7 +366,7 @@ export class DashboardModel extends DocumentModel implements IDashboardModel {
 
   private _metadata: IObservableJSON = new ObservableJSON();
   private _loaded = new Signal<this, void>(this);
-  private _mode: Dashboard.Mode = 'edit';
+  private _mode: Dashboard.Mode = 'grid-edit';
   private _scrollMode: Dashboard.ScrollMode = 'constrained';
   private _path: string;
   private _restore: boolean = false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,25 +6,25 @@ import { UUID, ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 import { ArrayExt, toArray } from '@lumino/algorithm';
 
-
 /**
  * Gets the presto metadata portion of a notebook or cell.
- * 
+ *
  * @param source - the notebook or cell containing the metadata.
  */
-export function getMetadata(source: NotebookPanel | Cell): any| undefined {
+export function getMetadata(source: NotebookPanel | Cell): any | undefined {
   return source?.model.metadata.get('presto');
 }
 
-
-export function updateMetadata(source: NotebookPanel | Cell, newValues: ReadonlyPartialJSONObject): void {
+export function updateMetadata(
+  source: NotebookPanel | Cell,
+  newValues: ReadonlyPartialJSONObject
+): void {
   const oldMetadata = getMetadata(source);
-  if (oldMetadata !== undefined) {
+  if (oldMetadata != null) {
     source.model.metadata.set('presto', { ...oldMetadata, ...newValues });
   } else {
-    source.model.metadata.set('presto', newValues)
+    source.model.metadata.set('presto', newValues);
   }
-  
 }
 /**
  * Adds a random, unique ID to a notebook's metadata.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,30 @@ import { NotebookPanel, INotebookTracker } from '@jupyterlab/notebook';
 
 import { Cell } from '@jupyterlab/cells';
 
-import { UUID } from '@lumino/coreutils';
+import { UUID, ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 import { ArrayExt, toArray } from '@lumino/algorithm';
 
+
+/**
+ * Gets the presto metadata portion of a notebook or cell.
+ * 
+ * @param source - the notebook or cell containing the metadata.
+ */
+export function getMetadata(source: NotebookPanel | Cell): any| undefined {
+  return source?.model.metadata.get('presto');
+}
+
+
+export function updateMetadata(source: NotebookPanel | Cell, newValues: ReadonlyPartialJSONObject): void {
+  const oldMetadata = getMetadata(source);
+  if (oldMetadata !== undefined) {
+    source.model.metadata.set('presto', { ...oldMetadata, ...newValues });
+  } else {
+    source.model.metadata.set('presto', newValues)
+  }
+  
+}
 /**
  * Adds a random, unique ID to a notebook's metadata.
  *
@@ -14,7 +34,7 @@ import { ArrayExt, toArray } from '@lumino/algorithm';
  * @returns - the notebook's ID.
  */
 export function addNotebookId(notebook: NotebookPanel): string {
-  const metadata: any | undefined = notebook.model.metadata.get('presto');
+  const metadata = getMetadata(notebook);
   let id: string;
 
   if (metadata !== undefined) {
@@ -37,7 +57,7 @@ export function addNotebookId(notebook: NotebookPanel): string {
  * @returns - the ID of the notebook, or undefined if it has none.
  */
 export function getNotebookId(notebook: NotebookPanel): string | undefined {
-  const metadata: any | undefined = notebook?.model.metadata.get('presto');
+  const metadata = getMetadata(notebook);
   if (metadata === undefined || metadata.id === undefined) {
     return undefined;
   }
@@ -68,7 +88,7 @@ export function getNotebookById(
  * @returns - the cell's ID.
  */
 export function addCellId(cell: Cell): string {
-  const metadata: any | undefined = cell.model.metadata.get('presto');
+  const metadata = getMetadata(cell);
   let id: string;
 
   if (metadata !== undefined) {
@@ -91,7 +111,7 @@ export function addCellId(cell: Cell): string {
  * @returns - the ID of the cell, or undefined if it has none.
  */
 export function getCellId(cell: Cell): string | undefined {
-  const metadata: any | undefined = cell?.model.metadata.get('presto');
+  const metadata = getMetadata(cell);
   if (metadata === undefined || metadata.id === undefined) {
     return undefined;
   }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -50,14 +50,14 @@ const DASHBOARD_WIDGET_CHILD_CLASS = 'pr-DashboardWidgetChild';
 const EDITABLE_WIDGET_CLASS = 'pr-EditableWidget';
 
 /**
- * The class name added to dashboard outputs being dragged.
- */
-const IN_DRAG_CLASS = 'pr-InDrag';
-
-/**
  * The class name added to markdown dashboard outputs.
  */
 const MARKDOWN_OUTPUT_CLASS = 'pr-MarkdownOutput';
+
+/**
+ * The class name added to dashboard widget drag images.
+ */
+const DRAG_IMAGE_CLASS = 'pr-DragImage';
 
 /**
  * Widget to wrap delete/move/etc functionality of widgets in a dashboard (future).
@@ -292,7 +292,7 @@ export class DashboardWidget extends Widget {
     window.addEventListener('mouseup', this);
     window.addEventListener('mousemove', this);
 
-    this.node.style.opacity = '0.6';
+    // this.node.style.opacity = '0.6';
 
     // Set mode to resize if the mousedown happened on a resizer.
     if ((target as HTMLElement).classList.contains('pr-Resizer')) {
@@ -434,7 +434,8 @@ export class DashboardWidget extends Widget {
     clientY: number
   ): Promise<void> {
     const dragImage = target;
-    dragImage.style.opacity = '0.6';
+
+    dragImage.classList.add(DRAG_IMAGE_CLASS);
 
     this.node.style.opacity = '0';
     this.node.style.pointerEvents = 'none';
@@ -445,8 +446,8 @@ export class DashboardWidget extends Widget {
       proposedAction: 'move',
       supportedActions: 'copy-move',
       source: this,
-      widgetX: this._clickData.widgetX,
-      widgetY: this._clickData.widgetY,
+      dragAdjustX: this._clickData.widgetX,
+      dragAdjustY: this._clickData.widgetY,
     });
 
     this._drag.mimeData.setData(DASHBOARD_WIDGET_MIME, this);
@@ -460,7 +461,6 @@ export class DashboardWidget extends Widget {
       }
       this.node.style.opacity = null;
       this.node.style.pointerEvents = 'auto';
-      this.removeClass(IN_DRAG_CLASS);
       this._drag = null;
       this._clickData = null;
     });

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -363,10 +363,10 @@ export class DashboardWidget extends Widget {
     this.node.style.width = `${width}px`;
     this.node.style.height = `${height}px`;
 
-    if (this.mode === 'grid') {
+    if (this.mode === 'grid-edit') {
       (this.parent.layout as DashboardLayout).drawDropZone(this.pos, '#2b98f0');
     }
-    if (this.mode !== 'grid' && this._fitToContent && !event.altKey) {
+    if (this.mode === 'free-edit' && this._fitToContent && !event.altKey) {
       this.fitContent();
     }
   }
@@ -594,7 +594,7 @@ export class DashboardWidget extends Widget {
     } else {
       this.addClass(EDITABLE_WIDGET_CLASS);
     }
-    if (newMode === 'grid') {
+    if (newMode === 'grid-edit') {
       if (this.parent) {
         (this.parent as Dashboard).updateWidget(this, this.pos);
       }
@@ -635,9 +635,9 @@ export class DashboardWidget extends Widget {
   private _cell: CodeCell | MarkdownCell | null = null;
   private _cellId: string;
   private _ready = new Signal<this, void>(this);
-  private _fitToContent = true;
+  private _fitToContent = false;
   private _mouseMode: DashboardWidget.MouseMode = 'none';
-  private _mode: Dashboard.Mode = 'edit';
+  private _mode: Dashboard.Mode = 'grid-edit';
   private _drag: Drag | null = null;
   private _clickData: {
     pressX: number;

--- a/src/widgetstore.ts
+++ b/src/widgetstore.ts
@@ -229,7 +229,7 @@ export class Widgetstore extends Litestore {
 
   getWidgets(): IIterator<Record<WidgetSchema>> {
     const table = this.get(Widgetstore.WIDGET_SCHEMA);
-    return filter(table, (record) => true);
+    return filter(table, (record) => record.widgetId && !record.removed);
   }
 
   /**

--- a/style/index.css
+++ b/style/index.css
@@ -84,8 +84,8 @@
 
 .pr-Canvas.pr-TiledLayout {
     background-image: linear-gradient(45deg, rgba(160,160,160,.15) 25%, transparent 25%), linear-gradient(-45deg, rgba(160,160,160,.15) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, rgba(160,160,160,.15) 75%), linear-gradient(-45deg, transparent 75%, rgba(160,160,160,.15) 70%);
-    background-size: 100px 100px;
-    background-position: 0 0, 0 50px, 50px -50px, -50px 0px;
+    background-size: 64px 64px;
+    background-position: 0 0, 0 32px, 32px -32px, -32px 0px;
 }
 
 .pr-OnboardingGif {
@@ -113,7 +113,6 @@ select.pr-ToolbarSelector.jp-mod-styled {
     display: block;
     box-shadow: none;
     border: none;
-    /* top: 5px !important; */
   }
 
 .pr-ToolbarSelector.jp-mod-styled select {
@@ -127,5 +126,6 @@ select.pr-ToolbarSelector.jp-mod-styled {
   }
 
   .pr-DragImage {
-    box-shadow: var(--jp-elevation-z2);
+    box-shadow: var(--jp-elevation-z1);
+    border: var(--jp-border-width) solid var(--jp-brand-color1);
   }

--- a/style/index.css
+++ b/style/index.css
@@ -124,9 +124,8 @@ select.pr-ToolbarSelector.jp-mod-styled {
     display: block;
     box-shadow: none;
     border: none;
-    /* top: 5px !important; */
   }
-/*   
-  .pr-ToolbarSelector {
-    top: 5px !important;
-  } */
+
+  .pr-DragImage {
+    box-shadow: var(--jp-elevation-z2);
+  }


### PR DESCRIPTION
## What's new
- Experimental embedding of single-notebook dashboards in notebook metadata. This allows dashboards to be served with Voila (!!!).
- "Infinite" and fixed-size dashboards.
- Dashboards are now tiled by default and "free edit" mode is disabled. Instead, individual widgets can be set free from the grid in their context menu.
- Smaller default tile size.
- Style changes.

## Fixed
- Removed some unneeded components for the dashboard model and model factory.

## Todo/issues
- New model for dashboard files that provides an editor view of the dashboard embedded in their metadata. Still deciding if dashboards need their own file type or if single-notebook embedded dashboards are the way to go.
- More robust schema for embedded dashboards [(something like this?)](https://jupyter-dashboards-layout.readthedocs.io/en/latest/metadata.html)
- Toolbar access to dashboard sizing features.
- Editable embedded dashboards.

## Notes
Embedded dashboards can now be served with Voila! Check back for a link to see how once I make the issue on the Voila repo.
