### PR TITLE
Design and resizer improvements

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -5,6 +5,7 @@ import greyDashboardSvgstr from '../style/icons/dashboard_icon_filled_grey.svg';
 import blueDashboardSvgstr from '../style/icons/dashboard_icon_filled_blue.svg';
 import whiteDashboardOutlineSvgstr from '../style/icons/dashboard_icon_outline_white.svg';
 import greyDashboardOutlineSvgstr from '../style/icons/dashboard_icon_outline_grey.svg';
+import tealDashboardSvgstr from '../style/icons/dashboard_icon_filled_teal.svg';
 import redoIcon from '../style/icons/redo.svg';
 import fullscreenIcon from '../style/icons/fullscreen.svg';
 import statusIcon from '../style/icons/dummy.svg';
@@ -17,6 +18,11 @@ import resizer2Svgstr from '../style/icons/drag indicator lines.svg';
  * Dashboard icons
  */
 export namespace DashboardIcons {
+  export const tealDashboard = new LabIcon({
+    name: 'pr-icons:teal-dashboard',
+    svgstr: tealDashboardSvgstr
+  });
+
   export const whiteDashboard = new LabIcon({
     name: 'pr-icons:white-dashboard',
     svgstr: whiteDashboardSvgstr

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ const extension: JupyterFrontEndPlugin<IDashboardTracker> = {
       contentType: 'file',
       extensions: ['.dashboard', '.dash'],
       fileFormat: 'text',
-      icon: DashboardIcons.blueDashboard,
+      icon: DashboardIcons.tealDashboard,
       iconLabel: 'Dashboard',
       mimeTypes: ['application/json']
     };
@@ -550,7 +550,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.createNew, {
     label: 'Dashboard',
-    icon: DashboardIcons.blueDashboard,
+    icon: DashboardIcons.tealDashboard,
     execute: async args => {
       // A new file is created and opened separately to override the default
       // opening behavior when there's a notebook and open the dashboard in a

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -508,7 +508,7 @@ export class DashboardLayout extends Layout {
    */
   updateLayoutFromWidgetstore(): void {
     this._signalChanges = false;
-    const records = this._widgetstore.getWidgets();
+    const records = this._widgetstore.get(Widgetstore.WIDGET_SCHEMA);
     each(records, record => {
       this._updateLayoutFromRecord(record);
     });
@@ -869,10 +869,10 @@ export class DashboardLayout extends Layout {
    */
   setTileSize(s: number): void {
     this._tileSize = s;
-    const backgroundPosition = `0 0, 0 ${s}px, ${s}px -${s}px, -${s}px 0px`;
+    // const backgroundPosition = `0 0, 0 ${s}px, ${s}px -${s}px, -${s}px 0px`;
 
-    this.canvas.style.backgroundPosition = backgroundPosition;
-    this.canvas.style.backgroundSize = `${2 * s}px ${2 * s}px`;
+    // this.canvas.style.backgroundPosition = backgroundPosition;
+    this.canvas.style.backgroundSize = `${s}px ${s}px`;
     this.parent.update();
 
     this.startBatch();

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -23,8 +23,6 @@ import {
 
 import { Signal, ISignal } from '@lumino/signaling';
 
-import { DashboardIcons } from './icons';
-
 import { Widgetstore, WidgetPosition } from './widgetstore';
 
 import { DashboardLayout } from './layout';
@@ -152,8 +150,14 @@ export class DashboardWidget extends Widget {
       });
     }
 
-    const resizer = DashboardWidget.createResizer();
-    this.node.appendChild(resizer);
+    const resizerTopLeft = DashboardWidget.createResizer('top-left');
+    const resizerTopRight = DashboardWidget.createResizer('top-right');
+    const resizerBottomLeft = DashboardWidget.createResizer('bottom-left');
+    const resizerBottomRight = DashboardWidget.createResizer('bottom-right');
+    this.node.appendChild(resizerTopLeft);
+    this.node.appendChild(resizerTopRight);
+    this.node.appendChild(resizerBottomLeft);
+    this.node.appendChild(resizerBottomRight);
 
     this.addClass(DASHBOARD_WIDGET_CLASS);
     this.addClass(EDITABLE_WIDGET_CLASS);
@@ -294,9 +298,19 @@ export class DashboardWidget extends Widget {
 
     // this.node.style.opacity = '0.6';
 
+    const elem = target as HTMLElement;
     // Set mode to resize if the mousedown happened on a resizer.
-    if ((target as HTMLElement).classList.contains('pr-Resizer')) {
+    if (elem.classList.contains('pr-Resizer')) {
       this._mouseMode = 'resize';
+      if (elem.classList.contains('pr-ResizerTopRight')) {
+        this._selectedResizer = 'top-right';
+      } else if (elem.classList.contains('pr-ResizerTopLeft')) {
+        this._selectedResizer = 'top-left';
+      } else if (elem.classList.contains('pr-ResizerBottomLeft')) {
+        this._selectedResizer = 'bottom-left';
+      } else {
+        this._selectedResizer = 'bottom-right';
+      }
     } else {
       this._mouseMode = 'drag';
     }
@@ -305,12 +319,16 @@ export class DashboardWidget extends Widget {
 
     const rect = this.node.getBoundingClientRect();
 
+    const { width, height, top, left } = this.pos;
+
     this._clickData = {
       pressX: event.clientX,
       pressY: event.clientY,
       cell,
-      pressWidth: parseInt(this.node.style.width, 10),
-      pressHeight: parseInt(this.node.style.height, 10),
+      origWidth: width,
+      origHeight: height,
+      origLeft: left,
+      origTop: top,
       target: this.node.cloneNode(true) as HTMLElement,
       widgetX: rect.left,
       widgetY: rect.top
@@ -352,16 +370,44 @@ export class DashboardWidget extends Widget {
    * Handle `mousemove` events when the widget mouseMode is `resize`.
    */
   private _resizeMouseMove(event: MouseEvent): void {
-    const { pressX, pressY, pressWidth, pressHeight } = this._clickData;
+    const {
+      pressX,
+      pressY,
+      origWidth,
+      origHeight,
+      origLeft,
+      origTop
+    } = this._clickData;
 
     const deltaX = event.clientX - pressX;
     const deltaY = event.clientY - pressY;
 
-    const width = Math.max(pressWidth + deltaX, DashboardWidget.MIN_WIDTH);
-    const height = Math.max(pressHeight + deltaY, DashboardWidget.MIN_HEIGHT);
+    let { width, height, top, left } = this.pos;
 
-    this.node.style.width = `${width}px`;
-    this.node.style.height = `${height}px`;
+    switch (this._selectedResizer) {
+      case 'bottom-right':
+        width = Math.max(origWidth + deltaX, DashboardWidget.MIN_WIDTH);
+        height = Math.max(origHeight + deltaY, DashboardWidget.MIN_HEIGHT);
+        break;
+      case 'bottom-left':
+        width = Math.max(origWidth - deltaX, DashboardWidget.MIN_WIDTH);
+        height = Math.max(origHeight + deltaY, DashboardWidget.MIN_HEIGHT);
+        left = origLeft + deltaX;
+        break;
+      case 'top-right':
+        width = Math.max(origWidth + deltaX, DashboardWidget.MIN_WIDTH);
+        height = Math.max(origHeight - deltaY, DashboardWidget.MIN_HEIGHT);
+        top = origTop + deltaY;
+        break;
+      case 'top-left':
+        width = Math.max(origWidth - deltaX, DashboardWidget.MIN_WIDTH);
+        height = Math.max(origHeight - deltaY, DashboardWidget.MIN_HEIGHT);
+        top = origTop + deltaY;
+        left = origLeft + deltaX;
+        break;
+    }
+
+    this.pos = { width, height, top, left };
 
     if (this.mode === 'grid-edit') {
       (this.parent.layout as DashboardLayout).drawDropZone(this.pos, '#2b98f0');
@@ -377,8 +423,12 @@ export class DashboardWidget extends Widget {
   fitContent(): void {
     const element = this._content.node;
     // Pixels are added to prevent weird wrapping issues. Kind of a hack.
-    this.node.style.width = `${element.clientWidth + 3}px`;
-    this.node.style.height = `${element.clientHeight + 2}px`;
+    this.pos = {
+      width: element.clientWidth + 3,
+      height: element.clientHeight + 2,
+      left: undefined,
+      top: undefined
+    };
   }
 
   /**
@@ -642,8 +692,10 @@ export class DashboardWidget extends Widget {
   private _clickData: {
     pressX: number;
     pressY: number;
-    pressWidth: number;
-    pressHeight: number;
+    origWidth: number;
+    origHeight: number;
+    origLeft: number;
+    origTop: number;
     target: HTMLElement;
     cell: CodeCell | MarkdownCell;
     widgetX: number;
@@ -651,6 +703,7 @@ export class DashboardWidget extends Widget {
   } | null = null;
   private _locked = false;
   private _content: Widget;
+  private _selectedResizer: DashboardWidget.ResizerCorner;
 }
 
 /**
@@ -711,17 +764,38 @@ export namespace DashboardWidget {
   }
 
   /**
+   * A type for describing the corner for a widget resizer.
+   */
+  export type ResizerCorner =
+    | 'top-left'
+    | 'bottom-left'
+    | 'top-right'
+    | 'bottom-right';
+
+  /**
    * Create a resizer element for a dashboard widget.
    */
-  export function createResizer(): HTMLElement {
+  export function createResizer(corner: ResizerCorner): HTMLElement {
     const resizer = document.createElement('div');
     resizer.classList.add('pr-Resizer');
-    DashboardIcons.resizer2.element({
-      container: resizer,
-      width: '15px',
-      height: '15px',
-      pointerEvents: 'none'
-    });
+
+    switch (corner) {
+      case 'top-left':
+        resizer.classList.add('pr-ResizerTopLeft');
+        break;
+      case 'top-right':
+        resizer.classList.add('pr-ResizerTopRight');
+        break;
+      case 'bottom-left':
+        resizer.classList.add('pr-ResizerBottomLeft');
+        break;
+      case 'bottom-right':
+        resizer.classList.add('pr-ResizerBottomRight');
+        break;
+      default:
+        resizer.classList.add('pr-ResizerBottomRight');
+        break;
+    }
 
     return resizer;
   }

--- a/style/base.css
+++ b/style/base.css
@@ -4,8 +4,6 @@
 
 .pr-DashboardWidget {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .pr-DashboardWidget .pr-MarkdownOutput {
@@ -14,7 +12,7 @@
 
 .pr-EditableWidget {
   outline: var(--jp-border-width) solid var(--jp-inverse-layout-color4);
-  outline-offset: calc( -1 * var(--jp-border-width));
+  outline-offset: calc(-1 * var(--jp-border-width));
   background: var(--jp-layout-color0);
   overflow: visible;
 }
@@ -25,12 +23,12 @@
 
 .pr-EditableWidget:focus {
   outline: var(--jp-border-width) solid var(--jp-brand-color1);
-  outline-offset: calc( -1 * var(--jp-border-width));
+  outline-offset: calc(-1 * var(--jp-border-width));
 }
 
 .pr-EditableWidget:hover {
   outline: var(--jp-border-width) solid var(--jp-brand-color1);
-  outline-offset: calc( -1 * var(--jp-border-width));
+  outline-offset: calc(-1 * var(--jp-border-width));
   cursor: move;
 }
 
@@ -77,7 +75,12 @@
 }
 
 .pr-DashboardWidgetChild {
-  display: inline-block;
+  /* width: 100%;
+  height: 100%; */
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .pr-EditableWidget:focus .pr-Resizer {
@@ -89,18 +92,24 @@
 }
 
 .pr-Canvas.pr-FreeLayout {
-  background-image:
-    linear-gradient(to right, #E5E5E5 1px, transparent 1px),
-    linear-gradient(to bottom, #E5E5E5 1px, transparent 1px);
-  background-color: white;
+  background-image: linear-gradient(
+      to right,
+      var(--jp-border-color2) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, var(--jp-border-color2) 1px, transparent 1px);
+  background-color: var(--jp-cell-editor-background);
   background-size: 10px 10px;
 }
 
 .pr-Canvas.pr-TiledLayout {
-  background-image:
-    linear-gradient(to right, #E5E5E5 1px, transparent 1px),
-    linear-gradient(to bottom, #E5E5E5 1px, transparent 1px);
-  background-color: white;
+  background-image: linear-gradient(
+      to right,
+      var(--jp-border-color2) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, var(--jp-border-color2) 1px, transparent 1px);
+  background-color: var(--jp-cell-editor-background);
   background-size: 32px 32px;
 }
 
@@ -144,5 +153,5 @@ select.pr-ToolbarSelector.jp-mod-styled {
 .pr-DragImage {
   box-shadow: var(--jp-elevation-z1);
   outline: var(--jp-border-width) solid var(--jp-brand-color1);
-  outline-offset: calc( -1 * var(--jp-border-width));
+  outline-offset: calc(-1 * var(--jp-border-width));
 }

--- a/style/base.css
+++ b/style/base.css
@@ -13,8 +13,10 @@
 }
 
 .pr-EditableWidget {
-  border: var(--jp-border-width) solid var(--jp-inverse-layout-color4);
+  outline: var(--jp-border-width) solid var(--jp-inverse-layout-color4);
+  outline-offset: calc( -1 * var(--jp-border-width));
   background: var(--jp-layout-color0);
+  overflow: visible;
 }
 
 .pr-EditableWidget > .pr-DashboardWidgetChild {
@@ -22,30 +24,14 @@
 }
 
 .pr-EditableWidget:focus {
-  border: var(--jp-border-width) solid var(--jp-brand-color1);
-}
-
-.pr-EditableWidget:focus:after {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 2;
-  background: rgba(0, 0, 0, 0.1);
+  outline: var(--jp-border-width) solid var(--jp-brand-color1);
+  outline-offset: calc( -1 * var(--jp-border-width));
 }
 
 .pr-EditableWidget:hover {
-  border: var(--jp-border-width) solid var(--jp-brand-color1);
+  outline: var(--jp-border-width) solid var(--jp-brand-color1);
+  outline-offset: calc( -1 * var(--jp-border-width));
   cursor: move;
-}
-
-.pr-EditableWidget:hover:after {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 2;
-  background: rgba(0, 0, 0, 0.1);
 }
 
 .pr-DashboardArea {
@@ -54,20 +40,47 @@
 
 .pr-Resizer {
   display: none;
-  width: 15px;
-  height: 15px;
-  right: 0;
-  bottom: 0;
+  width: 8px;
+  height: 8px;
+  outline: 2px solid var(--jp-brand-color1);
   z-index: 3;
-  cursor: nwse-resize;
+  background-color: var(--jp-layout-color0);
   position: absolute;
+}
+
+.pr-Resizer:hover {
+  background-color: var(--jp-brand-color1);
+}
+
+.pr-ResizerBottomRight {
+  right: -4px;
+  bottom: -4px;
+  cursor: nwse-resize;
+}
+
+.pr-ResizerBottomLeft {
+  left: -4px;
+  bottom: -4px;
+  cursor: nesw-resize;
+}
+
+.pr-ResizerTopRight {
+  right: -4px;
+  top: -4px;
+  cursor: nesw-resize;
+}
+
+.pr-ResizerTopLeft {
+  left: -4px;
+  top: -4px;
+  cursor: nwse-resize;
 }
 
 .pr-DashboardWidgetChild {
   display: inline-block;
 }
 
-.pr-EditableWidget:hover .pr-Resizer {
+.pr-EditableWidget:focus .pr-Resizer {
   display: block;
 }
 
@@ -76,29 +89,19 @@
 }
 
 .pr-Canvas.pr-FreeLayout {
-  background-image: linear-gradient(
-      45deg,
-      rgba(160, 160, 160, 0.15) 25%,
-      transparent 25%
-    ),
-    linear-gradient(-45deg, rgba(160, 160, 160, 0.15) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, rgba(160, 160, 160, 0.15) 75%),
-    linear-gradient(-45deg, transparent 75%, rgba(160, 160, 160, 0.15) 70%);
-  background-size: 20px 20px;
-  background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+  background-image:
+    linear-gradient(to right, #E5E5E5 1px, transparent 1px),
+    linear-gradient(to bottom, #E5E5E5 1px, transparent 1px);
+  background-color: white;
+  background-size: 10px 10px;
 }
 
 .pr-Canvas.pr-TiledLayout {
-  background-image: linear-gradient(
-      45deg,
-      rgba(160, 160, 160, 0.15) 25%,
-      transparent 25%
-    ),
-    linear-gradient(-45deg, rgba(160, 160, 160, 0.15) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, rgba(160, 160, 160, 0.15) 75%),
-    linear-gradient(-45deg, transparent 75%, rgba(160, 160, 160, 0.15) 70%);
-  background-size: 64px 64px;
-  background-position: 0 0, 0 32px, 32px -32px, -32px 0px;
+  background-image:
+    linear-gradient(to right, #E5E5E5 1px, transparent 1px),
+    linear-gradient(to bottom, #E5E5E5 1px, transparent 1px);
+  background-color: white;
+  background-size: 32px 32px;
 }
 
 .pr-OnboardingGif {
@@ -140,5 +143,6 @@ select.pr-ToolbarSelector.jp-mod-styled {
 
 .pr-DragImage {
   box-shadow: var(--jp-elevation-z1);
-  border: var(--jp-border-width) solid var(--jp-brand-color1);
+  outline: var(--jp-border-width) solid var(--jp-brand-color1);
+  outline-offset: calc( -1 * var(--jp-border-width));
 }


### PR DESCRIPTION
## What's new
- Added resize handles to all four corners of dashboard widgets. #107 
- Added new teal dashboard icon #114
- Changed dashboard canvas in edit mode to a grid. #97 
- Other dashboard widget styling improvements.

![resizers2](https://user-images.githubusercontent.com/38936057/106843232-660ab680-665a-11eb-9d5c-48691ef7b1f3.gif)

## Fixed
- Bug causing undo/redo to be unable to remove added widgets.
- Bug causing  certain outputs to overflow the dashboard widget box (ex: `%matplotlib widget` plots). Note: only partially fixed, overflow still occurs in certain cases like very constrained text.
- Fixed bug causing issues displaying LaTeX formatted text #98 (markdown display is still broken, but $ $ format now works in things like ipywidgets)

## Todo/issues
- Update README.md with new look.

