### PR TITLE
Install the extension with pip on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,26 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
-       node-version: '10.x'
+       node-version: '14.x'
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install dependencies
-      run: python -m pip install jupyterlab
+      run: python -m pip install -U pip jupyterlab~=3.0 jupyter-packaging~=0.7.9
     - name: Build the extension
       run: |
         jlpm
         jlpm run eslint:check
 
-        jupyter labextension install .
-        
+        python -m pip install .
+
         jupyter labextension list 1>labextensions 2>&1
         cat labextensions | grep "jupyterlab-interactive-dashboard-editor.*OK"
 
         python -m jupyterlab.browser_check
+


### PR DESCRIPTION
## What's new

## Fixed

Attempt at fixing CI, by installing the extension with `pip` now that it has been updated to work with JupyterLab 3.0.

## Todo/issues

## Notes
