### PR TITLE
mybinder: jupyter lab build disable minimization

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# install extension
+# install extensions, don't minimize as this uses too much memory
+# https://discourse.jupyter.org/t/tip-binder-jupyterlab-extension/6022
 jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
 jupyter labextension install plotlywidget --no-build
 jupyter labextension install @jupyterlab/plotly-extension --no-build
-jupyter labextension install jupyterlab-interactive-dashboard-editor
+jupyter labextension install jupyterlab-interactive-dashboard-editor --no-build
+jupyter lab build --minimize=False
 
 # remove unnecessary directories when using the binder
 rm -rf src


### PR DESCRIPTION
## Fixed
jupyterlab-interactive-dashboard-editor is broken in the [current mybinder link](https://mybinder.org/v2/gh/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master?urlpath=lab). This is because by default building a JupyterLab extension includes a minimisation step that uses more memory than is available on some mybinder clusters.

This can be avoided by disabling minimisation.

## Notes
- https://discourse.jupyter.org/t/tip-binder-jupyterlab-extension/6022
- https://discourse.jupyter.org/t/jupyter-lab-build-hangs-and-then-fails-at-webpack-config-webpack-prod-minimize-config-js/6017/3