### PR TITLE
[DRAFT] .ipynb model

### DIFF
--- a/share/jupyter/nbconvert/templates/presto/base.html.j2
+++ b/share/jupyter/nbconvert/templates/presto/base.html.j2
@@ -1,0 +1,270 @@
+{%- extends 'display_priority.j2' -%}
+{% from 'celltags.j2' import celltags %}
+
+{% block codecell %}
+{%- if not cell.outputs -%}
+{%- set no_output_class="jp-mod-noOutputs" -%}
+{%- endif -%}
+{%- if not resources.global_content_filter.include_input -%}
+{%- set no_input_class="jp-mod-noInput" -%}
+{%- endif -%}
+<div class="jp-Cell jp-CodeCell jp-Notebook-cell {{ no_output_class }} {{ no_input_class }} {{ celltags(cell) }}">
+{{ super() }}
+</div>
+{%- endblock codecell %}
+
+{% block input_group -%}
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+{{ super() }}
+</div>
+</div>
+{% endblock input_group %}
+
+{% block input %}
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+{{ cell.source | highlight_code(metadata=cell.metadata) }}
+     </div>
+</div>
+{%- endblock input %}
+
+{% block output_group %}
+<div class="jp-Cell-outputWrapper">
+{{ super() }}
+</div>
+{% endblock output_group %}
+
+{% block outputs %}
+<div class="jp-OutputArea jp-Cell-outputArea">
+{{ super() }}
+</div>
+{% endblock outputs %}
+
+{% block in_prompt -%}
+<div class="jp-InputPrompt jp-InputArea-prompt">
+    {%- if cell.execution_count is defined -%}
+        In&nbsp;[{{ cell.execution_count|replace(None, "&nbsp;") }}]:
+    {%- else -%}
+        In&nbsp;[&nbsp;]:
+    {%- endif -%}
+</div>
+{%- endblock in_prompt %}
+
+{% block empty_in_prompt -%}
+<div class="jp-InputPrompt jp-InputArea-prompt">
+</div>
+{%- endblock empty_in_prompt %}
+
+{#
+  output_prompt doesn't do anything in HTML,
+  because there is a prompt div in each output area (see output block)
+ #}
+{% block output_prompt %}
+{% endblock output_prompt %}
+
+{% block output_area_prompt %}
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">
+{%- if output.output_type == 'execute_result' -%}
+    {%- if cell.execution_count is defined -%}
+        Out[{{ cell.execution_count|replace(None, "&nbsp;") }}]:
+    {%- else -%}
+        Out[&nbsp;]:
+    {%- endif -%}
+{%- endif -%}
+    </div>
+{% endblock output_area_prompt %}
+
+{% block output %}
+<div class="jp-OutputArea-child">
+{% if resources.global_content_filter.include_output_prompt %}
+    {{ self.output_area_prompt() }}
+{% endif %}
+{{ super() }}
+</div>
+{% endblock output %}
+
+{% block markdowncell scoped %}
+<div class="jp-Cell-inputWrapper">
+{%- if resources.global_content_filter.include_input_prompt-%}
+    {{ self.empty_in_prompt() }}
+{%- endif -%}
+<div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput {{ celltags(cell) }}" data-mime-type="text/markdown">
+{{ cell.source  | markdown2html | strip_files_prefix }}
+</div>
+</div>
+{%- endblock markdowncell %}
+
+{% block unknowncell scoped %}
+unknown type  {{ cell.type }}
+{% endblock unknowncell %}
+
+{% block execute_result -%}
+{%- set extra_class="jp-OutputArea-executeResult" -%}
+{% block data_priority scoped %}
+{{ super() }}
+{% endblock data_priority %}
+{%- set extra_class="" -%}
+{%- endblock execute_result %}
+
+{% block stream_stdout -%}
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>
+{{- output.text | ansi2html -}}
+</pre>
+</div>
+{%- endblock stream_stdout %}
+
+{% block stream_stderr -%}
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>
+{{- output.text | ansi2html -}}
+</pre>
+</div>
+{%- endblock stream_stderr %}
+
+{% block data_svg scoped -%}
+<div class="jp-RenderedSVG jp-OutputArea-output {{ extra_class }}" data-mime-type="image/svg+xml">
+{%- if output.svg_filename %}
+<img src="{{ output.svg_filename | posix_path }}">
+{%- else %}
+{{ output.data['image/svg+xml'] }}
+{%- endif %}
+</div>
+{%- endblock data_svg %}
+
+{% block data_html scoped -%}
+<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output {{ extra_class }}" data-mime-type="text/html">
+{{ output.data['text/html'] }}
+</div>
+{%- endblock data_html %}
+
+{% block data_markdown scoped -%}
+<div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-OutputArea-output {{ extra_class }}" data-mime-type="text/markdown">
+{{ output.data['text/markdown'] | markdown2html }}
+</div>
+{%- endblock data_markdown %}
+
+{% block data_png scoped %}
+<div class="jp-RenderedImage jp-OutputArea-output {{ extra_class }}">
+{%- if 'image/png' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/png'] | posix_path }}"
+{%- else %}
+<img src="data:image/png;base64,{{ output.data['image/png'] }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/png') -%}
+{%- if width is not none %}
+width={{ width }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/png') -%}
+{%- if height is not none %}
+height={{ height }}
+{%- endif %}
+{%- if output | get_metadata('unconfined', 'image/png') %}
+class="unconfined"
+{%- endif %}
+>
+</div>
+{%- endblock data_png %}
+
+{% block data_jpg scoped %}
+<div class="jp-RenderedImage jp-OutputArea-output {{ extra_class }}">
+{%- if 'image/jpeg' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/jpeg'] | posix_path }}"
+{%- else %}
+<img src="data:image/jpeg;base64,{{ output.data['image/jpeg'] }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/jpeg') -%}
+{%- if width is not none %}
+width={{ width }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/jpeg') -%}
+{%- if height is not none %}
+height={{ height }}
+{%- endif %}
+{%- if output | get_metadata('unconfined', 'image/jpeg') %}
+class="unconfined"
+{%- endif %}
+>
+</div>
+{%- endblock data_jpg %}
+
+{% block data_latex scoped %}
+<div class="jp-RenderedLatex jp-OutputArea-output {{ extra_class }}" data-mime-type="text/latex">
+{{ output.data['text/latex'] | e }}
+</div>
+{%- endblock data_latex %}
+
+{% block error -%}
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>
+{{- super() -}}
+</pre>
+</div>
+{%- endblock error %}
+
+{%- block traceback_line %}
+{{ line | ansi2html }}
+{%- endblock traceback_line %}
+
+{%- block data_text scoped %}
+<div class="jp-RenderedText jp-OutputArea-output {{ extra_class }}" data-mime-type="text/plain">
+<pre>
+{{- output.data['text/plain'] | ansi2html -}}
+</pre>
+</div>
+{%- endblock -%}
+
+{#
+ ###############################################################################
+ # TODO: how to better handle JavaScript repr?                                 #
+ ###############################################################################
+ #}
+
+{% set div_id = uuid4() %}
+{%- block data_javascript scoped %}
+<div id="{{ div_id }}" class="jp-RenderedJavaScript jp-OutputArea-output {{ extra_class }}" data-mime-type="application/javascript">
+<script type="text/javascript">
+var element = document.getElementById('{{ div_id }}');
+{{ output.data['application/javascript'] }}
+</script>
+</div>
+{%- endblock -%}
+
+{%- block data_widget_state scoped %}
+{% set div_id = uuid4() %}
+{% set datatype_list = output.data | filter_data_type %}
+{% set datatype = datatype_list[0]%}
+<div id="{{ div_id }}" class="output_subarea output_widget_state {{ extra_class }}">
+<script type="text/javascript">
+var element = document.getElementById('{{ div_id }}');
+</script>
+<script type="{{ datatype }}">
+{{ output.data[datatype] | json_dumps }}
+</script>
+</div>
+{%- endblock data_widget_state -%}
+
+{%- block data_widget_view scoped %}
+{% set div_id = uuid4() %}
+{% set datatype_list = output.data | filter_data_type %}
+{% set datatype = datatype_list[0]%}
+<div id="{{ div_id }}" class="jupyter-widgets jp-OutputArea-output {{ extra_class }}">
+<script type="text/javascript">
+var element = document.getElementById('{{ div_id }}');
+</script>
+<script type="{{ datatype }}">
+{{ output.data[datatype] | json_dumps }}
+</script>
+</div>
+{%- endblock data_widget_view -%}
+
+{%- block footer %}
+{% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
+{% if mimetype in nb.metadata.get("widgets",{})%}
+<script type="{{ mimetype }}">
+{{ nb.metadata.widgets[mimetype] | json_dumps }}
+</script>
+{% endif %}
+{{ super() }}
+{%- endblock footer-%}

--- a/share/jupyter/nbconvert/templates/presto/conf.json
+++ b/share/jupyter/nbconvert/templates/presto/conf.json
@@ -1,0 +1,12 @@
+{
+    "base_template": "base",
+    "mimetypes": {
+        "text/html": true
+    },
+    "preprocessors": {
+        "100-pygments": {
+            "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
+            "enabled": true
+        }
+    }
+}

--- a/share/jupyter/nbconvert/templates/presto/conf.json
+++ b/share/jupyter/nbconvert/templates/presto/conf.json
@@ -1,12 +1,12 @@
 {
-    "base_template": "base",
-    "mimetypes": {
-        "text/html": true
-    },
-    "preprocessors": {
-        "100-pygments": {
-            "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
-            "enabled": true
-        }
+  "base_template": "base",
+  "mimetypes": {
+    "text/html": true
+  },
+  "preprocessors": {
+    "100-pygments": {
+      "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
+      "enabled": true
     }
+  }
 }

--- a/share/jupyter/nbconvert/templates/presto/index.html.j2
+++ b/share/jupyter/nbconvert/templates/presto/index.html.j2
@@ -1,0 +1,96 @@
+{%- extends 'base.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+{%- block header -%}
+<!DOCTYPE html>
+<html>
+<head>
+{%- block html_head -%}
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
+<title>{{nb_title}}</title>
+
+{%- block html_head_js -%}
+{%- block html_head_js_requirejs -%}
+<script src="{{ resources.require_js_url }}"></script>
+{%- endblock html_head_js_requirejs -%}
+{%- endblock html_head_js -%}
+
+{% block jupyter_widgets %}
+  {%- if "widgets" in nb.metadata -%}
+    {{ jupyter_widgets(resources.jupyter_widgets_base_url, resources.html_manager_semver_range) }}
+  {%- endif -%}
+{% endblock jupyter_widgets %}
+
+{% block extra_css %}
+{% endblock extra_css %}
+
+{% for css in resources.inlining.css -%}
+  <style type="text/css">
+    {{ css }}
+  </style>
+{% endfor %}
+
+{% block notebook_css %}
+{{ resources.include_css("static/index.css") }}
+{% if resources.theme == 'dark' %}
+    {{ resources.include_css("static/theme-dark.css") }}
+{% else %}
+    {{ resources.include_css("static/theme-light.css") }}
+{% endif %}
+<style type="text/css">
+a.anchor-link {
+   display: none;
+}
+.highlight  {
+    margin: 0.4em;
+}
+
+/* Input area styling */
+.jp-InputArea {
+    overflow: hidden;
+}
+
+.jp-InputArea-editor {
+    overflow: hidden;
+}
+
+@media print {
+  body {
+    margin: 0;
+  }
+}
+</style>
+
+{% endblock notebook_css %}
+
+{{ mathjax() }}
+
+{%- block html_head_css -%}
+{%- endblock html_head_css -%}
+
+{%- endblock html_head -%}
+</head>
+{%- endblock header -%}
+
+{%- block body_header -%}
+{% if resources.theme == 'dark' %}
+<body class="jp-Notebook" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark">
+{% else %}
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+{% endif %}
+{%- endblock body_header -%}
+
+{% block body_footer %}
+</body>
+{% endblock body_footer %}
+
+{% block footer %}
+{% block footer_js %}
+{% endblock footer_js %}
+{{ super() }}
+</html>
+{% endblock footer %}
+

--- a/share/jupyter/nbconvert/templates/presto/static/index.css
+++ b/share/jupyter/nbconvert/templates/presto/static/index.css
@@ -1,0 +1,13736 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*
+ * Mozilla scrollbar styling
+ */
+
+/* use standard opaque scrollbars for most nodes */
+[data-jp-theme-scrollbars='true'] {
+  scrollbar-color: rgb(var(--jp-scrollbar-thumb-color))
+    var(--jp-scrollbar-background-color);
+}
+
+/* for code nodes, use a transparent style of scrollbar. These selectors
+ * will match lower in the tree, and so will override the above */
+[data-jp-theme-scrollbars='true'] .CodeMirror-hscrollbar,
+[data-jp-theme-scrollbars='true'] .CodeMirror-vscrollbar {
+  scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;
+}
+
+/*
+ * Webkit scrollbar styling
+ */
+
+/* use standard opaque scrollbars for most nodes */
+
+[data-jp-theme-scrollbars='true'] ::-webkit-scrollbar,
+[data-jp-theme-scrollbars='true'] ::-webkit-scrollbar-corner {
+  background: var(--jp-scrollbar-background-color);
+}
+
+[data-jp-theme-scrollbars='true'] ::-webkit-scrollbar-thumb {
+  background: rgb(var(--jp-scrollbar-thumb-color));
+  border: var(--jp-scrollbar-thumb-margin) solid transparent;
+  background-clip: content-box;
+  border-radius: var(--jp-scrollbar-thumb-radius);
+}
+
+[data-jp-theme-scrollbars='true'] ::-webkit-scrollbar-track:horizontal {
+  border-left: var(--jp-scrollbar-endpad) solid
+    var(--jp-scrollbar-background-color);
+  border-right: var(--jp-scrollbar-endpad) solid
+    var(--jp-scrollbar-background-color);
+}
+
+[data-jp-theme-scrollbars='true'] ::-webkit-scrollbar-track:vertical {
+  border-top: var(--jp-scrollbar-endpad) solid
+    var(--jp-scrollbar-background-color);
+  border-bottom: var(--jp-scrollbar-endpad) solid
+    var(--jp-scrollbar-background-color);
+}
+
+/* for code nodes, use a transparent style of scrollbar */
+
+[data-jp-theme-scrollbars='true'] .CodeMirror-hscrollbar::-webkit-scrollbar,
+[data-jp-theme-scrollbars='true'] .CodeMirror-vscrollbar::-webkit-scrollbar,
+[data-jp-theme-scrollbars='true']
+  .CodeMirror-hscrollbar::-webkit-scrollbar-corner,
+[data-jp-theme-scrollbars='true']
+  .CodeMirror-vscrollbar::-webkit-scrollbar-corner {
+  background-color: transparent;
+}
+
+[data-jp-theme-scrollbars='true']
+  .CodeMirror-hscrollbar::-webkit-scrollbar-thumb,
+[data-jp-theme-scrollbars='true']
+  .CodeMirror-vscrollbar::-webkit-scrollbar-thumb {
+  background: rgba(var(--jp-scrollbar-thumb-color), 0.5);
+  border: var(--jp-scrollbar-thumb-margin) solid transparent;
+  background-clip: content-box;
+  border-radius: var(--jp-scrollbar-thumb-radius);
+}
+
+[data-jp-theme-scrollbars='true']
+  .CodeMirror-hscrollbar::-webkit-scrollbar-track:horizontal {
+  border-left: var(--jp-scrollbar-endpad) solid transparent;
+  border-right: var(--jp-scrollbar-endpad) solid transparent;
+}
+
+[data-jp-theme-scrollbars='true']
+  .CodeMirror-vscrollbar::-webkit-scrollbar-track:vertical {
+  border-top: var(--jp-scrollbar-endpad) solid transparent;
+  border-bottom: var(--jp-scrollbar-endpad) solid transparent;
+}
+
+/*
+ * Phosphor
+ */
+
+.lm-ScrollBar[data-orientation='horizontal'] {
+  min-height: 16px;
+  max-height: 16px;
+  min-width: 45px;
+  border-top: 1px solid #a0a0a0;
+}
+
+.lm-ScrollBar[data-orientation='vertical'] {
+  min-width: 16px;
+  max-width: 16px;
+  min-height: 45px;
+  border-left: 1px solid #a0a0a0;
+}
+
+.lm-ScrollBar-button {
+  background-color: #f0f0f0;
+  background-position: center center;
+  min-height: 15px;
+  max-height: 15px;
+  min-width: 15px;
+  max-width: 15px;
+}
+
+.lm-ScrollBar-button:hover {
+  background-color: #dadada;
+}
+
+.lm-ScrollBar-button.lm-mod-active {
+  background-color: #cdcdcd;
+}
+
+.lm-ScrollBar-track {
+  background: #f0f0f0;
+}
+
+.lm-ScrollBar-thumb {
+  background: #cdcdcd;
+}
+
+.lm-ScrollBar-thumb:hover {
+  background: #bababa;
+}
+
+.lm-ScrollBar-thumb.lm-mod-active {
+  background: #a0a0a0;
+}
+
+.lm-ScrollBar[data-orientation='horizontal'] .lm-ScrollBar-thumb {
+  height: 100%;
+  min-width: 15px;
+  border-left: 1px solid #a0a0a0;
+  border-right: 1px solid #a0a0a0;
+}
+
+.lm-ScrollBar[data-orientation='vertical'] .lm-ScrollBar-thumb {
+  width: 100%;
+  min-height: 15px;
+  border-top: 1px solid #a0a0a0;
+  border-bottom: 1px solid #a0a0a0;
+}
+
+.lm-ScrollBar[data-orientation='horizontal']
+  .lm-ScrollBar-button[data-action='decrement'] {
+  background-image: var(--jp-icon-caret-left);
+  background-size: 17px;
+}
+
+.lm-ScrollBar[data-orientation='horizontal']
+  .lm-ScrollBar-button[data-action='increment'] {
+  background-image: var(--jp-icon-caret-right);
+  background-size: 17px;
+}
+
+.lm-ScrollBar[data-orientation='vertical']
+  .lm-ScrollBar-button[data-action='decrement'] {
+  background-image: var(--jp-icon-caret-up);
+  background-size: 17px;
+}
+
+.lm-ScrollBar[data-orientation='vertical']
+  .lm-ScrollBar-button[data-action='increment'] {
+  background-image: var(--jp-icon-caret-down);
+  background-size: 17px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-Widget, /* </DEPRECATED> */
+.lm-Widget {
+  box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+}
+
+
+/* <DEPRECATED> */ .p-Widget.p-mod-hidden, /* </DEPRECATED> */
+.lm-Widget.lm-mod-hidden {
+  display: none !important;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-CommandPalette, /* </DEPRECATED> */
+.lm-CommandPalette {
+  display: flex;
+  flex-direction: column;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-search, /* </DEPRECATED> */
+.lm-CommandPalette-search {
+  flex: 0 0 auto;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-content, /* </DEPRECATED> */
+.lm-CommandPalette-content {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 0;
+  min-height: 0;
+  overflow: auto;
+  list-style-type: none;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-header, /* </DEPRECATED> */
+.lm-CommandPalette-header {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-item, /* </DEPRECATED> */
+.lm-CommandPalette-item {
+  display: flex;
+  flex-direction: row;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-itemIcon, /* </DEPRECATED> */
+.lm-CommandPalette-itemIcon {
+  flex: 0 0 auto;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-itemContent, /* </DEPRECATED> */
+.lm-CommandPalette-itemContent {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-itemShortcut, /* </DEPRECATED> */
+.lm-CommandPalette-itemShortcut {
+  flex: 0 0 auto;
+}
+
+
+/* <DEPRECATED> */ .p-CommandPalette-itemLabel, /* </DEPRECATED> */
+.lm-CommandPalette-itemLabel {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-DockPanel, /* </DEPRECATED> */
+.lm-DockPanel {
+  z-index: 0;
+}
+
+
+/* <DEPRECATED> */ .p-DockPanel-widget, /* </DEPRECATED> */
+.lm-DockPanel-widget {
+  z-index: 0;
+}
+
+
+/* <DEPRECATED> */ .p-DockPanel-tabBar, /* </DEPRECATED> */
+.lm-DockPanel-tabBar {
+  z-index: 1;
+}
+
+
+/* <DEPRECATED> */ .p-DockPanel-handle, /* </DEPRECATED> */
+.lm-DockPanel-handle {
+  z-index: 2;
+}
+
+
+/* <DEPRECATED> */ .p-DockPanel-handle.p-mod-hidden, /* </DEPRECATED> */
+.lm-DockPanel-handle.lm-mod-hidden {
+  display: none !important;
+}
+
+
+/* <DEPRECATED> */ .p-DockPanel-handle:after, /* </DEPRECATED> */
+.lm-DockPanel-handle:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  content: '';
+}
+
+
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='horizontal'],
+/* </DEPRECATED> */
+.lm-DockPanel-handle[data-orientation='horizontal'] {
+  cursor: ew-resize;
+}
+
+
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='vertical'],
+/* </DEPRECATED> */
+.lm-DockPanel-handle[data-orientation='vertical'] {
+  cursor: ns-resize;
+}
+
+
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='horizontal']:after,
+/* </DEPRECATED> */
+.lm-DockPanel-handle[data-orientation='horizontal']:after {
+  left: 50%;
+  min-width: 8px;
+  transform: translateX(-50%);
+}
+
+
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='vertical']:after,
+/* </DEPRECATED> */
+.lm-DockPanel-handle[data-orientation='vertical']:after {
+  top: 50%;
+  min-height: 8px;
+  transform: translateY(-50%);
+}
+
+
+/* <DEPRECATED> */ .p-DockPanel-overlay, /* </DEPRECATED> */
+.lm-DockPanel-overlay {
+  z-index: 3;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+
+/* <DEPRECATED> */ .p-DockPanel-overlay.p-mod-hidden, /* </DEPRECATED> */
+.lm-DockPanel-overlay.lm-mod-hidden {
+  display: none !important;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-Menu, /* </DEPRECATED> */
+.lm-Menu {
+  z-index: 10000;
+  position: absolute;
+  white-space: nowrap;
+  overflow-x: hidden;
+  overflow-y: auto;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+
+/* <DEPRECATED> */ .p-Menu-content, /* </DEPRECATED> */
+.lm-Menu-content {
+  margin: 0;
+  padding: 0;
+  display: table;
+  list-style-type: none;
+}
+
+
+/* <DEPRECATED> */ .p-Menu-item, /* </DEPRECATED> */
+.lm-Menu-item {
+  display: table-row;
+}
+
+
+/* <DEPRECATED> */
+.p-Menu-item.p-mod-hidden,
+.p-Menu-item.p-mod-collapsed,
+/* </DEPRECATED> */
+.lm-Menu-item.lm-mod-hidden,
+.lm-Menu-item.lm-mod-collapsed {
+  display: none !important;
+}
+
+
+/* <DEPRECATED> */
+.p-Menu-itemIcon,
+.p-Menu-itemSubmenuIcon,
+/* </DEPRECATED> */
+.lm-Menu-itemIcon,
+.lm-Menu-itemSubmenuIcon {
+  display: table-cell;
+  text-align: center;
+}
+
+
+/* <DEPRECATED> */ .p-Menu-itemLabel, /* </DEPRECATED> */
+.lm-Menu-itemLabel {
+  display: table-cell;
+  text-align: left;
+}
+
+
+/* <DEPRECATED> */ .p-Menu-itemShortcut, /* </DEPRECATED> */
+.lm-Menu-itemShortcut {
+  display: table-cell;
+  text-align: right;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-MenuBar, /* </DEPRECATED> */
+.lm-MenuBar {
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+
+/* <DEPRECATED> */ .p-MenuBar-content, /* </DEPRECATED> */
+.lm-MenuBar-content {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: row;
+  list-style-type: none;
+}
+
+
+/* <DEPRECATED> */ .p--MenuBar-item, /* </DEPRECATED> */
+.lm-MenuBar-item {
+  box-sizing: border-box;
+}
+
+
+/* <DEPRECATED> */
+.p-MenuBar-itemIcon,
+.p-MenuBar-itemLabel,
+/* </DEPRECATED> */
+.lm-MenuBar-itemIcon,
+.lm-MenuBar-itemLabel {
+  display: inline-block;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-ScrollBar, /* </DEPRECATED> */
+.lm-ScrollBar {
+  display: flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='horizontal'],
+/* </DEPRECATED> */
+.lm-ScrollBar[data-orientation='horizontal'] {
+  flex-direction: row;
+}
+
+
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='vertical'],
+/* </DEPRECATED> */
+.lm-ScrollBar[data-orientation='vertical'] {
+  flex-direction: column;
+}
+
+
+/* <DEPRECATED> */ .p-ScrollBar-button, /* </DEPRECATED> */
+.lm-ScrollBar-button {
+  box-sizing: border-box;
+  flex: 0 0 auto;
+}
+
+
+/* <DEPRECATED> */ .p-ScrollBar-track, /* </DEPRECATED> */
+.lm-ScrollBar-track {
+  box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
+  flex: 1 1 auto;
+}
+
+
+/* <DEPRECATED> */ .p-ScrollBar-thumb, /* </DEPRECATED> */
+.lm-ScrollBar-thumb {
+  box-sizing: border-box;
+  position: absolute;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-SplitPanel-child, /* </DEPRECATED> */
+.lm-SplitPanel-child {
+  z-index: 0;
+}
+
+
+/* <DEPRECATED> */ .p-SplitPanel-handle, /* </DEPRECATED> */
+.lm-SplitPanel-handle {
+  z-index: 1;
+}
+
+
+/* <DEPRECATED> */ .p-SplitPanel-handle.p-mod-hidden, /* </DEPRECATED> */
+.lm-SplitPanel-handle.lm-mod-hidden {
+  display: none !important;
+}
+
+
+/* <DEPRECATED> */ .p-SplitPanel-handle:after, /* </DEPRECATED> */
+.lm-SplitPanel-handle:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  content: '';
+}
+
+
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle,
+/* </DEPRECATED> */
+.lm-SplitPanel[data-orientation='horizontal'] > .lm-SplitPanel-handle {
+  cursor: ew-resize;
+}
+
+
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle,
+/* </DEPRECATED> */
+.lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle {
+  cursor: ns-resize;
+}
+
+
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle:after,
+/* </DEPRECATED> */
+.lm-SplitPanel[data-orientation='horizontal'] > .lm-SplitPanel-handle:after {
+  left: 50%;
+  min-width: 8px;
+  transform: translateX(-50%);
+}
+
+
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle:after,
+/* </DEPRECATED> */
+.lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle:after {
+  top: 50%;
+  min-height: 8px;
+  transform: translateY(-50%);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-TabBar, /* </DEPRECATED> */
+.lm-TabBar {
+  display: flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+
+/* <DEPRECATED> */ .p-TabBar[data-orientation='horizontal'], /* </DEPRECATED> */
+.lm-TabBar[data-orientation='horizontal'] {
+  flex-direction: row;
+}
+
+
+/* <DEPRECATED> */ .p-TabBar[data-orientation='vertical'], /* </DEPRECATED> */
+.lm-TabBar[data-orientation='vertical'] {
+  flex-direction: column;
+}
+
+
+/* <DEPRECATED> */ .p-TabBar-content, /* </DEPRECATED> */
+.lm-TabBar-content {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex: 1 1 auto;
+  list-style-type: none;
+}
+
+
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content,
+/* </DEPRECATED> */
+.lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-content {
+  flex-direction: row;
+}
+
+
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='vertical'] > .p-TabBar-content,
+/* </DEPRECATED> */
+.lm-TabBar[data-orientation='vertical'] > .lm-TabBar-content {
+  flex-direction: column;
+}
+
+
+/* <DEPRECATED> */ .p-TabBar-tab, /* </DEPRECATED> */
+.lm-TabBar-tab {
+  display: flex;
+  flex-direction: row;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+
+/* <DEPRECATED> */
+.p-TabBar-tabIcon,
+.p-TabBar-tabCloseIcon,
+/* </DEPRECATED> */
+.lm-TabBar-tabIcon,
+.lm-TabBar-tabCloseIcon {
+  flex: 0 0 auto;
+}
+
+
+/* <DEPRECATED> */ .p-TabBar-tabLabel, /* </DEPRECATED> */
+.lm-TabBar-tabLabel {
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+
+/* <DEPRECATED> */ .p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
+.lm-TabBar-tab.lm-mod-hidden {
+  display: none !important;
+}
+
+
+/* <DEPRECATED> */ .p-TabBar.p-mod-dragging .p-TabBar-tab, /* </DEPRECATED> */
+.lm-TabBar.lm-mod-dragging .lm-TabBar-tab {
+  position: relative;
+}
+
+
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging[data-orientation='horizontal'] .p-TabBar-tab,
+/* </DEPRECATED> */
+.lm-TabBar.lm-mod-dragging[data-orientation='horizontal'] .lm-TabBar-tab {
+  left: 0;
+  transition: left 150ms ease;
+}
+
+
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging[data-orientation='vertical'] .p-TabBar-tab,
+/* </DEPRECATED> */
+.lm-TabBar.lm-mod-dragging[data-orientation='vertical'] .lm-TabBar-tab {
+  top: 0;
+  transition: top 150ms ease;
+}
+
+
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging
+/* </DEPRECATED> */
+.lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
+  transition: none;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ .p-TabPanel-tabBar, /* </DEPRECATED> */
+.lm-TabPanel-tabBar {
+  z-index: 1;
+}
+
+
+/* <DEPRECATED> */ .p-TabPanel-stackedPanel, /* </DEPRECATED> */
+.lm-TabPanel-stackedPanel {
+  z-index: 0;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+@charset "UTF-8";
+/*!
+
+Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0.
+
+*/
+html{
+  -webkit-box-sizing:border-box;
+          box-sizing:border-box; }
+
+*,
+*::before,
+*::after{
+  -webkit-box-sizing:inherit;
+          box-sizing:inherit; }
+
+body{
+  text-transform:none;
+  line-height:1.28581;
+  letter-spacing:0;
+  font-size:14px;
+  font-weight:400;
+  color:#182026;
+  font-family:-apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", "Icons16", sans-serif; }
+
+p{
+  margin-top:0;
+  margin-bottom:10px; }
+
+small{
+  font-size:12px; }
+
+strong{
+  font-weight:600; }
+
+::-moz-selection{
+  background:rgba(125, 188, 255, 0.6); }
+
+::selection{
+  background:rgba(125, 188, 255, 0.6); }
+.bp3-heading{
+  color:#182026;
+  font-weight:600;
+  margin:0 0 10px;
+  padding:0; }
+  .bp3-dark .bp3-heading{
+    color:#f5f8fa; }
+
+h1.bp3-heading, .bp3-running-text h1{
+  line-height:40px;
+  font-size:36px; }
+
+h2.bp3-heading, .bp3-running-text h2{
+  line-height:32px;
+  font-size:28px; }
+
+h3.bp3-heading, .bp3-running-text h3{
+  line-height:25px;
+  font-size:22px; }
+
+h4.bp3-heading, .bp3-running-text h4{
+  line-height:21px;
+  font-size:18px; }
+
+h5.bp3-heading, .bp3-running-text h5{
+  line-height:19px;
+  font-size:16px; }
+
+h6.bp3-heading, .bp3-running-text h6{
+  line-height:16px;
+  font-size:14px; }
+.bp3-ui-text{
+  text-transform:none;
+  line-height:1.28581;
+  letter-spacing:0;
+  font-size:14px;
+  font-weight:400; }
+
+.bp3-monospace-text{
+  text-transform:none;
+  font-family:monospace; }
+
+.bp3-text-muted{
+  color:#5c7080; }
+  .bp3-dark .bp3-text-muted{
+    color:#a7b6c2; }
+
+.bp3-text-disabled{
+  color:rgba(92, 112, 128, 0.6); }
+  .bp3-dark .bp3-text-disabled{
+    color:rgba(167, 182, 194, 0.6); }
+
+.bp3-text-overflow-ellipsis{
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  word-wrap:normal; }
+.bp3-running-text{
+  line-height:1.5;
+  font-size:14px; }
+  .bp3-running-text h1{
+    color:#182026;
+    font-weight:600;
+    margin-top:40px;
+    margin-bottom:20px; }
+    .bp3-dark .bp3-running-text h1{
+      color:#f5f8fa; }
+  .bp3-running-text h2{
+    color:#182026;
+    font-weight:600;
+    margin-top:40px;
+    margin-bottom:20px; }
+    .bp3-dark .bp3-running-text h2{
+      color:#f5f8fa; }
+  .bp3-running-text h3{
+    color:#182026;
+    font-weight:600;
+    margin-top:40px;
+    margin-bottom:20px; }
+    .bp3-dark .bp3-running-text h3{
+      color:#f5f8fa; }
+  .bp3-running-text h4{
+    color:#182026;
+    font-weight:600;
+    margin-top:40px;
+    margin-bottom:20px; }
+    .bp3-dark .bp3-running-text h4{
+      color:#f5f8fa; }
+  .bp3-running-text h5{
+    color:#182026;
+    font-weight:600;
+    margin-top:40px;
+    margin-bottom:20px; }
+    .bp3-dark .bp3-running-text h5{
+      color:#f5f8fa; }
+  .bp3-running-text h6{
+    color:#182026;
+    font-weight:600;
+    margin-top:40px;
+    margin-bottom:20px; }
+    .bp3-dark .bp3-running-text h6{
+      color:#f5f8fa; }
+  .bp3-running-text hr{
+    margin:20px 0;
+    border:none;
+    border-bottom:1px solid rgba(16, 22, 26, 0.15); }
+    .bp3-dark .bp3-running-text hr{
+      border-color:rgba(255, 255, 255, 0.15); }
+  .bp3-running-text p{
+    margin:0 0 10px;
+    padding:0; }
+
+.bp3-text-large{
+  font-size:16px; }
+
+.bp3-text-small{
+  font-size:12px; }
+a{
+  text-decoration:none;
+  color:#106ba3; }
+  a:hover{
+    cursor:pointer;
+    text-decoration:underline;
+    color:#106ba3; }
+  a .bp3-icon, a .bp3-icon-standard, a .bp3-icon-large{
+    color:inherit; }
+  a code,
+  .bp3-dark a code{
+    color:inherit; }
+  .bp3-dark a,
+  .bp3-dark a:hover{
+    color:#48aff0; }
+    .bp3-dark a .bp3-icon, .bp3-dark a .bp3-icon-standard, .bp3-dark a .bp3-icon-large,
+    .bp3-dark a:hover .bp3-icon,
+    .bp3-dark a:hover .bp3-icon-standard,
+    .bp3-dark a:hover .bp3-icon-large{
+      color:inherit; }
+.bp3-running-text code, .bp3-code{
+  text-transform:none;
+  font-family:monospace;
+  border-radius:3px;
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
+  background:rgba(255, 255, 255, 0.7);
+  padding:2px 5px;
+  color:#5c7080;
+  font-size:smaller; }
+  .bp3-dark .bp3-running-text code, .bp3-running-text .bp3-dark code, .bp3-dark .bp3-code{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+    background:rgba(16, 22, 26, 0.3);
+    color:#a7b6c2; }
+  .bp3-running-text a > code, a > .bp3-code{
+    color:#137cbd; }
+    .bp3-dark .bp3-running-text a > code, .bp3-running-text .bp3-dark a > code, .bp3-dark a > .bp3-code{
+      color:inherit; }
+
+.bp3-running-text pre, .bp3-code-block{
+  text-transform:none;
+  font-family:monospace;
+  display:block;
+  margin:10px 0;
+  border-radius:3px;
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+  background:rgba(255, 255, 255, 0.7);
+  padding:13px 15px 12px;
+  line-height:1.4;
+  color:#182026;
+  font-size:13px;
+  word-break:break-all;
+  word-wrap:break-word; }
+  .bp3-dark .bp3-running-text pre, .bp3-running-text .bp3-dark pre, .bp3-dark .bp3-code-block{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+    background:rgba(16, 22, 26, 0.3);
+    color:#f5f8fa; }
+  .bp3-running-text pre > code, .bp3-code-block > code{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:none;
+    padding:0;
+    color:inherit;
+    font-size:inherit; }
+
+.bp3-running-text kbd, .bp3-key{
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  border-radius:3px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+  background:#ffffff;
+  min-width:24px;
+  height:24px;
+  padding:3px 6px;
+  vertical-align:middle;
+  line-height:24px;
+  color:#5c7080;
+  font-family:inherit;
+  font-size:12px; }
+  .bp3-running-text kbd .bp3-icon, .bp3-key .bp3-icon, .bp3-running-text kbd .bp3-icon-standard, .bp3-key .bp3-icon-standard, .bp3-running-text kbd .bp3-icon-large, .bp3-key .bp3-icon-large{
+    margin-right:5px; }
+  .bp3-dark .bp3-running-text kbd, .bp3-running-text .bp3-dark kbd, .bp3-dark .bp3-key{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
+    background:#394b59;
+    color:#a7b6c2; }
+.bp3-running-text blockquote, .bp3-blockquote{
+  margin:0 0 10px;
+  border-left:solid 4px rgba(167, 182, 194, 0.5);
+  padding:0 20px; }
+  .bp3-dark .bp3-running-text blockquote, .bp3-running-text .bp3-dark blockquote, .bp3-dark .bp3-blockquote{
+    border-color:rgba(115, 134, 148, 0.5); }
+.bp3-running-text ul,
+.bp3-running-text ol, .bp3-list{
+  margin:10px 0;
+  padding-left:30px; }
+  .bp3-running-text ul li:not(:last-child), .bp3-running-text ol li:not(:last-child), .bp3-list li:not(:last-child){
+    margin-bottom:5px; }
+  .bp3-running-text ul ol, .bp3-running-text ol ol, .bp3-list ol,
+  .bp3-running-text ul ul,
+  .bp3-running-text ol ul,
+  .bp3-list ul{
+    margin-top:5px; }
+
+.bp3-list-unstyled{
+  margin:0;
+  padding:0;
+  list-style:none; }
+  .bp3-list-unstyled li{
+    padding:0; }
+.bp3-rtl{
+  text-align:right; }
+
+.bp3-dark{
+  color:#f5f8fa; }
+
+:focus{
+  outline:rgba(19, 124, 189, 0.6) auto 2px;
+  outline-offset:2px;
+  -moz-outline-radius:6px; }
+
+.bp3-focus-disabled :focus{
+  outline:none !important; }
+  .bp3-focus-disabled :focus ~ .bp3-control-indicator{
+    outline:none !important; }
+
+.bp3-alert{
+  max-width:400px;
+  padding:20px; }
+
+.bp3-alert-body{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex; }
+  .bp3-alert-body .bp3-icon{
+    margin-top:0;
+    margin-right:20px;
+    font-size:40px; }
+
+.bp3-alert-footer{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:reverse;
+      -ms-flex-direction:row-reverse;
+          flex-direction:row-reverse;
+  margin-top:10px; }
+  .bp3-alert-footer .bp3-button{
+    margin-left:10px; }
+.bp3-breadcrumbs{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -ms-flex-wrap:wrap;
+      flex-wrap:wrap;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  margin:0;
+  cursor:default;
+  height:30px;
+  padding:0;
+  list-style:none; }
+  .bp3-breadcrumbs > li{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-align:center;
+        -ms-flex-align:center;
+            align-items:center; }
+    .bp3-breadcrumbs > li::after{
+      display:block;
+      margin:0 5px;
+      background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.71 7.29l-4-4a1.003 1.003 0 0 0-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z' fill='%235C7080'/%3e%3c/svg%3e");
+      width:16px;
+      height:16px;
+      content:""; }
+    .bp3-breadcrumbs > li:last-of-type::after{
+      display:none; }
+
+.bp3-breadcrumb,
+.bp3-breadcrumb-current,
+.bp3-breadcrumbs-collapsed{
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  font-size:16px; }
+
+.bp3-breadcrumb,
+.bp3-breadcrumbs-collapsed{
+  color:#5c7080; }
+
+.bp3-breadcrumb:hover{
+  text-decoration:none; }
+
+.bp3-breadcrumb.bp3-disabled{
+  cursor:not-allowed;
+  color:rgba(92, 112, 128, 0.6); }
+
+.bp3-breadcrumb .bp3-icon{
+  margin-right:5px; }
+
+.bp3-breadcrumb-current{
+  color:inherit;
+  font-weight:600; }
+  .bp3-breadcrumb-current .bp3-input{
+    vertical-align:baseline;
+    font-size:inherit;
+    font-weight:inherit; }
+
+.bp3-breadcrumbs-collapsed{
+  margin-right:2px;
+  border:none;
+  border-radius:3px;
+  background:#ced9e0;
+  cursor:pointer;
+  padding:1px 5px;
+  vertical-align:text-bottom; }
+  .bp3-breadcrumbs-collapsed::before{
+    display:block;
+    background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cg fill='%235C7080'%3e%3ccircle cx='2' cy='8.03' r='2'/%3e%3ccircle cx='14' cy='8.03' r='2'/%3e%3ccircle cx='8' cy='8.03' r='2'/%3e%3c/g%3e%3c/svg%3e") center no-repeat;
+    width:16px;
+    height:16px;
+    content:""; }
+  .bp3-breadcrumbs-collapsed:hover{
+    background:#bfccd6;
+    text-decoration:none;
+    color:#182026; }
+
+.bp3-dark .bp3-breadcrumb,
+.bp3-dark .bp3-breadcrumbs-collapsed{
+  color:#a7b6c2; }
+
+.bp3-dark .bp3-breadcrumbs > li::after{
+  color:#a7b6c2; }
+
+.bp3-dark .bp3-breadcrumb.bp3-disabled{
+  color:rgba(167, 182, 194, 0.6); }
+
+.bp3-dark .bp3-breadcrumb-current{
+  color:#f5f8fa; }
+
+.bp3-dark .bp3-breadcrumbs-collapsed{
+  background:rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-breadcrumbs-collapsed:hover{
+    background:rgba(16, 22, 26, 0.6);
+    color:#f5f8fa; }
+.bp3-button{
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  border:none;
+  border-radius:3px;
+  cursor:pointer;
+  padding:5px 10px;
+  vertical-align:middle;
+  text-align:left;
+  font-size:14px;
+  min-width:30px;
+  min-height:30px; }
+  .bp3-button > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-button > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-button::before,
+  .bp3-button > *{
+    margin-right:7px; }
+  .bp3-button:empty::before,
+  .bp3-button > :last-child{
+    margin-right:0; }
+  .bp3-button:empty{
+    padding:0 !important; }
+  .bp3-button:disabled, .bp3-button.bp3-disabled{
+    cursor:not-allowed; }
+  .bp3-button.bp3-fill{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    width:100%; }
+  .bp3-button.bp3-align-right,
+  .bp3-align-right .bp3-button{
+    text-align:right; }
+  .bp3-button.bp3-align-left,
+  .bp3-align-left .bp3-button{
+    text-align:left; }
+  .bp3-button:not([class*="bp3-intent-"]){
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+    background-color:#f5f8fa;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    color:#182026; }
+    .bp3-button:not([class*="bp3-intent-"]):hover{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+      background-clip:padding-box;
+      background-color:#ebf1f5; }
+    .bp3-button:not([class*="bp3-intent-"]):active, .bp3-button:not([class*="bp3-intent-"]).bp3-active{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#d8e1e8;
+      background-image:none; }
+    .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
+      outline:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(206, 217, 224, 0.5);
+      background-image:none;
+      cursor:not-allowed;
+      color:rgba(92, 112, 128, 0.6); }
+      .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active:hover, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active:hover{
+        background:rgba(206, 217, 224, 0.7); }
+  .bp3-button.bp3-intent-primary{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#137cbd;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    color:#ffffff; }
+    .bp3-button.bp3-intent-primary:hover, .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
+      color:#ffffff; }
+    .bp3-button.bp3-intent-primary:hover{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+      background-color:#106ba3; }
+    .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#0e5a8a;
+      background-image:none; }
+    .bp3-button.bp3-intent-primary:disabled, .bp3-button.bp3-intent-primary.bp3-disabled{
+      border-color:transparent;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(19, 124, 189, 0.5);
+      background-image:none;
+      color:rgba(255, 255, 255, 0.6); }
+  .bp3-button.bp3-intent-success{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#0f9960;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    color:#ffffff; }
+    .bp3-button.bp3-intent-success:hover, .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
+      color:#ffffff; }
+    .bp3-button.bp3-intent-success:hover{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+      background-color:#0d8050; }
+    .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#0a6640;
+      background-image:none; }
+    .bp3-button.bp3-intent-success:disabled, .bp3-button.bp3-intent-success.bp3-disabled{
+      border-color:transparent;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(15, 153, 96, 0.5);
+      background-image:none;
+      color:rgba(255, 255, 255, 0.6); }
+  .bp3-button.bp3-intent-warning{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#d9822b;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    color:#ffffff; }
+    .bp3-button.bp3-intent-warning:hover, .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
+      color:#ffffff; }
+    .bp3-button.bp3-intent-warning:hover{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+      background-color:#bf7326; }
+    .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#a66321;
+      background-image:none; }
+    .bp3-button.bp3-intent-warning:disabled, .bp3-button.bp3-intent-warning.bp3-disabled{
+      border-color:transparent;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(217, 130, 43, 0.5);
+      background-image:none;
+      color:rgba(255, 255, 255, 0.6); }
+  .bp3-button.bp3-intent-danger{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#db3737;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    color:#ffffff; }
+    .bp3-button.bp3-intent-danger:hover, .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
+      color:#ffffff; }
+    .bp3-button.bp3-intent-danger:hover{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+      background-color:#c23030; }
+    .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#a82a2a;
+      background-image:none; }
+    .bp3-button.bp3-intent-danger:disabled, .bp3-button.bp3-intent-danger.bp3-disabled{
+      border-color:transparent;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(219, 55, 55, 0.5);
+      background-image:none;
+      color:rgba(255, 255, 255, 0.6); }
+  .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
+    stroke:#ffffff; }
+  .bp3-button.bp3-large,
+  .bp3-large .bp3-button{
+    min-width:40px;
+    min-height:40px;
+    padding:5px 15px;
+    font-size:16px; }
+    .bp3-button.bp3-large::before,
+    .bp3-button.bp3-large > *,
+    .bp3-large .bp3-button::before,
+    .bp3-large .bp3-button > *{
+      margin-right:10px; }
+    .bp3-button.bp3-large:empty::before,
+    .bp3-button.bp3-large > :last-child,
+    .bp3-large .bp3-button:empty::before,
+    .bp3-large .bp3-button > :last-child{
+      margin-right:0; }
+  .bp3-button.bp3-small,
+  .bp3-small .bp3-button{
+    min-width:24px;
+    min-height:24px;
+    padding:0 7px; }
+  .bp3-button.bp3-loading{
+    position:relative; }
+    .bp3-button.bp3-loading[class*="bp3-icon-"]::before{
+      visibility:hidden; }
+    .bp3-button.bp3-loading .bp3-button-spinner{
+      position:absolute;
+      margin:0; }
+    .bp3-button.bp3-loading > :not(.bp3-button-spinner){
+      visibility:hidden; }
+  .bp3-button[class*="bp3-icon-"]::before{
+    line-height:1;
+    font-family:"Icons16", sans-serif;
+    font-size:16px;
+    font-weight:400;
+    font-style:normal;
+    -moz-osx-font-smoothing:grayscale;
+    -webkit-font-smoothing:antialiased;
+    color:#5c7080; }
+  .bp3-button .bp3-icon, .bp3-button .bp3-icon-standard, .bp3-button .bp3-icon-large{
+    color:#5c7080; }
+    .bp3-button .bp3-icon.bp3-align-right, .bp3-button .bp3-icon-standard.bp3-align-right, .bp3-button .bp3-icon-large.bp3-align-right{
+      margin-left:7px; }
+  .bp3-button .bp3-icon:first-child:last-child,
+  .bp3-button .bp3-spinner + .bp3-icon:last-child{
+    margin:0 -7px; }
+  .bp3-dark .bp3-button:not([class*="bp3-intent-"]){
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+    background-color:#394b59;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+    color:#f5f8fa; }
+    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover, .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
+      color:#f5f8fa; }
+    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+      background-color:#30404d; }
+    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#202b33;
+      background-image:none; }
+    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(57, 75, 89, 0.5);
+      background-image:none;
+      color:rgba(167, 182, 194, 0.6); }
+      .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active{
+        background:rgba(57, 75, 89, 0.7); }
+    .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-button-spinner .bp3-spinner-head{
+      background:rgba(16, 22, 26, 0.5);
+      stroke:#8a9ba8; }
+    .bp3-dark .bp3-button:not([class*="bp3-intent-"])[class*="bp3-icon-"]::before{
+      color:#a7b6c2; }
+    .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-icon, .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-icon-standard, .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-icon-large{
+      color:#a7b6c2; }
+  .bp3-dark .bp3-button[class*="bp3-intent-"]{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-button[class*="bp3-intent-"]:hover{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-button[class*="bp3-intent-"]:active, .bp3-dark .bp3-button[class*="bp3-intent-"].bp3-active{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
+    .bp3-dark .bp3-button[class*="bp3-intent-"]:disabled, .bp3-dark .bp3-button[class*="bp3-intent-"].bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-image:none;
+      color:rgba(255, 255, 255, 0.3); }
+    .bp3-dark .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
+      stroke:#8a9ba8; }
+  .bp3-button:disabled::before,
+  .bp3-button:disabled .bp3-icon, .bp3-button:disabled .bp3-icon-standard, .bp3-button:disabled .bp3-icon-large, .bp3-button.bp3-disabled::before,
+  .bp3-button.bp3-disabled .bp3-icon, .bp3-button.bp3-disabled .bp3-icon-standard, .bp3-button.bp3-disabled .bp3-icon-large, .bp3-button[class*="bp3-intent-"]::before,
+  .bp3-button[class*="bp3-intent-"] .bp3-icon, .bp3-button[class*="bp3-intent-"] .bp3-icon-standard, .bp3-button[class*="bp3-intent-"] .bp3-icon-large{
+    color:inherit !important; }
+  .bp3-button.bp3-minimal{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:none; }
+    .bp3-button.bp3-minimal:hover{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(167, 182, 194, 0.3);
+      text-decoration:none;
+      color:#182026; }
+    .bp3-button.bp3-minimal:active, .bp3-button.bp3-minimal.bp3-active{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(115, 134, 148, 0.3);
+      color:#182026; }
+    .bp3-button.bp3-minimal:disabled, .bp3-button.bp3-minimal:disabled:hover, .bp3-button.bp3-minimal.bp3-disabled, .bp3-button.bp3-minimal.bp3-disabled:hover{
+      background:none;
+      cursor:not-allowed;
+      color:rgba(92, 112, 128, 0.6); }
+      .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
+        background:rgba(115, 134, 148, 0.3); }
+    .bp3-dark .bp3-button.bp3-minimal{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:none;
+      color:inherit; }
+      .bp3-dark .bp3-button.bp3-minimal:hover, .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none; }
+      .bp3-dark .bp3-button.bp3-minimal:hover{
+        background:rgba(138, 155, 168, 0.15); }
+      .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
+        background:rgba(138, 155, 168, 0.3);
+        color:#f5f8fa; }
+      .bp3-dark .bp3-button.bp3-minimal:disabled, .bp3-dark .bp3-button.bp3-minimal:disabled:hover, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover{
+        background:none;
+        cursor:not-allowed;
+        color:rgba(167, 182, 194, 0.6); }
+        .bp3-dark .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
+          background:rgba(138, 155, 168, 0.3); }
+    .bp3-button.bp3-minimal.bp3-intent-primary{
+      color:#106ba3; }
+      .bp3-button.bp3-minimal.bp3-intent-primary:hover, .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#106ba3; }
+      .bp3-button.bp3-minimal.bp3-intent-primary:hover{
+        background:rgba(19, 124, 189, 0.15);
+        color:#106ba3; }
+      .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
+        background:rgba(19, 124, 189, 0.3);
+        color:#106ba3; }
+      .bp3-button.bp3-minimal.bp3-intent-primary:disabled, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled{
+        background:none;
+        color:rgba(16, 107, 163, 0.5); }
+        .bp3-button.bp3-minimal.bp3-intent-primary:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled.bp3-active{
+          background:rgba(19, 124, 189, 0.3); }
+      .bp3-button.bp3-minimal.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
+        stroke:#106ba3; }
+      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary{
+        color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:hover{
+          background:rgba(19, 124, 189, 0.2);
+          color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
+          background:rgba(19, 124, 189, 0.3);
+          color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled{
+          background:none;
+          color:rgba(72, 175, 240, 0.5); }
+          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled.bp3-active{
+            background:rgba(19, 124, 189, 0.3); }
+    .bp3-button.bp3-minimal.bp3-intent-success{
+      color:#0d8050; }
+      .bp3-button.bp3-minimal.bp3-intent-success:hover, .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#0d8050; }
+      .bp3-button.bp3-minimal.bp3-intent-success:hover{
+        background:rgba(15, 153, 96, 0.15);
+        color:#0d8050; }
+      .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
+        background:rgba(15, 153, 96, 0.3);
+        color:#0d8050; }
+      .bp3-button.bp3-minimal.bp3-intent-success:disabled, .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled{
+        background:none;
+        color:rgba(13, 128, 80, 0.5); }
+        .bp3-button.bp3-minimal.bp3-intent-success:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled.bp3-active{
+          background:rgba(15, 153, 96, 0.3); }
+      .bp3-button.bp3-minimal.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
+        stroke:#0d8050; }
+      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success{
+        color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:hover{
+          background:rgba(15, 153, 96, 0.2);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
+          background:rgba(15, 153, 96, 0.3);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled{
+          background:none;
+          color:rgba(61, 204, 145, 0.5); }
+          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled.bp3-active{
+            background:rgba(15, 153, 96, 0.3); }
+    .bp3-button.bp3-minimal.bp3-intent-warning{
+      color:#bf7326; }
+      .bp3-button.bp3-minimal.bp3-intent-warning:hover, .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#bf7326; }
+      .bp3-button.bp3-minimal.bp3-intent-warning:hover{
+        background:rgba(217, 130, 43, 0.15);
+        color:#bf7326; }
+      .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
+        background:rgba(217, 130, 43, 0.3);
+        color:#bf7326; }
+      .bp3-button.bp3-minimal.bp3-intent-warning:disabled, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled{
+        background:none;
+        color:rgba(191, 115, 38, 0.5); }
+        .bp3-button.bp3-minimal.bp3-intent-warning:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled.bp3-active{
+          background:rgba(217, 130, 43, 0.3); }
+      .bp3-button.bp3-minimal.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
+        stroke:#bf7326; }
+      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning{
+        color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:hover{
+          background:rgba(217, 130, 43, 0.2);
+          color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
+          background:rgba(217, 130, 43, 0.3);
+          color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled{
+          background:none;
+          color:rgba(255, 179, 102, 0.5); }
+          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled.bp3-active{
+            background:rgba(217, 130, 43, 0.3); }
+    .bp3-button.bp3-minimal.bp3-intent-danger{
+      color:#c23030; }
+      .bp3-button.bp3-minimal.bp3-intent-danger:hover, .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#c23030; }
+      .bp3-button.bp3-minimal.bp3-intent-danger:hover{
+        background:rgba(219, 55, 55, 0.15);
+        color:#c23030; }
+      .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
+        background:rgba(219, 55, 55, 0.3);
+        color:#c23030; }
+      .bp3-button.bp3-minimal.bp3-intent-danger:disabled, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled{
+        background:none;
+        color:rgba(194, 48, 48, 0.5); }
+        .bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active{
+          background:rgba(219, 55, 55, 0.3); }
+      .bp3-button.bp3-minimal.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
+        stroke:#c23030; }
+      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger{
+        color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:hover{
+          background:rgba(219, 55, 55, 0.2);
+          color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
+          background:rgba(219, 55, 55, 0.3);
+          color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled{
+          background:none;
+          color:rgba(255, 115, 115, 0.5); }
+          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active{
+            background:rgba(219, 55, 55, 0.3); }
+
+a.bp3-button{
+  text-align:center;
+  text-decoration:none;
+  -webkit-transition:none;
+  transition:none; }
+  a.bp3-button, a.bp3-button:hover, a.bp3-button:active{
+    color:#182026; }
+  a.bp3-button.bp3-disabled{
+    color:rgba(92, 112, 128, 0.6); }
+
+.bp3-button-text{
+  -webkit-box-flex:0;
+      -ms-flex:0 1 auto;
+          flex:0 1 auto; }
+
+.bp3-button.bp3-align-left .bp3-button-text, .bp3-button.bp3-align-right .bp3-button-text,
+.bp3-button-group.bp3-align-left .bp3-button-text,
+.bp3-button-group.bp3-align-right .bp3-button-text{
+  -webkit-box-flex:1;
+      -ms-flex:1 1 auto;
+          flex:1 1 auto; }
+.bp3-button-group{
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex; }
+  .bp3-button-group .bp3-button{
+    -webkit-box-flex:0;
+        -ms-flex:0 0 auto;
+            flex:0 0 auto;
+    position:relative;
+    z-index:4; }
+    .bp3-button-group .bp3-button:focus{
+      z-index:5; }
+    .bp3-button-group .bp3-button:hover{
+      z-index:6; }
+    .bp3-button-group .bp3-button:active, .bp3-button-group .bp3-button.bp3-active{
+      z-index:7; }
+    .bp3-button-group .bp3-button:disabled, .bp3-button-group .bp3-button.bp3-disabled{
+      z-index:3; }
+    .bp3-button-group .bp3-button[class*="bp3-intent-"]{
+      z-index:9; }
+      .bp3-button-group .bp3-button[class*="bp3-intent-"]:focus{
+        z-index:10; }
+      .bp3-button-group .bp3-button[class*="bp3-intent-"]:hover{
+        z-index:11; }
+      .bp3-button-group .bp3-button[class*="bp3-intent-"]:active, .bp3-button-group .bp3-button[class*="bp3-intent-"].bp3-active{
+        z-index:12; }
+      .bp3-button-group .bp3-button[class*="bp3-intent-"]:disabled, .bp3-button-group .bp3-button[class*="bp3-intent-"].bp3-disabled{
+        z-index:8; }
+  .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:first-child) .bp3-button,
+  .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:first-child){
+    border-top-left-radius:0;
+    border-bottom-left-radius:0; }
+  .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
+  .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child){
+    margin-right:-1px;
+    border-top-right-radius:0;
+    border-bottom-right-radius:0; }
+  .bp3-button-group.bp3-minimal .bp3-button{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:none; }
+    .bp3-button-group.bp3-minimal .bp3-button:hover{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(167, 182, 194, 0.3);
+      text-decoration:none;
+      color:#182026; }
+    .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(115, 134, 148, 0.3);
+      color:#182026; }
+    .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
+      background:none;
+      cursor:not-allowed;
+      color:rgba(92, 112, 128, 0.6); }
+      .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
+        background:rgba(115, 134, 148, 0.3); }
+    .bp3-dark .bp3-button-group.bp3-minimal .bp3-button{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:none;
+      color:inherit; }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none; }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover{
+        background:rgba(138, 155, 168, 0.15); }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
+        background:rgba(138, 155, 168, 0.3);
+        color:#f5f8fa; }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
+        background:none;
+        cursor:not-allowed;
+        color:rgba(167, 182, 194, 0.6); }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
+          background:rgba(138, 155, 168, 0.3); }
+    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary{
+      color:#106ba3; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#106ba3; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover{
+        background:rgba(19, 124, 189, 0.15);
+        color:#106ba3; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
+        background:rgba(19, 124, 189, 0.3);
+        color:#106ba3; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled{
+        background:none;
+        color:rgba(16, 107, 163, 0.5); }
+        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled.bp3-active{
+          background:rgba(19, 124, 189, 0.3); }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
+        stroke:#106ba3; }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary{
+        color:#48aff0; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover{
+          background:rgba(19, 124, 189, 0.2);
+          color:#48aff0; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
+          background:rgba(19, 124, 189, 0.3);
+          color:#48aff0; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled{
+          background:none;
+          color:rgba(72, 175, 240, 0.5); }
+          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled.bp3-active{
+            background:rgba(19, 124, 189, 0.3); }
+    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success{
+      color:#0d8050; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#0d8050; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover{
+        background:rgba(15, 153, 96, 0.15);
+        color:#0d8050; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
+        background:rgba(15, 153, 96, 0.3);
+        color:#0d8050; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled{
+        background:none;
+        color:rgba(13, 128, 80, 0.5); }
+        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled.bp3-active{
+          background:rgba(15, 153, 96, 0.3); }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
+        stroke:#0d8050; }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success{
+        color:#3dcc91; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover{
+          background:rgba(15, 153, 96, 0.2);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
+          background:rgba(15, 153, 96, 0.3);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled{
+          background:none;
+          color:rgba(61, 204, 145, 0.5); }
+          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled.bp3-active{
+            background:rgba(15, 153, 96, 0.3); }
+    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning{
+      color:#bf7326; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#bf7326; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover{
+        background:rgba(217, 130, 43, 0.15);
+        color:#bf7326; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
+        background:rgba(217, 130, 43, 0.3);
+        color:#bf7326; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled{
+        background:none;
+        color:rgba(191, 115, 38, 0.5); }
+        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled.bp3-active{
+          background:rgba(217, 130, 43, 0.3); }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
+        stroke:#bf7326; }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning{
+        color:#ffb366; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover{
+          background:rgba(217, 130, 43, 0.2);
+          color:#ffb366; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
+          background:rgba(217, 130, 43, 0.3);
+          color:#ffb366; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled{
+          background:none;
+          color:rgba(255, 179, 102, 0.5); }
+          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled.bp3-active{
+            background:rgba(217, 130, 43, 0.3); }
+    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger{
+      color:#c23030; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:none;
+        color:#c23030; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover{
+        background:rgba(219, 55, 55, 0.15);
+        color:#c23030; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
+        background:rgba(219, 55, 55, 0.3);
+        color:#c23030; }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled{
+        background:none;
+        color:rgba(194, 48, 48, 0.5); }
+        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled.bp3-active{
+          background:rgba(219, 55, 55, 0.3); }
+      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
+        stroke:#c23030; }
+      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger{
+        color:#ff7373; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover{
+          background:rgba(219, 55, 55, 0.2);
+          color:#ff7373; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
+          background:rgba(219, 55, 55, 0.3);
+          color:#ff7373; }
+        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled{
+          background:none;
+          color:rgba(255, 115, 115, 0.5); }
+          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled.bp3-active{
+            background:rgba(219, 55, 55, 0.3); }
+  .bp3-button-group .bp3-popover-wrapper,
+  .bp3-button-group .bp3-popover-target{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto; }
+  .bp3-button-group.bp3-fill{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    width:100%; }
+  .bp3-button-group .bp3-button.bp3-fill,
+  .bp3-button-group.bp3-fill .bp3-button:not(.bp3-fixed){
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto; }
+  .bp3-button-group.bp3-vertical{
+    -webkit-box-orient:vertical;
+    -webkit-box-direction:normal;
+        -ms-flex-direction:column;
+            flex-direction:column;
+    -webkit-box-align:stretch;
+        -ms-flex-align:stretch;
+            align-items:stretch;
+    vertical-align:top; }
+    .bp3-button-group.bp3-vertical.bp3-fill{
+      width:unset;
+      height:100%; }
+    .bp3-button-group.bp3-vertical .bp3-button{
+      margin-right:0 !important;
+      width:100%; }
+    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-popover-wrapper:first-child .bp3-button,
+    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:first-child{
+      border-radius:3px 3px 0 0; }
+    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-popover-wrapper:last-child .bp3-button,
+    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:last-child{
+      border-radius:0 0 3px 3px; }
+    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
+    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:not(:last-child){
+      margin-bottom:-1px; }
+  .bp3-button-group.bp3-align-left .bp3-button{
+    text-align:left; }
+  .bp3-dark .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
+  .bp3-dark .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child){
+    margin-right:1px; }
+  .bp3-dark .bp3-button-group.bp3-vertical > .bp3-popover-wrapper:not(:last-child) .bp3-button,
+  .bp3-dark .bp3-button-group.bp3-vertical > .bp3-button:not(:last-child){
+    margin-bottom:1px; }
+.bp3-callout{
+  line-height:1.5;
+  font-size:14px;
+  position:relative;
+  border-radius:3px;
+  background-color:rgba(138, 155, 168, 0.15);
+  width:100%;
+  padding:10px 12px 9px; }
+  .bp3-callout[class*="bp3-icon-"]{
+    padding-left:40px; }
+    .bp3-callout[class*="bp3-icon-"]::before{
+      line-height:1;
+      font-family:"Icons20", sans-serif;
+      font-size:20px;
+      font-weight:400;
+      font-style:normal;
+      -moz-osx-font-smoothing:grayscale;
+      -webkit-font-smoothing:antialiased;
+      position:absolute;
+      top:10px;
+      left:10px;
+      color:#5c7080; }
+  .bp3-callout.bp3-callout-icon{
+    padding-left:40px; }
+    .bp3-callout.bp3-callout-icon > .bp3-icon:first-child{
+      position:absolute;
+      top:10px;
+      left:10px;
+      color:#5c7080; }
+  .bp3-callout .bp3-heading{
+    margin-top:0;
+    margin-bottom:5px;
+    line-height:20px; }
+    .bp3-callout .bp3-heading:last-child{
+      margin-bottom:0; }
+  .bp3-dark .bp3-callout{
+    background-color:rgba(138, 155, 168, 0.2); }
+    .bp3-dark .bp3-callout[class*="bp3-icon-"]::before{
+      color:#a7b6c2; }
+  .bp3-callout.bp3-intent-primary{
+    background-color:rgba(19, 124, 189, 0.15); }
+    .bp3-callout.bp3-intent-primary[class*="bp3-icon-"]::before,
+    .bp3-callout.bp3-intent-primary > .bp3-icon:first-child,
+    .bp3-callout.bp3-intent-primary .bp3-heading{
+      color:#106ba3; }
+    .bp3-dark .bp3-callout.bp3-intent-primary{
+      background-color:rgba(19, 124, 189, 0.25); }
+      .bp3-dark .bp3-callout.bp3-intent-primary[class*="bp3-icon-"]::before,
+      .bp3-dark .bp3-callout.bp3-intent-primary > .bp3-icon:first-child,
+      .bp3-dark .bp3-callout.bp3-intent-primary .bp3-heading{
+        color:#48aff0; }
+  .bp3-callout.bp3-intent-success{
+    background-color:rgba(15, 153, 96, 0.15); }
+    .bp3-callout.bp3-intent-success[class*="bp3-icon-"]::before,
+    .bp3-callout.bp3-intent-success > .bp3-icon:first-child,
+    .bp3-callout.bp3-intent-success .bp3-heading{
+      color:#0d8050; }
+    .bp3-dark .bp3-callout.bp3-intent-success{
+      background-color:rgba(15, 153, 96, 0.25); }
+      .bp3-dark .bp3-callout.bp3-intent-success[class*="bp3-icon-"]::before,
+      .bp3-dark .bp3-callout.bp3-intent-success > .bp3-icon:first-child,
+      .bp3-dark .bp3-callout.bp3-intent-success .bp3-heading{
+        color:#3dcc91; }
+  .bp3-callout.bp3-intent-warning{
+    background-color:rgba(217, 130, 43, 0.15); }
+    .bp3-callout.bp3-intent-warning[class*="bp3-icon-"]::before,
+    .bp3-callout.bp3-intent-warning > .bp3-icon:first-child,
+    .bp3-callout.bp3-intent-warning .bp3-heading{
+      color:#bf7326; }
+    .bp3-dark .bp3-callout.bp3-intent-warning{
+      background-color:rgba(217, 130, 43, 0.25); }
+      .bp3-dark .bp3-callout.bp3-intent-warning[class*="bp3-icon-"]::before,
+      .bp3-dark .bp3-callout.bp3-intent-warning > .bp3-icon:first-child,
+      .bp3-dark .bp3-callout.bp3-intent-warning .bp3-heading{
+        color:#ffb366; }
+  .bp3-callout.bp3-intent-danger{
+    background-color:rgba(219, 55, 55, 0.15); }
+    .bp3-callout.bp3-intent-danger[class*="bp3-icon-"]::before,
+    .bp3-callout.bp3-intent-danger > .bp3-icon:first-child,
+    .bp3-callout.bp3-intent-danger .bp3-heading{
+      color:#c23030; }
+    .bp3-dark .bp3-callout.bp3-intent-danger{
+      background-color:rgba(219, 55, 55, 0.25); }
+      .bp3-dark .bp3-callout.bp3-intent-danger[class*="bp3-icon-"]::before,
+      .bp3-dark .bp3-callout.bp3-intent-danger > .bp3-icon:first-child,
+      .bp3-dark .bp3-callout.bp3-intent-danger .bp3-heading{
+        color:#ff7373; }
+  .bp3-running-text .bp3-callout{
+    margin:20px 0; }
+.bp3-card{
+  border-radius:3px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+  background-color:#ffffff;
+  padding:20px;
+  -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+  .bp3-card.bp3-dark,
+  .bp3-dark .bp3-card{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+    background-color:#30404d; }
+
+.bp3-elevation-0{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0); }
+  .bp3-elevation-0.bp3-dark,
+  .bp3-dark .bp3-elevation-0{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0); }
+
+.bp3-elevation-1{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-elevation-1.bp3-dark,
+  .bp3-dark .bp3-elevation-1{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
+
+.bp3-elevation-2{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 1px 1px rgba(16, 22, 26, 0.2), 0 2px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 1px 1px rgba(16, 22, 26, 0.2), 0 2px 6px rgba(16, 22, 26, 0.2); }
+  .bp3-elevation-2.bp3-dark,
+  .bp3-dark .bp3-elevation-2{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.4), 0 2px 6px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.4), 0 2px 6px rgba(16, 22, 26, 0.4); }
+
+.bp3-elevation-3{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2); }
+  .bp3-elevation-3.bp3-dark,
+  .bp3-dark .bp3-elevation-3{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
+
+.bp3-elevation-4{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2); }
+  .bp3-elevation-4.bp3-dark,
+  .bp3-dark .bp3-elevation-4{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4); }
+
+.bp3-card.bp3-interactive:hover{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  cursor:pointer; }
+  .bp3-card.bp3-interactive:hover.bp3-dark,
+  .bp3-dark .bp3-card.bp3-interactive:hover{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
+
+.bp3-card.bp3-interactive:active{
+  opacity:0.9;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+  -webkit-transition-duration:0;
+          transition-duration:0; }
+  .bp3-card.bp3-interactive:active.bp3-dark,
+  .bp3-dark .bp3-card.bp3-interactive:active{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
+
+.bp3-collapse{
+  height:0;
+  overflow-y:hidden;
+  -webkit-transition:height 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:height 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+  .bp3-collapse .bp3-collapse-body{
+    -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+    .bp3-collapse .bp3-collapse-body[aria-hidden="true"]{
+      display:none; }
+
+.bp3-context-menu .bp3-popover-target{
+  display:block; }
+
+.bp3-context-menu-popover-target{
+  position:fixed; }
+
+.bp3-divider{
+  margin:5px;
+  border-right:1px solid rgba(16, 22, 26, 0.15);
+  border-bottom:1px solid rgba(16, 22, 26, 0.15); }
+  .bp3-dark .bp3-divider{
+    border-color:rgba(16, 22, 26, 0.4); }
+.bp3-dialog-container{
+  opacity:1;
+  -webkit-transform:scale(1);
+          transform:scale(1);
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  width:100%;
+  min-height:100%;
+  pointer-events:none;
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-dialog-container.bp3-overlay-enter > .bp3-dialog, .bp3-dialog-container.bp3-overlay-appear > .bp3-dialog{
+    opacity:0;
+    -webkit-transform:scale(0.5);
+            transform:scale(0.5); }
+  .bp3-dialog-container.bp3-overlay-enter-active > .bp3-dialog, .bp3-dialog-container.bp3-overlay-appear-active > .bp3-dialog{
+    opacity:1;
+    -webkit-transform:scale(1);
+            transform:scale(1);
+    -webkit-transition-property:opacity, -webkit-transform;
+    transition-property:opacity, -webkit-transform;
+    transition-property:opacity, transform;
+    transition-property:opacity, transform, -webkit-transform;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
+    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-dialog-container.bp3-overlay-exit > .bp3-dialog{
+    opacity:1;
+    -webkit-transform:scale(1);
+            transform:scale(1); }
+  .bp3-dialog-container.bp3-overlay-exit-active > .bp3-dialog{
+    opacity:0;
+    -webkit-transform:scale(0.5);
+            transform:scale(0.5);
+    -webkit-transition-property:opacity, -webkit-transform;
+    transition-property:opacity, -webkit-transform;
+    transition-property:opacity, transform;
+    transition-property:opacity, transform, -webkit-transform;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
+    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+
+.bp3-dialog{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+          flex-direction:column;
+  margin:30px 0;
+  border-radius:6px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  background:#ebf1f5;
+  width:500px;
+  padding-bottom:20px;
+  pointer-events:all;
+  -webkit-user-select:text;
+     -moz-user-select:text;
+      -ms-user-select:text;
+          user-select:text; }
+  .bp3-dialog:focus{
+    outline:0; }
+  .bp3-dialog.bp3-dark,
+  .bp3-dark .bp3-dialog{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+    background:#293742;
+    color:#f5f8fa; }
+
+.bp3-dialog-header{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+          flex:0 0 auto;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  border-radius:6px 6px 0 0;
+  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+  background:#ffffff;
+  min-height:40px;
+  padding-right:5px;
+  padding-left:20px; }
+  .bp3-dialog-header .bp3-icon-large,
+  .bp3-dialog-header .bp3-icon{
+    -webkit-box-flex:0;
+        -ms-flex:0 0 auto;
+            flex:0 0 auto;
+    margin-right:10px;
+    color:#5c7080; }
+  .bp3-dialog-header .bp3-heading{
+    overflow:hidden;
+    text-overflow:ellipsis;
+    white-space:nowrap;
+    word-wrap:normal;
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto;
+    margin:0;
+    line-height:inherit; }
+    .bp3-dialog-header .bp3-heading:last-child{
+      margin-right:20px; }
+  .bp3-dark .bp3-dialog-header{
+    -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
+            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
+    background:#30404d; }
+    .bp3-dark .bp3-dialog-header .bp3-icon-large,
+    .bp3-dark .bp3-dialog-header .bp3-icon{
+      color:#a7b6c2; }
+
+.bp3-dialog-body{
+  -webkit-box-flex:1;
+      -ms-flex:1 1 auto;
+          flex:1 1 auto;
+  margin:20px;
+  line-height:18px; }
+
+.bp3-dialog-footer{
+  -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+          flex:0 0 auto;
+  margin:0 20px; }
+
+.bp3-dialog-footer-actions{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-pack:end;
+      -ms-flex-pack:end;
+          justify-content:flex-end; }
+  .bp3-dialog-footer-actions .bp3-button{
+    margin-left:10px; }
+.bp3-drawer{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+          flex-direction:column;
+  margin:0;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  background:#ffffff;
+  padding:0; }
+  .bp3-drawer:focus{
+    outline:0; }
+  .bp3-drawer.bp3-position-top{
+    top:0;
+    right:0;
+    left:0;
+    height:50%; }
+    .bp3-drawer.bp3-position-top.bp3-overlay-enter, .bp3-drawer.bp3-position-top.bp3-overlay-appear{
+      -webkit-transform:translateY(-100%);
+              transform:translateY(-100%); }
+    .bp3-drawer.bp3-position-top.bp3-overlay-enter-active, .bp3-drawer.bp3-position-top.bp3-overlay-appear-active{
+      -webkit-transform:translateY(0);
+              transform:translateY(0);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+    .bp3-drawer.bp3-position-top.bp3-overlay-exit{
+      -webkit-transform:translateY(0);
+              transform:translateY(0); }
+    .bp3-drawer.bp3-position-top.bp3-overlay-exit-active{
+      -webkit-transform:translateY(-100%);
+              transform:translateY(-100%);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+  .bp3-drawer.bp3-position-bottom{
+    right:0;
+    bottom:0;
+    left:0;
+    height:50%; }
+    .bp3-drawer.bp3-position-bottom.bp3-overlay-enter, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear{
+      -webkit-transform:translateY(100%);
+              transform:translateY(100%); }
+    .bp3-drawer.bp3-position-bottom.bp3-overlay-enter-active, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear-active{
+      -webkit-transform:translateY(0);
+              transform:translateY(0);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+    .bp3-drawer.bp3-position-bottom.bp3-overlay-exit{
+      -webkit-transform:translateY(0);
+              transform:translateY(0); }
+    .bp3-drawer.bp3-position-bottom.bp3-overlay-exit-active{
+      -webkit-transform:translateY(100%);
+              transform:translateY(100%);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+  .bp3-drawer.bp3-position-left{
+    top:0;
+    bottom:0;
+    left:0;
+    width:50%; }
+    .bp3-drawer.bp3-position-left.bp3-overlay-enter, .bp3-drawer.bp3-position-left.bp3-overlay-appear{
+      -webkit-transform:translateX(-100%);
+              transform:translateX(-100%); }
+    .bp3-drawer.bp3-position-left.bp3-overlay-enter-active, .bp3-drawer.bp3-position-left.bp3-overlay-appear-active{
+      -webkit-transform:translateX(0);
+              transform:translateX(0);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+    .bp3-drawer.bp3-position-left.bp3-overlay-exit{
+      -webkit-transform:translateX(0);
+              transform:translateX(0); }
+    .bp3-drawer.bp3-position-left.bp3-overlay-exit-active{
+      -webkit-transform:translateX(-100%);
+              transform:translateX(-100%);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+  .bp3-drawer.bp3-position-right{
+    top:0;
+    right:0;
+    bottom:0;
+    width:50%; }
+    .bp3-drawer.bp3-position-right.bp3-overlay-enter, .bp3-drawer.bp3-position-right.bp3-overlay-appear{
+      -webkit-transform:translateX(100%);
+              transform:translateX(100%); }
+    .bp3-drawer.bp3-position-right.bp3-overlay-enter-active, .bp3-drawer.bp3-position-right.bp3-overlay-appear-active{
+      -webkit-transform:translateX(0);
+              transform:translateX(0);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+    .bp3-drawer.bp3-position-right.bp3-overlay-exit{
+      -webkit-transform:translateX(0);
+              transform:translateX(0); }
+    .bp3-drawer.bp3-position-right.bp3-overlay-exit-active{
+      -webkit-transform:translateX(100%);
+              transform:translateX(100%);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+  .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+  .bp3-position-right):not(.bp3-vertical){
+    top:0;
+    right:0;
+    bottom:0;
+    width:50%; }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right):not(.bp3-vertical).bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right):not(.bp3-vertical).bp3-overlay-appear{
+      -webkit-transform:translateX(100%);
+              transform:translateX(100%); }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right):not(.bp3-vertical).bp3-overlay-enter-active, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right):not(.bp3-vertical).bp3-overlay-appear-active{
+      -webkit-transform:translateX(0);
+              transform:translateX(0);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit{
+      -webkit-transform:translateX(0);
+              transform:translateX(0); }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit-active{
+      -webkit-transform:translateX(100%);
+              transform:translateX(100%);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+  .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+  .bp3-position-right).bp3-vertical{
+    right:0;
+    bottom:0;
+    left:0;
+    height:50%; }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right).bp3-vertical.bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right).bp3-vertical.bp3-overlay-appear{
+      -webkit-transform:translateY(100%);
+              transform:translateY(100%); }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right).bp3-vertical.bp3-overlay-enter-active, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right).bp3-vertical.bp3-overlay-appear-active{
+      -webkit-transform:translateY(0);
+              transform:translateY(0);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right).bp3-vertical.bp3-overlay-exit{
+      -webkit-transform:translateY(0);
+              transform:translateY(0); }
+    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
+    .bp3-position-right).bp3-vertical.bp3-overlay-exit-active{
+      -webkit-transform:translateY(100%);
+              transform:translateY(100%);
+      -webkit-transition-property:-webkit-transform;
+      transition-property:-webkit-transform;
+      transition-property:transform;
+      transition-property:transform, -webkit-transform;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
+      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+      -webkit-transition-delay:0;
+              transition-delay:0; }
+  .bp3-drawer.bp3-dark,
+  .bp3-dark .bp3-drawer{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+    background:#30404d;
+    color:#f5f8fa; }
+
+.bp3-drawer-header{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+          flex:0 0 auto;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  position:relative;
+  border-radius:0;
+  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+  min-height:40px;
+  padding:5px;
+  padding-left:20px; }
+  .bp3-drawer-header .bp3-icon-large,
+  .bp3-drawer-header .bp3-icon{
+    -webkit-box-flex:0;
+        -ms-flex:0 0 auto;
+            flex:0 0 auto;
+    margin-right:10px;
+    color:#5c7080; }
+  .bp3-drawer-header .bp3-heading{
+    overflow:hidden;
+    text-overflow:ellipsis;
+    white-space:nowrap;
+    word-wrap:normal;
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto;
+    margin:0;
+    line-height:inherit; }
+    .bp3-drawer-header .bp3-heading:last-child{
+      margin-right:20px; }
+  .bp3-dark .bp3-drawer-header{
+    -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
+            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-drawer-header .bp3-icon-large,
+    .bp3-dark .bp3-drawer-header .bp3-icon{
+      color:#a7b6c2; }
+
+.bp3-drawer-body{
+  -webkit-box-flex:1;
+      -ms-flex:1 1 auto;
+          flex:1 1 auto;
+  overflow:auto;
+  line-height:18px; }
+
+.bp3-drawer-footer{
+  -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+          flex:0 0 auto;
+  position:relative;
+  -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
+  padding:10px 20px; }
+  .bp3-dark .bp3-drawer-footer{
+    -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4);
+            box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4); }
+.bp3-editable-text{
+  display:inline-block;
+  position:relative;
+  cursor:text;
+  max-width:100%;
+  vertical-align:top;
+  white-space:nowrap; }
+  .bp3-editable-text::before{
+    position:absolute;
+    top:-3px;
+    right:-3px;
+    bottom:-3px;
+    left:-3px;
+    border-radius:3px;
+    content:"";
+    -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+  .bp3-editable-text:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
+  .bp3-editable-text.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+    background-color:#ffffff; }
+  .bp3-editable-text.bp3-disabled::before{
+    -webkit-box-shadow:none;
+            box-shadow:none; }
+  .bp3-editable-text.bp3-intent-primary .bp3-editable-text-input,
+  .bp3-editable-text.bp3-intent-primary .bp3-editable-text-content{
+    color:#137cbd; }
+  .bp3-editable-text.bp3-intent-primary:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(19, 124, 189, 0.4);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(19, 124, 189, 0.4); }
+  .bp3-editable-text.bp3-intent-primary.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-editable-text.bp3-intent-success .bp3-editable-text-input,
+  .bp3-editable-text.bp3-intent-success .bp3-editable-text-content{
+    color:#0f9960; }
+  .bp3-editable-text.bp3-intent-success:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px rgba(15, 153, 96, 0.4);
+            box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px rgba(15, 153, 96, 0.4); }
+  .bp3-editable-text.bp3-intent-success.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-editable-text.bp3-intent-warning .bp3-editable-text-input,
+  .bp3-editable-text.bp3-intent-warning .bp3-editable-text-content{
+    color:#d9822b; }
+  .bp3-editable-text.bp3-intent-warning:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px rgba(217, 130, 43, 0.4);
+            box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px rgba(217, 130, 43, 0.4); }
+  .bp3-editable-text.bp3-intent-warning.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-editable-text.bp3-intent-danger .bp3-editable-text-input,
+  .bp3-editable-text.bp3-intent-danger .bp3-editable-text-content{
+    color:#db3737; }
+  .bp3-editable-text.bp3-intent-danger:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px rgba(219, 55, 55, 0.4);
+            box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px rgba(219, 55, 55, 0.4); }
+  .bp3-editable-text.bp3-intent-danger.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-dark .bp3-editable-text:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15); }
+  .bp3-dark .bp3-editable-text.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+    background-color:rgba(16, 22, 26, 0.3); }
+  .bp3-dark .bp3-editable-text.bp3-disabled::before{
+    -webkit-box-shadow:none;
+            box-shadow:none; }
+  .bp3-dark .bp3-editable-text.bp3-intent-primary .bp3-editable-text-content{
+    color:#48aff0; }
+  .bp3-dark .bp3-editable-text.bp3-intent-primary:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(72, 175, 240, 0), 0 0 0 0 rgba(72, 175, 240, 0), inset 0 0 0 1px rgba(72, 175, 240, 0.4);
+            box-shadow:0 0 0 0 rgba(72, 175, 240, 0), 0 0 0 0 rgba(72, 175, 240, 0), inset 0 0 0 1px rgba(72, 175, 240, 0.4); }
+  .bp3-dark .bp3-editable-text.bp3-intent-primary.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #48aff0, 0 0 0 3px rgba(72, 175, 240, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px #48aff0, 0 0 0 3px rgba(72, 175, 240, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-editable-text.bp3-intent-success .bp3-editable-text-content{
+    color:#3dcc91; }
+  .bp3-dark .bp3-editable-text.bp3-intent-success:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(61, 204, 145, 0), 0 0 0 0 rgba(61, 204, 145, 0), inset 0 0 0 1px rgba(61, 204, 145, 0.4);
+            box-shadow:0 0 0 0 rgba(61, 204, 145, 0), 0 0 0 0 rgba(61, 204, 145, 0), inset 0 0 0 1px rgba(61, 204, 145, 0.4); }
+  .bp3-dark .bp3-editable-text.bp3-intent-success.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #3dcc91, 0 0 0 3px rgba(61, 204, 145, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px #3dcc91, 0 0 0 3px rgba(61, 204, 145, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-editable-text.bp3-intent-warning .bp3-editable-text-content{
+    color:#ffb366; }
+  .bp3-dark .bp3-editable-text.bp3-intent-warning:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(255, 179, 102, 0), 0 0 0 0 rgba(255, 179, 102, 0), inset 0 0 0 1px rgba(255, 179, 102, 0.4);
+            box-shadow:0 0 0 0 rgba(255, 179, 102, 0), 0 0 0 0 rgba(255, 179, 102, 0), inset 0 0 0 1px rgba(255, 179, 102, 0.4); }
+  .bp3-dark .bp3-editable-text.bp3-intent-warning.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #ffb366, 0 0 0 3px rgba(255, 179, 102, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px #ffb366, 0 0 0 3px rgba(255, 179, 102, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-editable-text.bp3-intent-danger .bp3-editable-text-content{
+    color:#ff7373; }
+  .bp3-dark .bp3-editable-text.bp3-intent-danger:hover::before{
+    -webkit-box-shadow:0 0 0 0 rgba(255, 115, 115, 0), 0 0 0 0 rgba(255, 115, 115, 0), inset 0 0 0 1px rgba(255, 115, 115, 0.4);
+            box-shadow:0 0 0 0 rgba(255, 115, 115, 0), 0 0 0 0 rgba(255, 115, 115, 0), inset 0 0 0 1px rgba(255, 115, 115, 0.4); }
+  .bp3-dark .bp3-editable-text.bp3-intent-danger.bp3-editable-text-editing::before{
+    -webkit-box-shadow:0 0 0 1px #ff7373, 0 0 0 3px rgba(255, 115, 115, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px #ff7373, 0 0 0 3px rgba(255, 115, 115, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+
+.bp3-editable-text-input,
+.bp3-editable-text-content{
+  display:inherit;
+  position:relative;
+  min-width:inherit;
+  max-width:inherit;
+  vertical-align:top;
+  text-transform:inherit;
+  letter-spacing:inherit;
+  color:inherit;
+  font:inherit;
+  resize:none; }
+
+.bp3-editable-text-input{
+  border:none;
+  -webkit-box-shadow:none;
+          box-shadow:none;
+  background:none;
+  width:100%;
+  padding:0;
+  white-space:pre-wrap; }
+  .bp3-editable-text-input::-webkit-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-editable-text-input::-moz-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-editable-text-input:-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-editable-text-input::-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-editable-text-input::placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-editable-text-input:focus{
+    outline:none; }
+  .bp3-editable-text-input::-ms-clear{
+    display:none; }
+
+.bp3-editable-text-content{
+  overflow:hidden;
+  padding-right:2px;
+  text-overflow:ellipsis;
+  white-space:pre; }
+  .bp3-editable-text-editing > .bp3-editable-text-content{
+    position:absolute;
+    left:0;
+    visibility:hidden; }
+  .bp3-editable-text-placeholder > .bp3-editable-text-content{
+    color:rgba(92, 112, 128, 0.6); }
+    .bp3-dark .bp3-editable-text-placeholder > .bp3-editable-text-content{
+      color:rgba(167, 182, 194, 0.6); }
+
+.bp3-editable-text.bp3-multiline{
+  display:block; }
+  .bp3-editable-text.bp3-multiline .bp3-editable-text-content{
+    overflow:auto;
+    white-space:pre-wrap;
+    word-wrap:break-word; }
+.bp3-control-group{
+  -webkit-transform:translateZ(0);
+          transform:translateZ(0);
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+  -webkit-box-align:stretch;
+      -ms-flex-align:stretch;
+          align-items:stretch; }
+  .bp3-control-group > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-control-group > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-control-group .bp3-button,
+  .bp3-control-group .bp3-html-select,
+  .bp3-control-group .bp3-input,
+  .bp3-control-group .bp3-select{
+    position:relative; }
+  .bp3-control-group .bp3-input{
+    z-index:2;
+    border-radius:inherit; }
+    .bp3-control-group .bp3-input:focus{
+      z-index:14;
+      border-radius:3px; }
+    .bp3-control-group .bp3-input[class*="bp3-intent"]{
+      z-index:13; }
+      .bp3-control-group .bp3-input[class*="bp3-intent"]:focus{
+        z-index:15; }
+    .bp3-control-group .bp3-input[readonly], .bp3-control-group .bp3-input:disabled, .bp3-control-group .bp3-input.bp3-disabled{
+      z-index:1; }
+  .bp3-control-group .bp3-input-group[class*="bp3-intent"] .bp3-input{
+    z-index:13; }
+    .bp3-control-group .bp3-input-group[class*="bp3-intent"] .bp3-input:focus{
+      z-index:15; }
+  .bp3-control-group .bp3-button,
+  .bp3-control-group .bp3-html-select select,
+  .bp3-control-group .bp3-select select{
+    -webkit-transform:translateZ(0);
+            transform:translateZ(0);
+    z-index:4;
+    border-radius:inherit; }
+    .bp3-control-group .bp3-button:focus,
+    .bp3-control-group .bp3-html-select select:focus,
+    .bp3-control-group .bp3-select select:focus{
+      z-index:5; }
+    .bp3-control-group .bp3-button:hover,
+    .bp3-control-group .bp3-html-select select:hover,
+    .bp3-control-group .bp3-select select:hover{
+      z-index:6; }
+    .bp3-control-group .bp3-button:active,
+    .bp3-control-group .bp3-html-select select:active,
+    .bp3-control-group .bp3-select select:active{
+      z-index:7; }
+    .bp3-control-group .bp3-button[readonly], .bp3-control-group .bp3-button:disabled, .bp3-control-group .bp3-button.bp3-disabled,
+    .bp3-control-group .bp3-html-select select[readonly],
+    .bp3-control-group .bp3-html-select select:disabled,
+    .bp3-control-group .bp3-html-select select.bp3-disabled,
+    .bp3-control-group .bp3-select select[readonly],
+    .bp3-control-group .bp3-select select:disabled,
+    .bp3-control-group .bp3-select select.bp3-disabled{
+      z-index:3; }
+    .bp3-control-group .bp3-button[class*="bp3-intent"],
+    .bp3-control-group .bp3-html-select select[class*="bp3-intent"],
+    .bp3-control-group .bp3-select select[class*="bp3-intent"]{
+      z-index:9; }
+      .bp3-control-group .bp3-button[class*="bp3-intent"]:focus,
+      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:focus,
+      .bp3-control-group .bp3-select select[class*="bp3-intent"]:focus{
+        z-index:10; }
+      .bp3-control-group .bp3-button[class*="bp3-intent"]:hover,
+      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:hover,
+      .bp3-control-group .bp3-select select[class*="bp3-intent"]:hover{
+        z-index:11; }
+      .bp3-control-group .bp3-button[class*="bp3-intent"]:active,
+      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:active,
+      .bp3-control-group .bp3-select select[class*="bp3-intent"]:active{
+        z-index:12; }
+      .bp3-control-group .bp3-button[class*="bp3-intent"][readonly], .bp3-control-group .bp3-button[class*="bp3-intent"]:disabled, .bp3-control-group .bp3-button[class*="bp3-intent"].bp3-disabled,
+      .bp3-control-group .bp3-html-select select[class*="bp3-intent"][readonly],
+      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:disabled,
+      .bp3-control-group .bp3-html-select select[class*="bp3-intent"].bp3-disabled,
+      .bp3-control-group .bp3-select select[class*="bp3-intent"][readonly],
+      .bp3-control-group .bp3-select select[class*="bp3-intent"]:disabled,
+      .bp3-control-group .bp3-select select[class*="bp3-intent"].bp3-disabled{
+        z-index:8; }
+  .bp3-control-group .bp3-input-group > .bp3-icon,
+  .bp3-control-group .bp3-input-group > .bp3-button,
+  .bp3-control-group .bp3-input-group > .bp3-input-action{
+    z-index:16; }
+  .bp3-control-group .bp3-select::after,
+  .bp3-control-group .bp3-html-select::after,
+  .bp3-control-group .bp3-select > .bp3-icon,
+  .bp3-control-group .bp3-html-select > .bp3-icon{
+    z-index:17; }
+  .bp3-control-group:not(.bp3-vertical) > *{
+    margin-right:-1px; }
+  .bp3-dark .bp3-control-group:not(.bp3-vertical) > *{
+    margin-right:0; }
+  .bp3-dark .bp3-control-group:not(.bp3-vertical) > .bp3-button + .bp3-button{
+    margin-left:1px; }
+  .bp3-control-group .bp3-popover-wrapper,
+  .bp3-control-group .bp3-popover-target{
+    border-radius:inherit; }
+  .bp3-control-group > :first-child{
+    border-radius:3px 0 0 3px; }
+  .bp3-control-group > :last-child{
+    margin-right:0;
+    border-radius:0 3px 3px 0; }
+  .bp3-control-group > :only-child{
+    margin-right:0;
+    border-radius:3px; }
+  .bp3-control-group .bp3-input-group .bp3-button{
+    border-radius:3px; }
+  .bp3-control-group > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto; }
+  .bp3-control-group.bp3-fill > *:not(.bp3-fixed){
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto; }
+  .bp3-control-group.bp3-vertical{
+    -webkit-box-orient:vertical;
+    -webkit-box-direction:normal;
+        -ms-flex-direction:column;
+            flex-direction:column; }
+    .bp3-control-group.bp3-vertical > *{
+      margin-top:-1px; }
+    .bp3-control-group.bp3-vertical > :first-child{
+      margin-top:0;
+      border-radius:3px 3px 0 0; }
+    .bp3-control-group.bp3-vertical > :last-child{
+      border-radius:0 0 3px 3px; }
+.bp3-control{
+  display:block;
+  position:relative;
+  margin-bottom:10px;
+  cursor:pointer;
+  text-transform:none; }
+  .bp3-control input:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#137cbd;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    color:#ffffff; }
+  .bp3-control:hover input:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#106ba3; }
+  .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background:#0e5a8a; }
+  .bp3-control input:disabled:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(19, 124, 189, 0.5); }
+  .bp3-dark .bp3-control input:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-control:hover input:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+    background-color:#106ba3; }
+  .bp3-dark .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background-color:#0e5a8a; }
+  .bp3-dark .bp3-control input:disabled:checked ~ .bp3-control-indicator{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(14, 90, 138, 0.5); }
+  .bp3-control:not(.bp3-align-right){
+    padding-left:26px; }
+    .bp3-control:not(.bp3-align-right) .bp3-control-indicator{
+      margin-left:-26px; }
+  .bp3-control.bp3-align-right{
+    padding-right:26px; }
+    .bp3-control.bp3-align-right .bp3-control-indicator{
+      margin-right:-26px; }
+  .bp3-control.bp3-disabled{
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-control.bp3-inline{
+    display:inline-block;
+    margin-right:20px; }
+  .bp3-control input{
+    position:absolute;
+    top:0;
+    left:0;
+    opacity:0;
+    z-index:-1; }
+  .bp3-control .bp3-control-indicator{
+    display:inline-block;
+    position:relative;
+    margin-top:-3px;
+    margin-right:10px;
+    border:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+    background-clip:padding-box;
+    background-color:#f5f8fa;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    cursor:pointer;
+    width:1em;
+    height:1em;
+    vertical-align:middle;
+    font-size:16px;
+    -webkit-user-select:none;
+       -moz-user-select:none;
+        -ms-user-select:none;
+            user-select:none; }
+    .bp3-control .bp3-control-indicator::before{
+      display:block;
+      width:1em;
+      height:1em;
+      content:""; }
+  .bp3-control:hover .bp3-control-indicator{
+    background-color:#ebf1f5; }
+  .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background:#d8e1e8; }
+  .bp3-control input:disabled ~ .bp3-control-indicator{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(206, 217, 224, 0.5);
+    cursor:not-allowed; }
+  .bp3-control input:focus ~ .bp3-control-indicator{
+    outline:rgba(19, 124, 189, 0.6) auto 2px;
+    outline-offset:2px;
+    -moz-outline-radius:6px; }
+  .bp3-control.bp3-align-right .bp3-control-indicator{
+    float:right;
+    margin-top:1px;
+    margin-left:10px; }
+  .bp3-control.bp3-large{
+    font-size:16px; }
+    .bp3-control.bp3-large:not(.bp3-align-right){
+      padding-left:30px; }
+      .bp3-control.bp3-large:not(.bp3-align-right) .bp3-control-indicator{
+        margin-left:-30px; }
+    .bp3-control.bp3-large.bp3-align-right{
+      padding-right:30px; }
+      .bp3-control.bp3-large.bp3-align-right .bp3-control-indicator{
+        margin-right:-30px; }
+    .bp3-control.bp3-large .bp3-control-indicator{
+      font-size:20px; }
+    .bp3-control.bp3-large.bp3-align-right .bp3-control-indicator{
+      margin-top:0; }
+  .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#137cbd;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    color:#ffffff; }
+  .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+    background-color:#106ba3; }
+  .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background:#0e5a8a; }
+  .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(19, 124, 189, 0.5); }
+  .bp3-dark .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+    background-color:#106ba3; }
+  .bp3-dark .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background-color:#0e5a8a; }
+  .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(14, 90, 138, 0.5); }
+  .bp3-control.bp3-checkbox .bp3-control-indicator{
+    border-radius:3px; }
+  .bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator::before{
+    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='white'/%3e%3c/svg%3e"); }
+  .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator::before{
+    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M11 7H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z' fill='white'/%3e%3c/svg%3e"); }
+  .bp3-control.bp3-radio .bp3-control-indicator{
+    border-radius:50%; }
+  .bp3-control.bp3-radio input:checked ~ .bp3-control-indicator::before{
+    background-image:radial-gradient(#ffffff, #ffffff 28%, transparent 32%); }
+  .bp3-control.bp3-radio input:checked:disabled ~ .bp3-control-indicator::before{
+    opacity:0.5; }
+  .bp3-control.bp3-radio input:focus ~ .bp3-control-indicator{
+    -moz-outline-radius:16px; }
+  .bp3-control.bp3-switch input ~ .bp3-control-indicator{
+    background:rgba(167, 182, 194, 0.5); }
+  .bp3-control.bp3-switch:hover input ~ .bp3-control-indicator{
+    background:rgba(115, 134, 148, 0.5); }
+  .bp3-control.bp3-switch input:not(:disabled):active ~ .bp3-control-indicator{
+    background:rgba(92, 112, 128, 0.5); }
+  .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator{
+    background:rgba(206, 217, 224, 0.5); }
+    .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator::before{
+      background:rgba(255, 255, 255, 0.8); }
+  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator{
+    background:#137cbd; }
+  .bp3-control.bp3-switch:hover input:checked ~ .bp3-control-indicator{
+    background:#106ba3; }
+  .bp3-control.bp3-switch input:checked:not(:disabled):active ~ .bp3-control-indicator{
+    background:#0e5a8a; }
+  .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator{
+    background:rgba(19, 124, 189, 0.5); }
+    .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator::before{
+      background:rgba(255, 255, 255, 0.8); }
+  .bp3-control.bp3-switch:not(.bp3-align-right){
+    padding-left:38px; }
+    .bp3-control.bp3-switch:not(.bp3-align-right) .bp3-control-indicator{
+      margin-left:-38px; }
+  .bp3-control.bp3-switch.bp3-align-right{
+    padding-right:38px; }
+    .bp3-control.bp3-switch.bp3-align-right .bp3-control-indicator{
+      margin-right:-38px; }
+  .bp3-control.bp3-switch .bp3-control-indicator{
+    border:none;
+    border-radius:1.75em;
+    -webkit-box-shadow:none !important;
+            box-shadow:none !important;
+    width:auto;
+    min-width:1.75em;
+    -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+    .bp3-control.bp3-switch .bp3-control-indicator::before{
+      position:absolute;
+      left:0;
+      margin:2px;
+      border-radius:50%;
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+      background:#ffffff;
+      width:calc(1em - 4px);
+      height:calc(1em - 4px);
+      -webkit-transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+      transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
+    left:calc(100% - 1em); }
+  .bp3-control.bp3-switch.bp3-large:not(.bp3-align-right){
+    padding-left:45px; }
+    .bp3-control.bp3-switch.bp3-large:not(.bp3-align-right) .bp3-control-indicator{
+      margin-left:-45px; }
+  .bp3-control.bp3-switch.bp3-large.bp3-align-right{
+    padding-right:45px; }
+    .bp3-control.bp3-switch.bp3-large.bp3-align-right .bp3-control-indicator{
+      margin-right:-45px; }
+  .bp3-dark .bp3-control.bp3-switch input ~ .bp3-control-indicator{
+    background:rgba(16, 22, 26, 0.5); }
+  .bp3-dark .bp3-control.bp3-switch:hover input ~ .bp3-control-indicator{
+    background:rgba(16, 22, 26, 0.7); }
+  .bp3-dark .bp3-control.bp3-switch input:not(:disabled):active ~ .bp3-control-indicator{
+    background:rgba(16, 22, 26, 0.9); }
+  .bp3-dark .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator{
+    background:rgba(57, 75, 89, 0.5); }
+    .bp3-dark .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator::before{
+      background:rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator{
+    background:#137cbd; }
+  .bp3-dark .bp3-control.bp3-switch:hover input:checked ~ .bp3-control-indicator{
+    background:#106ba3; }
+  .bp3-dark .bp3-control.bp3-switch input:checked:not(:disabled):active ~ .bp3-control-indicator{
+    background:#0e5a8a; }
+  .bp3-dark .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator{
+    background:rgba(14, 90, 138, 0.5); }
+    .bp3-dark .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator::before{
+      background:rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-control.bp3-switch .bp3-control-indicator::before{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+    background:#394b59; }
+  .bp3-dark .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
+  .bp3-control.bp3-switch .bp3-switch-inner-text{
+    text-align:center;
+    font-size:0.7em; }
+  .bp3-control.bp3-switch .bp3-control-indicator-child:first-child{
+    visibility:hidden;
+    margin-right:1.2em;
+    margin-left:0.5em;
+    line-height:0; }
+  .bp3-control.bp3-switch .bp3-control-indicator-child:last-child{
+    visibility:visible;
+    margin-right:0.5em;
+    margin-left:1.2em;
+    line-height:1em; }
+  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:first-child{
+    visibility:visible;
+    line-height:1em; }
+  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:last-child{
+    visibility:hidden;
+    line-height:0; }
+  .bp3-dark .bp3-control{
+    color:#f5f8fa; }
+    .bp3-dark .bp3-control.bp3-disabled{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-control .bp3-control-indicator{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+      background-color:#394b59;
+      background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
+      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0)); }
+    .bp3-dark .bp3-control:hover .bp3-control-indicator{
+      background-color:#30404d; }
+    .bp3-dark .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background:#202b33; }
+    .bp3-dark .bp3-control input:disabled ~ .bp3-control-indicator{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(57, 75, 89, 0.5);
+      cursor:not-allowed; }
+    .bp3-dark .bp3-control.bp3-checkbox input:disabled:checked ~ .bp3-control-indicator, .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
+      color:rgba(167, 182, 194, 0.6); }
+.bp3-file-input{
+  display:inline-block;
+  position:relative;
+  cursor:pointer;
+  height:30px; }
+  .bp3-file-input input{
+    opacity:0;
+    margin:0;
+    min-width:200px; }
+    .bp3-file-input input:disabled + .bp3-file-upload-input,
+    .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(206, 217, 224, 0.5);
+      cursor:not-allowed;
+      color:rgba(92, 112, 128, 0.6);
+      resize:none; }
+      .bp3-file-input input:disabled + .bp3-file-upload-input::after,
+      .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
+        outline:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background-color:rgba(206, 217, 224, 0.5);
+        background-image:none;
+        cursor:not-allowed;
+        color:rgba(92, 112, 128, 0.6); }
+        .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active:hover,
+        .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active,
+        .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active:hover{
+          background:rgba(206, 217, 224, 0.7); }
+      .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input, .bp3-dark
+      .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background:rgba(57, 75, 89, 0.5);
+        color:rgba(167, 182, 194, 0.6); }
+        .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after, .bp3-dark
+        .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
+          -webkit-box-shadow:none;
+                  box-shadow:none;
+          background-color:rgba(57, 75, 89, 0.5);
+          background-image:none;
+          color:rgba(167, 182, 194, 0.6); }
+          .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-dark
+          .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active{
+            background:rgba(57, 75, 89, 0.7); }
+  .bp3-file-input.bp3-file-input-has-selection .bp3-file-upload-input{
+    color:#182026; }
+  .bp3-dark .bp3-file-input.bp3-file-input-has-selection .bp3-file-upload-input{
+    color:#f5f8fa; }
+  .bp3-file-input.bp3-fill{
+    width:100%; }
+  .bp3-file-input.bp3-large,
+  .bp3-large .bp3-file-input{
+    height:40px; }
+  .bp3-file-input .bp3-file-upload-input-custom-text::after{
+    content:attr(bp3-button-text); }
+
+.bp3-file-upload-input{
+  outline:none;
+  border:none;
+  border-radius:3px;
+  -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  background:#ffffff;
+  height:30px;
+  padding:0 10px;
+  vertical-align:middle;
+  line-height:30px;
+  color:#182026;
+  font-size:14px;
+  font-weight:400;
+  -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-appearance:none;
+     -moz-appearance:none;
+          appearance:none;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  word-wrap:normal;
+  position:absolute;
+  top:0;
+  right:0;
+  left:0;
+  padding-right:80px;
+  color:rgba(92, 112, 128, 0.6);
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-file-upload-input::-webkit-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-file-upload-input::-moz-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-file-upload-input:-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-file-upload-input::-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-file-upload-input::placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-file-upload-input:focus, .bp3-file-upload-input.bp3-active{
+    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-file-upload-input[type="search"], .bp3-file-upload-input.bp3-round{
+    border-radius:30px;
+    -webkit-box-sizing:border-box;
+            box-sizing:border-box;
+    padding-left:10px; }
+  .bp3-file-upload-input[readonly]{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
+  .bp3-file-upload-input:disabled, .bp3-file-upload-input.bp3-disabled{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(206, 217, 224, 0.5);
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6);
+    resize:none; }
+  .bp3-file-upload-input::after{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+    background-color:#f5f8fa;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    color:#182026;
+    min-width:24px;
+    min-height:24px;
+    overflow:hidden;
+    text-overflow:ellipsis;
+    white-space:nowrap;
+    word-wrap:normal;
+    position:absolute;
+    top:0;
+    right:0;
+    margin:3px;
+    border-radius:3px;
+    width:70px;
+    text-align:center;
+    line-height:24px;
+    content:"Browse"; }
+    .bp3-file-upload-input::after:hover{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+      background-clip:padding-box;
+      background-color:#ebf1f5; }
+    .bp3-file-upload-input::after:active, .bp3-file-upload-input::after.bp3-active{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#d8e1e8;
+      background-image:none; }
+    .bp3-file-upload-input::after:disabled, .bp3-file-upload-input::after.bp3-disabled{
+      outline:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(206, 217, 224, 0.5);
+      background-image:none;
+      cursor:not-allowed;
+      color:rgba(92, 112, 128, 0.6); }
+      .bp3-file-upload-input::after:disabled.bp3-active, .bp3-file-upload-input::after:disabled.bp3-active:hover, .bp3-file-upload-input::after.bp3-disabled.bp3-active, .bp3-file-upload-input::after.bp3-disabled.bp3-active:hover{
+        background:rgba(206, 217, 224, 0.7); }
+  .bp3-file-upload-input:hover::after{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+    background-clip:padding-box;
+    background-color:#ebf1f5; }
+  .bp3-file-upload-input:active::after{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background-color:#d8e1e8;
+    background-image:none; }
+  .bp3-large .bp3-file-upload-input{
+    height:40px;
+    line-height:40px;
+    font-size:16px;
+    padding-right:95px; }
+    .bp3-large .bp3-file-upload-input[type="search"], .bp3-large .bp3-file-upload-input.bp3-round{
+      padding:0 15px; }
+    .bp3-large .bp3-file-upload-input::after{
+      min-width:30px;
+      min-height:30px;
+      margin:5px;
+      width:85px;
+      line-height:30px; }
+  .bp3-dark .bp3-file-upload-input{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+    background:rgba(16, 22, 26, 0.3);
+    color:#f5f8fa;
+    color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-file-upload-input::-webkit-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-file-upload-input::-moz-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-file-upload-input:-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-file-upload-input::-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-file-upload-input::placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-file-upload-input:focus{
+      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-file-upload-input[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-file-upload-input:disabled, .bp3-dark .bp3-file-upload-input.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(57, 75, 89, 0.5);
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-file-upload-input::after{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+      background-color:#394b59;
+      background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
+      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+      color:#f5f8fa; }
+      .bp3-dark .bp3-file-upload-input::after:hover, .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
+        color:#f5f8fa; }
+      .bp3-dark .bp3-file-upload-input::after:hover{
+        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+        background-color:#30404d; }
+      .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
+        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+        background-color:#202b33;
+        background-image:none; }
+      .bp3-dark .bp3-file-upload-input::after:disabled, .bp3-dark .bp3-file-upload-input::after.bp3-disabled{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background-color:rgba(57, 75, 89, 0.5);
+        background-image:none;
+        color:rgba(167, 182, 194, 0.6); }
+        .bp3-dark .bp3-file-upload-input::after:disabled.bp3-active, .bp3-dark .bp3-file-upload-input::after.bp3-disabled.bp3-active{
+          background:rgba(57, 75, 89, 0.7); }
+      .bp3-dark .bp3-file-upload-input::after .bp3-button-spinner .bp3-spinner-head{
+        background:rgba(16, 22, 26, 0.5);
+        stroke:#8a9ba8; }
+    .bp3-dark .bp3-file-upload-input:hover::after{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+      background-color:#30404d; }
+    .bp3-dark .bp3-file-upload-input:active::after{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#202b33;
+      background-image:none; }
+
+.bp3-file-upload-input::after{
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
+.bp3-form-group{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+          flex-direction:column;
+  margin:0 0 15px; }
+  .bp3-form-group label.bp3-label{
+    margin-bottom:5px; }
+  .bp3-form-group .bp3-control{
+    margin-top:7px; }
+  .bp3-form-group .bp3-form-helper-text{
+    margin-top:5px;
+    color:#5c7080;
+    font-size:12px; }
+  .bp3-form-group.bp3-intent-primary .bp3-form-helper-text{
+    color:#106ba3; }
+  .bp3-form-group.bp3-intent-success .bp3-form-helper-text{
+    color:#0d8050; }
+  .bp3-form-group.bp3-intent-warning .bp3-form-helper-text{
+    color:#bf7326; }
+  .bp3-form-group.bp3-intent-danger .bp3-form-helper-text{
+    color:#c23030; }
+  .bp3-form-group.bp3-inline{
+    -webkit-box-orient:horizontal;
+    -webkit-box-direction:normal;
+        -ms-flex-direction:row;
+            flex-direction:row;
+    -webkit-box-align:start;
+        -ms-flex-align:start;
+            align-items:flex-start; }
+    .bp3-form-group.bp3-inline.bp3-large label.bp3-label{
+      margin:0 10px 0 0;
+      line-height:40px; }
+    .bp3-form-group.bp3-inline label.bp3-label{
+      margin:0 10px 0 0;
+      line-height:30px; }
+  .bp3-form-group.bp3-disabled .bp3-label,
+  .bp3-form-group.bp3-disabled .bp3-text-muted,
+  .bp3-form-group.bp3-disabled .bp3-form-helper-text{
+    color:rgba(92, 112, 128, 0.6) !important; }
+  .bp3-dark .bp3-form-group.bp3-intent-primary .bp3-form-helper-text{
+    color:#48aff0; }
+  .bp3-dark .bp3-form-group.bp3-intent-success .bp3-form-helper-text{
+    color:#3dcc91; }
+  .bp3-dark .bp3-form-group.bp3-intent-warning .bp3-form-helper-text{
+    color:#ffb366; }
+  .bp3-dark .bp3-form-group.bp3-intent-danger .bp3-form-helper-text{
+    color:#ff7373; }
+  .bp3-dark .bp3-form-group .bp3-form-helper-text{
+    color:#a7b6c2; }
+  .bp3-dark .bp3-form-group.bp3-disabled .bp3-label,
+  .bp3-dark .bp3-form-group.bp3-disabled .bp3-text-muted,
+  .bp3-dark .bp3-form-group.bp3-disabled .bp3-form-helper-text{
+    color:rgba(167, 182, 194, 0.6) !important; }
+.bp3-input-group{
+  display:block;
+  position:relative; }
+  .bp3-input-group .bp3-input{
+    position:relative;
+    width:100%; }
+    .bp3-input-group .bp3-input:not(:first-child){
+      padding-left:30px; }
+    .bp3-input-group .bp3-input:not(:last-child){
+      padding-right:30px; }
+  .bp3-input-group .bp3-input-action,
+  .bp3-input-group > .bp3-button,
+  .bp3-input-group > .bp3-icon{
+    position:absolute;
+    top:0; }
+    .bp3-input-group .bp3-input-action:first-child,
+    .bp3-input-group > .bp3-button:first-child,
+    .bp3-input-group > .bp3-icon:first-child{
+      left:0; }
+    .bp3-input-group .bp3-input-action:last-child,
+    .bp3-input-group > .bp3-button:last-child,
+    .bp3-input-group > .bp3-icon:last-child{
+      right:0; }
+  .bp3-input-group .bp3-button{
+    min-width:24px;
+    min-height:24px;
+    margin:3px;
+    padding:0 7px; }
+    .bp3-input-group .bp3-button:empty{
+      padding:0; }
+  .bp3-input-group > .bp3-icon{
+    z-index:1;
+    color:#5c7080; }
+    .bp3-input-group > .bp3-icon:empty{
+      line-height:1;
+      font-family:"Icons16", sans-serif;
+      font-size:16px;
+      font-weight:400;
+      font-style:normal;
+      -moz-osx-font-smoothing:grayscale;
+      -webkit-font-smoothing:antialiased; }
+  .bp3-input-group > .bp3-icon,
+  .bp3-input-group .bp3-input-action > .bp3-spinner{
+    margin:7px; }
+  .bp3-input-group .bp3-tag{
+    margin:5px; }
+  .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus),
+  .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus){
+    color:#5c7080; }
+    .bp3-dark .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus), .bp3-dark
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus){
+      color:#a7b6c2; }
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-standard, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-large,
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon,
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-standard,
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-large{
+      color:#5c7080; }
+  .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled,
+  .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled{
+    color:rgba(92, 112, 128, 0.6) !important; }
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled .bp3-icon, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled .bp3-icon-standard, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled .bp3-icon-large,
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled .bp3-icon,
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled .bp3-icon-standard,
+    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled .bp3-icon-large{
+      color:rgba(92, 112, 128, 0.6) !important; }
+  .bp3-input-group.bp3-disabled{
+    cursor:not-allowed; }
+    .bp3-input-group.bp3-disabled .bp3-icon{
+      color:rgba(92, 112, 128, 0.6); }
+  .bp3-input-group.bp3-large .bp3-button{
+    min-width:30px;
+    min-height:30px;
+    margin:5px; }
+  .bp3-input-group.bp3-large > .bp3-icon,
+  .bp3-input-group.bp3-large .bp3-input-action > .bp3-spinner{
+    margin:12px; }
+  .bp3-input-group.bp3-large .bp3-input{
+    height:40px;
+    line-height:40px;
+    font-size:16px; }
+    .bp3-input-group.bp3-large .bp3-input[type="search"], .bp3-input-group.bp3-large .bp3-input.bp3-round{
+      padding:0 15px; }
+    .bp3-input-group.bp3-large .bp3-input:not(:first-child){
+      padding-left:40px; }
+    .bp3-input-group.bp3-large .bp3-input:not(:last-child){
+      padding-right:40px; }
+  .bp3-input-group.bp3-small .bp3-button{
+    min-width:20px;
+    min-height:20px;
+    margin:2px; }
+  .bp3-input-group.bp3-small .bp3-tag{
+    min-width:20px;
+    min-height:20px;
+    margin:2px; }
+  .bp3-input-group.bp3-small > .bp3-icon,
+  .bp3-input-group.bp3-small .bp3-input-action > .bp3-spinner{
+    margin:4px; }
+  .bp3-input-group.bp3-small .bp3-input{
+    height:24px;
+    padding-right:8px;
+    padding-left:8px;
+    line-height:24px;
+    font-size:12px; }
+    .bp3-input-group.bp3-small .bp3-input[type="search"], .bp3-input-group.bp3-small .bp3-input.bp3-round{
+      padding:0 12px; }
+    .bp3-input-group.bp3-small .bp3-input:not(:first-child){
+      padding-left:24px; }
+    .bp3-input-group.bp3-small .bp3-input:not(:last-child){
+      padding-right:24px; }
+  .bp3-input-group.bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto;
+    width:100%; }
+  .bp3-input-group.bp3-round .bp3-button,
+  .bp3-input-group.bp3-round .bp3-input,
+  .bp3-input-group.bp3-round .bp3-tag{
+    border-radius:30px; }
+  .bp3-dark .bp3-input-group .bp3-icon{
+    color:#a7b6c2; }
+  .bp3-dark .bp3-input-group.bp3-disabled .bp3-icon{
+    color:rgba(167, 182, 194, 0.6); }
+  .bp3-input-group.bp3-intent-primary .bp3-input{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-primary .bp3-input:focus{
+      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-primary .bp3-input[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #137cbd;
+              box-shadow:inset 0 0 0 1px #137cbd; }
+    .bp3-input-group.bp3-intent-primary .bp3-input:disabled, .bp3-input-group.bp3-intent-primary .bp3-input.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-input-group.bp3-intent-primary > .bp3-icon{
+    color:#106ba3; }
+    .bp3-dark .bp3-input-group.bp3-intent-primary > .bp3-icon{
+      color:#48aff0; }
+  .bp3-input-group.bp3-intent-success .bp3-input{
+    -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-success .bp3-input:focus{
+      -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-success .bp3-input[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #0f9960;
+              box-shadow:inset 0 0 0 1px #0f9960; }
+    .bp3-input-group.bp3-intent-success .bp3-input:disabled, .bp3-input-group.bp3-intent-success .bp3-input.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-input-group.bp3-intent-success > .bp3-icon{
+    color:#0d8050; }
+    .bp3-dark .bp3-input-group.bp3-intent-success > .bp3-icon{
+      color:#3dcc91; }
+  .bp3-input-group.bp3-intent-warning .bp3-input{
+    -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-warning .bp3-input:focus{
+      -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-warning .bp3-input[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #d9822b;
+              box-shadow:inset 0 0 0 1px #d9822b; }
+    .bp3-input-group.bp3-intent-warning .bp3-input:disabled, .bp3-input-group.bp3-intent-warning .bp3-input.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-input-group.bp3-intent-warning > .bp3-icon{
+    color:#bf7326; }
+    .bp3-dark .bp3-input-group.bp3-intent-warning > .bp3-icon{
+      color:#ffb366; }
+  .bp3-input-group.bp3-intent-danger .bp3-input{
+    -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-danger .bp3-input:focus{
+      -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input-group.bp3-intent-danger .bp3-input[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #db3737;
+              box-shadow:inset 0 0 0 1px #db3737; }
+    .bp3-input-group.bp3-intent-danger .bp3-input:disabled, .bp3-input-group.bp3-intent-danger .bp3-input.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-input-group.bp3-intent-danger > .bp3-icon{
+    color:#c23030; }
+    .bp3-dark .bp3-input-group.bp3-intent-danger > .bp3-icon{
+      color:#ff7373; }
+.bp3-input{
+  outline:none;
+  border:none;
+  border-radius:3px;
+  -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  background:#ffffff;
+  height:30px;
+  padding:0 10px;
+  vertical-align:middle;
+  line-height:30px;
+  color:#182026;
+  font-size:14px;
+  font-weight:400;
+  -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-appearance:none;
+     -moz-appearance:none;
+          appearance:none; }
+  .bp3-input::-webkit-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input::-moz-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input:-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input::-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input::placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input:focus, .bp3-input.bp3-active{
+    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-input[type="search"], .bp3-input.bp3-round{
+    border-radius:30px;
+    -webkit-box-sizing:border-box;
+            box-sizing:border-box;
+    padding-left:10px; }
+  .bp3-input[readonly]{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
+  .bp3-input:disabled, .bp3-input.bp3-disabled{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(206, 217, 224, 0.5);
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6);
+    resize:none; }
+  .bp3-input.bp3-large{
+    height:40px;
+    line-height:40px;
+    font-size:16px; }
+    .bp3-input.bp3-large[type="search"], .bp3-input.bp3-large.bp3-round{
+      padding:0 15px; }
+  .bp3-input.bp3-small{
+    height:24px;
+    padding-right:8px;
+    padding-left:8px;
+    line-height:24px;
+    font-size:12px; }
+    .bp3-input.bp3-small[type="search"], .bp3-input.bp3-small.bp3-round{
+      padding:0 12px; }
+  .bp3-input.bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto;
+    width:100%; }
+  .bp3-dark .bp3-input{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+    background:rgba(16, 22, 26, 0.3);
+    color:#f5f8fa; }
+    .bp3-dark .bp3-input::-webkit-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-input::-moz-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-input:-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-input::-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-input::placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-input:focus{
+      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-input[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-input:disabled, .bp3-dark .bp3-input.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(57, 75, 89, 0.5);
+      color:rgba(167, 182, 194, 0.6); }
+  .bp3-input.bp3-intent-primary{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-primary:focus{
+      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-primary[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #137cbd;
+              box-shadow:inset 0 0 0 1px #137cbd; }
+    .bp3-input.bp3-intent-primary:disabled, .bp3-input.bp3-intent-primary.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+    .bp3-dark .bp3-input.bp3-intent-primary{
+      -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-primary:focus{
+        -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+                box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-primary[readonly]{
+        -webkit-box-shadow:inset 0 0 0 1px #137cbd;
+                box-shadow:inset 0 0 0 1px #137cbd; }
+      .bp3-dark .bp3-input.bp3-intent-primary:disabled, .bp3-dark .bp3-input.bp3-intent-primary.bp3-disabled{
+        -webkit-box-shadow:none;
+                box-shadow:none; }
+  .bp3-input.bp3-intent-success{
+    -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-success:focus{
+      -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-success[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #0f9960;
+              box-shadow:inset 0 0 0 1px #0f9960; }
+    .bp3-input.bp3-intent-success:disabled, .bp3-input.bp3-intent-success.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+    .bp3-dark .bp3-input.bp3-intent-success{
+      -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-success:focus{
+        -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+                box-shadow:0 0 0 1px #0f9960, 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-success[readonly]{
+        -webkit-box-shadow:inset 0 0 0 1px #0f9960;
+                box-shadow:inset 0 0 0 1px #0f9960; }
+      .bp3-dark .bp3-input.bp3-intent-success:disabled, .bp3-dark .bp3-input.bp3-intent-success.bp3-disabled{
+        -webkit-box-shadow:none;
+                box-shadow:none; }
+  .bp3-input.bp3-intent-warning{
+    -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-warning:focus{
+      -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-warning[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #d9822b;
+              box-shadow:inset 0 0 0 1px #d9822b; }
+    .bp3-input.bp3-intent-warning:disabled, .bp3-input.bp3-intent-warning.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+    .bp3-dark .bp3-input.bp3-intent-warning{
+      -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-warning:focus{
+        -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+                box-shadow:0 0 0 1px #d9822b, 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-warning[readonly]{
+        -webkit-box-shadow:inset 0 0 0 1px #d9822b;
+                box-shadow:inset 0 0 0 1px #d9822b; }
+      .bp3-dark .bp3-input.bp3-intent-warning:disabled, .bp3-dark .bp3-input.bp3-intent-warning.bp3-disabled{
+        -webkit-box-shadow:none;
+                box-shadow:none; }
+  .bp3-input.bp3-intent-danger{
+    -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-danger:focus{
+      -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-input.bp3-intent-danger[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px #db3737;
+              box-shadow:inset 0 0 0 1px #db3737; }
+    .bp3-input.bp3-intent-danger:disabled, .bp3-input.bp3-intent-danger.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+    .bp3-dark .bp3-input.bp3-intent-danger{
+      -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-danger:focus{
+        -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+                box-shadow:0 0 0 1px #db3737, 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+      .bp3-dark .bp3-input.bp3-intent-danger[readonly]{
+        -webkit-box-shadow:inset 0 0 0 1px #db3737;
+                box-shadow:inset 0 0 0 1px #db3737; }
+      .bp3-dark .bp3-input.bp3-intent-danger:disabled, .bp3-dark .bp3-input.bp3-intent-danger.bp3-disabled{
+        -webkit-box-shadow:none;
+                box-shadow:none; }
+  .bp3-input::-ms-clear{
+    display:none; }
+textarea.bp3-input{
+  max-width:100%;
+  padding:10px; }
+  textarea.bp3-input, textarea.bp3-input.bp3-large, textarea.bp3-input.bp3-small{
+    height:auto;
+    line-height:inherit; }
+  textarea.bp3-input.bp3-small{
+    padding:8px; }
+  .bp3-dark textarea.bp3-input{
+    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+    background:rgba(16, 22, 26, 0.3);
+    color:#f5f8fa; }
+    .bp3-dark textarea.bp3-input::-webkit-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark textarea.bp3-input::-moz-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark textarea.bp3-input:-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark textarea.bp3-input::-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark textarea.bp3-input::placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark textarea.bp3-input:focus{
+      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark textarea.bp3-input[readonly]{
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark textarea.bp3-input:disabled, .bp3-dark textarea.bp3-input.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:rgba(57, 75, 89, 0.5);
+      color:rgba(167, 182, 194, 0.6); }
+label.bp3-label{
+  display:block;
+  margin-top:0;
+  margin-bottom:15px; }
+  label.bp3-label .bp3-html-select,
+  label.bp3-label .bp3-input,
+  label.bp3-label .bp3-select,
+  label.bp3-label .bp3-slider,
+  label.bp3-label .bp3-popover-wrapper{
+    display:block;
+    margin-top:5px;
+    text-transform:none; }
+  label.bp3-label .bp3-button-group{
+    margin-top:5px; }
+  label.bp3-label .bp3-select select,
+  label.bp3-label .bp3-html-select select{
+    width:100%;
+    vertical-align:top;
+    font-weight:400; }
+  label.bp3-label.bp3-disabled,
+  label.bp3-label.bp3-disabled .bp3-text-muted{
+    color:rgba(92, 112, 128, 0.6); }
+  label.bp3-label.bp3-inline{
+    line-height:30px; }
+    label.bp3-label.bp3-inline .bp3-html-select,
+    label.bp3-label.bp3-inline .bp3-input,
+    label.bp3-label.bp3-inline .bp3-input-group,
+    label.bp3-label.bp3-inline .bp3-select,
+    label.bp3-label.bp3-inline .bp3-popover-wrapper{
+      display:inline-block;
+      margin:0 0 0 5px;
+      vertical-align:top; }
+    label.bp3-label.bp3-inline .bp3-button-group{
+      margin:0 0 0 5px; }
+    label.bp3-label.bp3-inline .bp3-input-group .bp3-input{
+      margin-left:0; }
+    label.bp3-label.bp3-inline.bp3-large{
+      line-height:40px; }
+  label.bp3-label:not(.bp3-inline) .bp3-popover-target{
+    display:block; }
+  .bp3-dark label.bp3-label{
+    color:#f5f8fa; }
+    .bp3-dark label.bp3-label.bp3-disabled,
+    .bp3-dark label.bp3-label.bp3-disabled .bp3-text-muted{
+      color:rgba(167, 182, 194, 0.6); }
+.bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button{
+  -webkit-box-flex:1;
+      -ms-flex:1 1 14px;
+          flex:1 1 14px;
+  width:30px;
+  min-height:0;
+  padding:0; }
+  .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:first-child{
+    border-radius:0 3px 0 0; }
+  .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:last-child{
+    border-radius:0 0 3px 0; }
+
+.bp3-numeric-input .bp3-button-group.bp3-vertical:first-child > .bp3-button:first-child{
+  border-radius:3px 0 0 0; }
+
+.bp3-numeric-input .bp3-button-group.bp3-vertical:first-child > .bp3-button:last-child{
+  border-radius:0 0 0 3px; }
+
+.bp3-numeric-input.bp3-large .bp3-button-group.bp3-vertical > .bp3-button{
+  width:40px; }
+
+form{
+  display:block; }
+.bp3-html-select select,
+.bp3-select select{
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  border:none;
+  border-radius:3px;
+  cursor:pointer;
+  padding:5px 10px;
+  vertical-align:middle;
+  text-align:left;
+  font-size:14px;
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-color:#f5f8fa;
+  background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
+  background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+  color:#182026;
+  border-radius:3px;
+  width:100%;
+  height:30px;
+  padding:0 25px 0 10px;
+  -moz-appearance:none;
+  -webkit-appearance:none; }
+  .bp3-html-select select > *, .bp3-select select > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-html-select select > .bp3-fill, .bp3-select select > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-html-select select::before,
+  .bp3-select select::before, .bp3-html-select select > *, .bp3-select select > *{
+    margin-right:7px; }
+  .bp3-html-select select:empty::before,
+  .bp3-select select:empty::before,
+  .bp3-html-select select > :last-child,
+  .bp3-select select > :last-child{
+    margin-right:0; }
+  .bp3-html-select select:hover,
+  .bp3-select select:hover{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+    background-clip:padding-box;
+    background-color:#ebf1f5; }
+  .bp3-html-select select:active,
+  .bp3-select select:active, .bp3-html-select select.bp3-active,
+  .bp3-select select.bp3-active{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background-color:#d8e1e8;
+    background-image:none; }
+  .bp3-html-select select:disabled,
+  .bp3-select select:disabled, .bp3-html-select select.bp3-disabled,
+  .bp3-select select.bp3-disabled{
+    outline:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background-color:rgba(206, 217, 224, 0.5);
+    background-image:none;
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6); }
+    .bp3-html-select select:disabled.bp3-active,
+    .bp3-select select:disabled.bp3-active, .bp3-html-select select:disabled.bp3-active:hover,
+    .bp3-select select:disabled.bp3-active:hover, .bp3-html-select select.bp3-disabled.bp3-active,
+    .bp3-select select.bp3-disabled.bp3-active, .bp3-html-select select.bp3-disabled.bp3-active:hover,
+    .bp3-select select.bp3-disabled.bp3-active:hover{
+      background:rgba(206, 217, 224, 0.7); }
+
+.bp3-html-select.bp3-minimal select,
+.bp3-select.bp3-minimal select{
+  -webkit-box-shadow:none;
+          box-shadow:none;
+  background:none; }
+  .bp3-html-select.bp3-minimal select:hover,
+  .bp3-select.bp3-minimal select:hover{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(167, 182, 194, 0.3);
+    text-decoration:none;
+    color:#182026; }
+  .bp3-html-select.bp3-minimal select:active,
+  .bp3-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal select.bp3-active,
+  .bp3-select.bp3-minimal select.bp3-active{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:rgba(115, 134, 148, 0.3);
+    color:#182026; }
+  .bp3-html-select.bp3-minimal select:disabled,
+  .bp3-select.bp3-minimal select:disabled, .bp3-html-select.bp3-minimal select:disabled:hover,
+  .bp3-select.bp3-minimal select:disabled:hover, .bp3-html-select.bp3-minimal select.bp3-disabled,
+  .bp3-select.bp3-minimal select.bp3-disabled, .bp3-html-select.bp3-minimal select.bp3-disabled:hover,
+  .bp3-select.bp3-minimal select.bp3-disabled:hover{
+    background:none;
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6); }
+    .bp3-html-select.bp3-minimal select:disabled.bp3-active,
+    .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active,
+    .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-disabled:hover.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-disabled:hover.bp3-active{
+      background:rgba(115, 134, 148, 0.3); }
+  .bp3-dark .bp3-html-select.bp3-minimal select, .bp3-html-select.bp3-minimal .bp3-dark select,
+  .bp3-dark .bp3-select.bp3-minimal select, .bp3-select.bp3-minimal .bp3-dark select{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:none;
+    color:inherit; }
+    .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
+    .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover, .bp3-dark .bp3-html-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal .bp3-dark select:active,
+    .bp3-dark .bp3-select.bp3-minimal select:active, .bp3-select.bp3-minimal .bp3-dark select:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-active{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:none; }
+    .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
+    .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover{
+      background:rgba(138, 155, 168, 0.15); }
+    .bp3-dark .bp3-html-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal .bp3-dark select:active,
+    .bp3-dark .bp3-select.bp3-minimal select:active, .bp3-select.bp3-minimal .bp3-dark select:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-active{
+      background:rgba(138, 155, 168, 0.3);
+      color:#f5f8fa; }
+    .bp3-dark .bp3-html-select.bp3-minimal select:disabled, .bp3-html-select.bp3-minimal .bp3-dark select:disabled,
+    .bp3-dark .bp3-select.bp3-minimal select:disabled, .bp3-select.bp3-minimal .bp3-dark select:disabled, .bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover, .bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover,
+    .bp3-dark .bp3-select.bp3-minimal select:disabled:hover, .bp3-select.bp3-minimal .bp3-dark select:disabled:hover, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover{
+      background:none;
+      cursor:not-allowed;
+      color:rgba(167, 182, 194, 0.6); }
+      .bp3-dark .bp3-html-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover.bp3-active{
+        background:rgba(138, 155, 168, 0.3); }
+  .bp3-html-select.bp3-minimal select.bp3-intent-primary,
+  .bp3-select.bp3-minimal select.bp3-intent-primary{
+    color:#106ba3; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
+    .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:none;
+      color:#106ba3; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-primary:hover{
+      background:rgba(19, 124, 189, 0.15);
+      color:#106ba3; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
+    .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active{
+      background:rgba(19, 124, 189, 0.3);
+      color:#106ba3; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-primary:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled{
+      background:none;
+      color:rgba(16, 107, 163, 0.5); }
+      .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active{
+        background:rgba(19, 124, 189, 0.3); }
+    .bp3-html-select.bp3-minimal select.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
+      stroke:#106ba3; }
+    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary{
+      color:#48aff0; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:hover,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:hover{
+        background:rgba(19, 124, 189, 0.2);
+        color:#48aff0; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-active{
+        background:rgba(19, 124, 189, 0.3);
+        color:#48aff0; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled{
+        background:none;
+        color:rgba(72, 175, 240, 0.5); }
+        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled.bp3-active{
+          background:rgba(19, 124, 189, 0.3); }
+  .bp3-html-select.bp3-minimal select.bp3-intent-success,
+  .bp3-select.bp3-minimal select.bp3-intent-success{
+    color:#0d8050; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-success:hover, .bp3-html-select.bp3-minimal select.bp3-intent-success:active,
+    .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:none;
+      color:#0d8050; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-success:hover{
+      background:rgba(15, 153, 96, 0.15);
+      color:#0d8050; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-success:active,
+    .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active{
+      background:rgba(15, 153, 96, 0.3);
+      color:#0d8050; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-success:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled{
+      background:none;
+      color:rgba(13, 128, 80, 0.5); }
+      .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active{
+        background:rgba(15, 153, 96, 0.3); }
+    .bp3-html-select.bp3-minimal select.bp3-intent-success .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
+      stroke:#0d8050; }
+    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success{
+      color:#3dcc91; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:hover,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:hover{
+        background:rgba(15, 153, 96, 0.2);
+        color:#3dcc91; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-active{
+        background:rgba(15, 153, 96, 0.3);
+        color:#3dcc91; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled{
+        background:none;
+        color:rgba(61, 204, 145, 0.5); }
+        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled.bp3-active{
+          background:rgba(15, 153, 96, 0.3); }
+  .bp3-html-select.bp3-minimal select.bp3-intent-warning,
+  .bp3-select.bp3-minimal select.bp3-intent-warning{
+    color:#bf7326; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
+    .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:none;
+      color:#bf7326; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-warning:hover{
+      background:rgba(217, 130, 43, 0.15);
+      color:#bf7326; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
+    .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active{
+      background:rgba(217, 130, 43, 0.3);
+      color:#bf7326; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-warning:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled{
+      background:none;
+      color:rgba(191, 115, 38, 0.5); }
+      .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active{
+        background:rgba(217, 130, 43, 0.3); }
+    .bp3-html-select.bp3-minimal select.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
+      stroke:#bf7326; }
+    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning{
+      color:#ffb366; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:hover,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:hover{
+        background:rgba(217, 130, 43, 0.2);
+        color:#ffb366; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-active{
+        background:rgba(217, 130, 43, 0.3);
+        color:#ffb366; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled{
+        background:none;
+        color:rgba(255, 179, 102, 0.5); }
+        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled.bp3-active{
+          background:rgba(217, 130, 43, 0.3); }
+  .bp3-html-select.bp3-minimal select.bp3-intent-danger,
+  .bp3-select.bp3-minimal select.bp3-intent-danger{
+    color:#c23030; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
+    .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background:none;
+      color:#c23030; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
+    .bp3-select.bp3-minimal select.bp3-intent-danger:hover{
+      background:rgba(219, 55, 55, 0.15);
+      color:#c23030; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
+    .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
+    .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active{
+      background:rgba(219, 55, 55, 0.3);
+      color:#c23030; }
+    .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-danger:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled,
+    .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled{
+      background:none;
+      color:rgba(194, 48, 48, 0.5); }
+      .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active,
+      .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active{
+        background:rgba(219, 55, 55, 0.3); }
+    .bp3-html-select.bp3-minimal select.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
+      stroke:#c23030; }
+    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger,
+    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger{
+      color:#ff7373; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:hover,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:hover{
+        background:rgba(219, 55, 55, 0.2);
+        color:#ff7373; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-active,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-active{
+        background:rgba(219, 55, 55, 0.3);
+        color:#ff7373; }
+      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled,
+      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled{
+        background:none;
+        color:rgba(255, 115, 115, 0.5); }
+        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled.bp3-active,
+        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled.bp3-active{
+          background:rgba(219, 55, 55, 0.3); }
+
+.bp3-html-select.bp3-large select,
+.bp3-select.bp3-large select{
+  height:40px;
+  padding-right:35px;
+  font-size:16px; }
+
+.bp3-dark .bp3-html-select select, .bp3-dark .bp3-select select{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color:#394b59;
+  background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
+  background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  color:#f5f8fa; }
+  .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover, .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
+    color:#f5f8fa; }
+  .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+    background-color:#30404d; }
+  .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background-color:#202b33;
+    background-image:none; }
+  .bp3-dark .bp3-html-select select:disabled, .bp3-dark .bp3-select select:disabled, .bp3-dark .bp3-html-select select.bp3-disabled, .bp3-dark .bp3-select select.bp3-disabled{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background-color:rgba(57, 75, 89, 0.5);
+    background-image:none;
+    color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-html-select select:disabled.bp3-active, .bp3-dark .bp3-select select:disabled.bp3-active, .bp3-dark .bp3-html-select select.bp3-disabled.bp3-active, .bp3-dark .bp3-select select.bp3-disabled.bp3-active{
+      background:rgba(57, 75, 89, 0.7); }
+  .bp3-dark .bp3-html-select select .bp3-button-spinner .bp3-spinner-head, .bp3-dark .bp3-select select .bp3-button-spinner .bp3-spinner-head{
+    background:rgba(16, 22, 26, 0.5);
+    stroke:#8a9ba8; }
+
+.bp3-html-select select:disabled,
+.bp3-select select:disabled{
+  -webkit-box-shadow:none;
+          box-shadow:none;
+  background-color:rgba(206, 217, 224, 0.5);
+  cursor:not-allowed;
+  color:rgba(92, 112, 128, 0.6); }
+
+.bp3-html-select .bp3-icon,
+.bp3-select .bp3-icon, .bp3-select::after{
+  position:absolute;
+  top:7px;
+  right:7px;
+  color:#5c7080;
+  pointer-events:none; }
+  .bp3-html-select .bp3-disabled.bp3-icon,
+  .bp3-select .bp3-disabled.bp3-icon, .bp3-disabled.bp3-select::after{
+    color:rgba(92, 112, 128, 0.6); }
+.bp3-html-select,
+.bp3-select{
+  display:inline-block;
+  position:relative;
+  vertical-align:middle;
+  letter-spacing:normal; }
+  .bp3-html-select select::-ms-expand,
+  .bp3-select select::-ms-expand{
+    display:none; }
+  .bp3-html-select .bp3-icon,
+  .bp3-select .bp3-icon{
+    color:#5c7080; }
+    .bp3-html-select .bp3-icon:hover,
+    .bp3-select .bp3-icon:hover{
+      color:#182026; }
+    .bp3-dark .bp3-html-select .bp3-icon, .bp3-dark
+    .bp3-select .bp3-icon{
+      color:#a7b6c2; }
+      .bp3-dark .bp3-html-select .bp3-icon:hover, .bp3-dark
+      .bp3-select .bp3-icon:hover{
+        color:#f5f8fa; }
+  .bp3-html-select.bp3-large::after,
+  .bp3-html-select.bp3-large .bp3-icon,
+  .bp3-select.bp3-large::after,
+  .bp3-select.bp3-large .bp3-icon{
+    top:12px;
+    right:12px; }
+  .bp3-html-select.bp3-fill,
+  .bp3-html-select.bp3-fill select,
+  .bp3-select.bp3-fill,
+  .bp3-select.bp3-fill select{
+    width:100%; }
+  .bp3-dark .bp3-html-select option, .bp3-dark
+  .bp3-select option{
+    background-color:#30404d;
+    color:#f5f8fa; }
+  .bp3-dark .bp3-html-select::after, .bp3-dark
+  .bp3-select::after{
+    color:#a7b6c2; }
+
+.bp3-select::after{
+  line-height:1;
+  font-family:"Icons16", sans-serif;
+  font-size:16px;
+  font-weight:400;
+  font-style:normal;
+  -moz-osx-font-smoothing:grayscale;
+  -webkit-font-smoothing:antialiased;
+  content:""; }
+.bp3-running-text table, table.bp3-html-table{
+  border-spacing:0;
+  font-size:14px; }
+  .bp3-running-text table th, table.bp3-html-table th,
+  .bp3-running-text table td,
+  table.bp3-html-table td{
+    padding:11px;
+    vertical-align:top;
+    text-align:left; }
+  .bp3-running-text table th, table.bp3-html-table th{
+    color:#182026;
+    font-weight:600; }
+  
+  .bp3-running-text table td,
+  table.bp3-html-table td{
+    color:#182026; }
+  .bp3-running-text table tbody tr:first-child th, table.bp3-html-table tbody tr:first-child th,
+  .bp3-running-text table tbody tr:first-child td,
+  table.bp3-html-table tbody tr:first-child td{
+    -webkit-box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
+            box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15); }
+  .bp3-dark .bp3-running-text table th, .bp3-running-text .bp3-dark table th, .bp3-dark table.bp3-html-table th{
+    color:#f5f8fa; }
+  .bp3-dark .bp3-running-text table td, .bp3-running-text .bp3-dark table td, .bp3-dark table.bp3-html-table td{
+    color:#f5f8fa; }
+  .bp3-dark .bp3-running-text table tbody tr:first-child th, .bp3-running-text .bp3-dark table tbody tr:first-child th, .bp3-dark table.bp3-html-table tbody tr:first-child th,
+  .bp3-dark .bp3-running-text table tbody tr:first-child td,
+  .bp3-running-text .bp3-dark table tbody tr:first-child td,
+  .bp3-dark table.bp3-html-table tbody tr:first-child td{
+    -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
+
+table.bp3-html-table.bp3-html-table-condensed th,
+table.bp3-html-table.bp3-html-table-condensed td, table.bp3-html-table.bp3-small th,
+table.bp3-html-table.bp3-small td{
+  padding-top:6px;
+  padding-bottom:6px; }
+
+table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
+  background:rgba(191, 204, 214, 0.15); }
+
+table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
+  -webkit-box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
+          box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15); }
+
+table.bp3-html-table.bp3-html-table-bordered tbody tr td{
+  -webkit-box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
+          box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15); }
+  table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
+    -webkit-box-shadow:inset 1px 1px 0 0 rgba(16, 22, 26, 0.15);
+            box-shadow:inset 1px 1px 0 0 rgba(16, 22, 26, 0.15); }
+
+table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
+  -webkit-box-shadow:none;
+          box-shadow:none; }
+  table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:not(:first-child){
+    -webkit-box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
+            box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15); }
+
+table.bp3-html-table.bp3-interactive tbody tr:hover td{
+  background-color:rgba(191, 204, 214, 0.3);
+  cursor:pointer; }
+
+table.bp3-html-table.bp3-interactive tbody tr:active td{
+  background-color:rgba(191, 204, 214, 0.4); }
+
+.bp3-dark table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
+  background:rgba(92, 112, 128, 0.15); }
+
+.bp3-dark table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
+  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
+
+.bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td{
+  -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+          box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
+    -webkit-box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15); }
+
+.bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
+  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:first-child{
+    -webkit-box-shadow:none;
+            box-shadow:none; }
+
+.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:hover td{
+  background-color:rgba(92, 112, 128, 0.3);
+  cursor:pointer; }
+
+.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:active td{
+  background-color:rgba(92, 112, 128, 0.4); }
+
+.bp3-key-combo{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center; }
+  .bp3-key-combo > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-key-combo > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-key-combo::before,
+  .bp3-key-combo > *{
+    margin-right:5px; }
+  .bp3-key-combo:empty::before,
+  .bp3-key-combo > :last-child{
+    margin-right:0; }
+
+.bp3-hotkey-dialog{
+  top:40px;
+  padding-bottom:0; }
+  .bp3-hotkey-dialog .bp3-dialog-body{
+    margin:0;
+    padding:0; }
+  .bp3-hotkey-dialog .bp3-hotkey-label{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1; }
+
+.bp3-hotkey-column{
+  margin:auto;
+  max-height:80vh;
+  overflow-y:auto;
+  padding:30px; }
+  .bp3-hotkey-column .bp3-heading{
+    margin-bottom:20px; }
+    .bp3-hotkey-column .bp3-heading:not(:first-child){
+      margin-top:40px; }
+
+.bp3-hotkey{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-pack:justify;
+      -ms-flex-pack:justify;
+          justify-content:space-between;
+  margin-right:0;
+  margin-left:0; }
+  .bp3-hotkey:not(:last-child){
+    margin-bottom:10px; }
+.bp3-icon{
+  display:inline-block;
+  -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+          flex:0 0 auto;
+  vertical-align:text-bottom; }
+  .bp3-icon:not(:empty)::before{
+    content:"" !important;
+    content:unset !important; }
+  .bp3-icon > svg{
+    display:block; }
+    .bp3-icon > svg:not([fill]){
+      fill:currentColor; }
+
+.bp3-icon.bp3-intent-primary, .bp3-icon-standard.bp3-intent-primary, .bp3-icon-large.bp3-intent-primary{
+  color:#106ba3; }
+  .bp3-dark .bp3-icon.bp3-intent-primary, .bp3-dark .bp3-icon-standard.bp3-intent-primary, .bp3-dark .bp3-icon-large.bp3-intent-primary{
+    color:#48aff0; }
+
+.bp3-icon.bp3-intent-success, .bp3-icon-standard.bp3-intent-success, .bp3-icon-large.bp3-intent-success{
+  color:#0d8050; }
+  .bp3-dark .bp3-icon.bp3-intent-success, .bp3-dark .bp3-icon-standard.bp3-intent-success, .bp3-dark .bp3-icon-large.bp3-intent-success{
+    color:#3dcc91; }
+
+.bp3-icon.bp3-intent-warning, .bp3-icon-standard.bp3-intent-warning, .bp3-icon-large.bp3-intent-warning{
+  color:#bf7326; }
+  .bp3-dark .bp3-icon.bp3-intent-warning, .bp3-dark .bp3-icon-standard.bp3-intent-warning, .bp3-dark .bp3-icon-large.bp3-intent-warning{
+    color:#ffb366; }
+
+.bp3-icon.bp3-intent-danger, .bp3-icon-standard.bp3-intent-danger, .bp3-icon-large.bp3-intent-danger{
+  color:#c23030; }
+  .bp3-dark .bp3-icon.bp3-intent-danger, .bp3-dark .bp3-icon-standard.bp3-intent-danger, .bp3-dark .bp3-icon-large.bp3-intent-danger{
+    color:#ff7373; }
+
+span.bp3-icon-standard{
+  line-height:1;
+  font-family:"Icons16", sans-serif;
+  font-size:16px;
+  font-weight:400;
+  font-style:normal;
+  -moz-osx-font-smoothing:grayscale;
+  -webkit-font-smoothing:antialiased;
+  display:inline-block; }
+
+span.bp3-icon-large{
+  line-height:1;
+  font-family:"Icons20", sans-serif;
+  font-size:20px;
+  font-weight:400;
+  font-style:normal;
+  -moz-osx-font-smoothing:grayscale;
+  -webkit-font-smoothing:antialiased;
+  display:inline-block; }
+
+span.bp3-icon:empty{
+  line-height:1;
+  font-family:"Icons20";
+  font-size:inherit;
+  font-weight:400;
+  font-style:normal; }
+  span.bp3-icon:empty::before{
+    -moz-osx-font-smoothing:grayscale;
+    -webkit-font-smoothing:antialiased; }
+
+.bp3-icon-add::before{
+  content:""; }
+
+.bp3-icon-add-column-left::before{
+  content:""; }
+
+.bp3-icon-add-column-right::before{
+  content:""; }
+
+.bp3-icon-add-row-bottom::before{
+  content:""; }
+
+.bp3-icon-add-row-top::before{
+  content:""; }
+
+.bp3-icon-add-to-artifact::before{
+  content:""; }
+
+.bp3-icon-add-to-folder::before{
+  content:""; }
+
+.bp3-icon-airplane::before{
+  content:""; }
+
+.bp3-icon-align-center::before{
+  content:""; }
+
+.bp3-icon-align-justify::before{
+  content:""; }
+
+.bp3-icon-align-left::before{
+  content:""; }
+
+.bp3-icon-align-right::before{
+  content:""; }
+
+.bp3-icon-alignment-bottom::before{
+  content:""; }
+
+.bp3-icon-alignment-horizontal-center::before{
+  content:""; }
+
+.bp3-icon-alignment-left::before{
+  content:""; }
+
+.bp3-icon-alignment-right::before{
+  content:""; }
+
+.bp3-icon-alignment-top::before{
+  content:""; }
+
+.bp3-icon-alignment-vertical-center::before{
+  content:""; }
+
+.bp3-icon-annotation::before{
+  content:""; }
+
+.bp3-icon-application::before{
+  content:""; }
+
+.bp3-icon-applications::before{
+  content:""; }
+
+.bp3-icon-archive::before{
+  content:""; }
+
+.bp3-icon-arrow-bottom-left::before{
+  content:"↙"; }
+
+.bp3-icon-arrow-bottom-right::before{
+  content:"↘"; }
+
+.bp3-icon-arrow-down::before{
+  content:"↓"; }
+
+.bp3-icon-arrow-left::before{
+  content:"←"; }
+
+.bp3-icon-arrow-right::before{
+  content:"→"; }
+
+.bp3-icon-arrow-top-left::before{
+  content:"↖"; }
+
+.bp3-icon-arrow-top-right::before{
+  content:"↗"; }
+
+.bp3-icon-arrow-up::before{
+  content:"↑"; }
+
+.bp3-icon-arrows-horizontal::before{
+  content:"↔"; }
+
+.bp3-icon-arrows-vertical::before{
+  content:"↕"; }
+
+.bp3-icon-asterisk::before{
+  content:"*"; }
+
+.bp3-icon-automatic-updates::before{
+  content:""; }
+
+.bp3-icon-badge::before{
+  content:""; }
+
+.bp3-icon-ban-circle::before{
+  content:""; }
+
+.bp3-icon-bank-account::before{
+  content:""; }
+
+.bp3-icon-barcode::before{
+  content:""; }
+
+.bp3-icon-blank::before{
+  content:""; }
+
+.bp3-icon-blocked-person::before{
+  content:""; }
+
+.bp3-icon-bold::before{
+  content:""; }
+
+.bp3-icon-book::before{
+  content:""; }
+
+.bp3-icon-bookmark::before{
+  content:""; }
+
+.bp3-icon-box::before{
+  content:""; }
+
+.bp3-icon-briefcase::before{
+  content:""; }
+
+.bp3-icon-bring-data::before{
+  content:""; }
+
+.bp3-icon-build::before{
+  content:""; }
+
+.bp3-icon-calculator::before{
+  content:""; }
+
+.bp3-icon-calendar::before{
+  content:""; }
+
+.bp3-icon-camera::before{
+  content:""; }
+
+.bp3-icon-caret-down::before{
+  content:"⌄"; }
+
+.bp3-icon-caret-left::before{
+  content:"〈"; }
+
+.bp3-icon-caret-right::before{
+  content:"〉"; }
+
+.bp3-icon-caret-up::before{
+  content:"⌃"; }
+
+.bp3-icon-cell-tower::before{
+  content:""; }
+
+.bp3-icon-changes::before{
+  content:""; }
+
+.bp3-icon-chart::before{
+  content:""; }
+
+.bp3-icon-chat::before{
+  content:""; }
+
+.bp3-icon-chevron-backward::before{
+  content:""; }
+
+.bp3-icon-chevron-down::before{
+  content:""; }
+
+.bp3-icon-chevron-forward::before{
+  content:""; }
+
+.bp3-icon-chevron-left::before{
+  content:""; }
+
+.bp3-icon-chevron-right::before{
+  content:""; }
+
+.bp3-icon-chevron-up::before{
+  content:""; }
+
+.bp3-icon-circle::before{
+  content:""; }
+
+.bp3-icon-circle-arrow-down::before{
+  content:""; }
+
+.bp3-icon-circle-arrow-left::before{
+  content:""; }
+
+.bp3-icon-circle-arrow-right::before{
+  content:""; }
+
+.bp3-icon-circle-arrow-up::before{
+  content:""; }
+
+.bp3-icon-citation::before{
+  content:""; }
+
+.bp3-icon-clean::before{
+  content:""; }
+
+.bp3-icon-clipboard::before{
+  content:""; }
+
+.bp3-icon-cloud::before{
+  content:"☁"; }
+
+.bp3-icon-cloud-download::before{
+  content:""; }
+
+.bp3-icon-cloud-upload::before{
+  content:""; }
+
+.bp3-icon-code::before{
+  content:""; }
+
+.bp3-icon-code-block::before{
+  content:""; }
+
+.bp3-icon-cog::before{
+  content:""; }
+
+.bp3-icon-collapse-all::before{
+  content:""; }
+
+.bp3-icon-column-layout::before{
+  content:""; }
+
+.bp3-icon-comment::before{
+  content:""; }
+
+.bp3-icon-comparison::before{
+  content:""; }
+
+.bp3-icon-compass::before{
+  content:""; }
+
+.bp3-icon-compressed::before{
+  content:""; }
+
+.bp3-icon-confirm::before{
+  content:""; }
+
+.bp3-icon-console::before{
+  content:""; }
+
+.bp3-icon-contrast::before{
+  content:""; }
+
+.bp3-icon-control::before{
+  content:""; }
+
+.bp3-icon-credit-card::before{
+  content:""; }
+
+.bp3-icon-cross::before{
+  content:"✗"; }
+
+.bp3-icon-crown::before{
+  content:""; }
+
+.bp3-icon-cube::before{
+  content:""; }
+
+.bp3-icon-cube-add::before{
+  content:""; }
+
+.bp3-icon-cube-remove::before{
+  content:""; }
+
+.bp3-icon-curved-range-chart::before{
+  content:""; }
+
+.bp3-icon-cut::before{
+  content:""; }
+
+.bp3-icon-dashboard::before{
+  content:""; }
+
+.bp3-icon-data-lineage::before{
+  content:""; }
+
+.bp3-icon-database::before{
+  content:""; }
+
+.bp3-icon-delete::before{
+  content:""; }
+
+.bp3-icon-delta::before{
+  content:"Δ"; }
+
+.bp3-icon-derive-column::before{
+  content:""; }
+
+.bp3-icon-desktop::before{
+  content:""; }
+
+.bp3-icon-diagram-tree::before{
+  content:""; }
+
+.bp3-icon-direction-left::before{
+  content:""; }
+
+.bp3-icon-direction-right::before{
+  content:""; }
+
+.bp3-icon-disable::before{
+  content:""; }
+
+.bp3-icon-document::before{
+  content:""; }
+
+.bp3-icon-document-open::before{
+  content:""; }
+
+.bp3-icon-document-share::before{
+  content:""; }
+
+.bp3-icon-dollar::before{
+  content:"$"; }
+
+.bp3-icon-dot::before{
+  content:"•"; }
+
+.bp3-icon-double-caret-horizontal::before{
+  content:""; }
+
+.bp3-icon-double-caret-vertical::before{
+  content:""; }
+
+.bp3-icon-double-chevron-down::before{
+  content:""; }
+
+.bp3-icon-double-chevron-left::before{
+  content:""; }
+
+.bp3-icon-double-chevron-right::before{
+  content:""; }
+
+.bp3-icon-double-chevron-up::before{
+  content:""; }
+
+.bp3-icon-doughnut-chart::before{
+  content:""; }
+
+.bp3-icon-download::before{
+  content:""; }
+
+.bp3-icon-drag-handle-horizontal::before{
+  content:""; }
+
+.bp3-icon-drag-handle-vertical::before{
+  content:""; }
+
+.bp3-icon-draw::before{
+  content:""; }
+
+.bp3-icon-drive-time::before{
+  content:""; }
+
+.bp3-icon-duplicate::before{
+  content:""; }
+
+.bp3-icon-edit::before{
+  content:"✎"; }
+
+.bp3-icon-eject::before{
+  content:"⏏"; }
+
+.bp3-icon-endorsed::before{
+  content:""; }
+
+.bp3-icon-envelope::before{
+  content:"✉"; }
+
+.bp3-icon-equals::before{
+  content:""; }
+
+.bp3-icon-eraser::before{
+  content:""; }
+
+.bp3-icon-error::before{
+  content:""; }
+
+.bp3-icon-euro::before{
+  content:"€"; }
+
+.bp3-icon-exchange::before{
+  content:""; }
+
+.bp3-icon-exclude-row::before{
+  content:""; }
+
+.bp3-icon-expand-all::before{
+  content:""; }
+
+.bp3-icon-export::before{
+  content:""; }
+
+.bp3-icon-eye-off::before{
+  content:""; }
+
+.bp3-icon-eye-on::before{
+  content:""; }
+
+.bp3-icon-eye-open::before{
+  content:""; }
+
+.bp3-icon-fast-backward::before{
+  content:""; }
+
+.bp3-icon-fast-forward::before{
+  content:""; }
+
+.bp3-icon-feed::before{
+  content:""; }
+
+.bp3-icon-feed-subscribed::before{
+  content:""; }
+
+.bp3-icon-film::before{
+  content:""; }
+
+.bp3-icon-filter::before{
+  content:""; }
+
+.bp3-icon-filter-keep::before{
+  content:""; }
+
+.bp3-icon-filter-list::before{
+  content:""; }
+
+.bp3-icon-filter-open::before{
+  content:""; }
+
+.bp3-icon-filter-remove::before{
+  content:""; }
+
+.bp3-icon-flag::before{
+  content:"⚑"; }
+
+.bp3-icon-flame::before{
+  content:""; }
+
+.bp3-icon-flash::before{
+  content:""; }
+
+.bp3-icon-floppy-disk::before{
+  content:""; }
+
+.bp3-icon-flow-branch::before{
+  content:""; }
+
+.bp3-icon-flow-end::before{
+  content:""; }
+
+.bp3-icon-flow-linear::before{
+  content:""; }
+
+.bp3-icon-flow-review::before{
+  content:""; }
+
+.bp3-icon-flow-review-branch::before{
+  content:""; }
+
+.bp3-icon-flows::before{
+  content:""; }
+
+.bp3-icon-folder-close::before{
+  content:""; }
+
+.bp3-icon-folder-new::before{
+  content:""; }
+
+.bp3-icon-folder-open::before{
+  content:""; }
+
+.bp3-icon-folder-shared::before{
+  content:""; }
+
+.bp3-icon-folder-shared-open::before{
+  content:""; }
+
+.bp3-icon-follower::before{
+  content:""; }
+
+.bp3-icon-following::before{
+  content:""; }
+
+.bp3-icon-font::before{
+  content:""; }
+
+.bp3-icon-fork::before{
+  content:""; }
+
+.bp3-icon-form::before{
+  content:""; }
+
+.bp3-icon-full-circle::before{
+  content:""; }
+
+.bp3-icon-full-stacked-chart::before{
+  content:""; }
+
+.bp3-icon-fullscreen::before{
+  content:""; }
+
+.bp3-icon-function::before{
+  content:""; }
+
+.bp3-icon-gantt-chart::before{
+  content:""; }
+
+.bp3-icon-geolocation::before{
+  content:""; }
+
+.bp3-icon-geosearch::before{
+  content:""; }
+
+.bp3-icon-git-branch::before{
+  content:""; }
+
+.bp3-icon-git-commit::before{
+  content:""; }
+
+.bp3-icon-git-merge::before{
+  content:""; }
+
+.bp3-icon-git-new-branch::before{
+  content:""; }
+
+.bp3-icon-git-pull::before{
+  content:""; }
+
+.bp3-icon-git-push::before{
+  content:""; }
+
+.bp3-icon-git-repo::before{
+  content:""; }
+
+.bp3-icon-glass::before{
+  content:""; }
+
+.bp3-icon-globe::before{
+  content:""; }
+
+.bp3-icon-globe-network::before{
+  content:""; }
+
+.bp3-icon-graph::before{
+  content:""; }
+
+.bp3-icon-graph-remove::before{
+  content:""; }
+
+.bp3-icon-greater-than::before{
+  content:""; }
+
+.bp3-icon-greater-than-or-equal-to::before{
+  content:""; }
+
+.bp3-icon-grid::before{
+  content:""; }
+
+.bp3-icon-grid-view::before{
+  content:""; }
+
+.bp3-icon-group-objects::before{
+  content:""; }
+
+.bp3-icon-grouped-bar-chart::before{
+  content:""; }
+
+.bp3-icon-hand::before{
+  content:""; }
+
+.bp3-icon-hand-down::before{
+  content:""; }
+
+.bp3-icon-hand-left::before{
+  content:""; }
+
+.bp3-icon-hand-right::before{
+  content:""; }
+
+.bp3-icon-hand-up::before{
+  content:""; }
+
+.bp3-icon-header::before{
+  content:""; }
+
+.bp3-icon-header-one::before{
+  content:""; }
+
+.bp3-icon-header-two::before{
+  content:""; }
+
+.bp3-icon-headset::before{
+  content:""; }
+
+.bp3-icon-heart::before{
+  content:"♥"; }
+
+.bp3-icon-heart-broken::before{
+  content:""; }
+
+.bp3-icon-heat-grid::before{
+  content:""; }
+
+.bp3-icon-heatmap::before{
+  content:""; }
+
+.bp3-icon-help::before{
+  content:"?"; }
+
+.bp3-icon-helper-management::before{
+  content:""; }
+
+.bp3-icon-highlight::before{
+  content:""; }
+
+.bp3-icon-history::before{
+  content:""; }
+
+.bp3-icon-home::before{
+  content:"⌂"; }
+
+.bp3-icon-horizontal-bar-chart::before{
+  content:""; }
+
+.bp3-icon-horizontal-bar-chart-asc::before{
+  content:""; }
+
+.bp3-icon-horizontal-bar-chart-desc::before{
+  content:""; }
+
+.bp3-icon-horizontal-distribution::before{
+  content:""; }
+
+.bp3-icon-id-number::before{
+  content:""; }
+
+.bp3-icon-image-rotate-left::before{
+  content:""; }
+
+.bp3-icon-image-rotate-right::before{
+  content:""; }
+
+.bp3-icon-import::before{
+  content:""; }
+
+.bp3-icon-inbox::before{
+  content:""; }
+
+.bp3-icon-inbox-filtered::before{
+  content:""; }
+
+.bp3-icon-inbox-geo::before{
+  content:""; }
+
+.bp3-icon-inbox-search::before{
+  content:""; }
+
+.bp3-icon-inbox-update::before{
+  content:""; }
+
+.bp3-icon-info-sign::before{
+  content:"ℹ"; }
+
+.bp3-icon-inheritance::before{
+  content:""; }
+
+.bp3-icon-inner-join::before{
+  content:""; }
+
+.bp3-icon-insert::before{
+  content:""; }
+
+.bp3-icon-intersection::before{
+  content:""; }
+
+.bp3-icon-ip-address::before{
+  content:""; }
+
+.bp3-icon-issue::before{
+  content:""; }
+
+.bp3-icon-issue-closed::before{
+  content:""; }
+
+.bp3-icon-issue-new::before{
+  content:""; }
+
+.bp3-icon-italic::before{
+  content:""; }
+
+.bp3-icon-join-table::before{
+  content:""; }
+
+.bp3-icon-key::before{
+  content:""; }
+
+.bp3-icon-key-backspace::before{
+  content:""; }
+
+.bp3-icon-key-command::before{
+  content:""; }
+
+.bp3-icon-key-control::before{
+  content:""; }
+
+.bp3-icon-key-delete::before{
+  content:""; }
+
+.bp3-icon-key-enter::before{
+  content:""; }
+
+.bp3-icon-key-escape::before{
+  content:""; }
+
+.bp3-icon-key-option::before{
+  content:""; }
+
+.bp3-icon-key-shift::before{
+  content:""; }
+
+.bp3-icon-key-tab::before{
+  content:""; }
+
+.bp3-icon-known-vehicle::before{
+  content:""; }
+
+.bp3-icon-label::before{
+  content:""; }
+
+.bp3-icon-layer::before{
+  content:""; }
+
+.bp3-icon-layers::before{
+  content:""; }
+
+.bp3-icon-layout::before{
+  content:""; }
+
+.bp3-icon-layout-auto::before{
+  content:""; }
+
+.bp3-icon-layout-balloon::before{
+  content:""; }
+
+.bp3-icon-layout-circle::before{
+  content:""; }
+
+.bp3-icon-layout-grid::before{
+  content:""; }
+
+.bp3-icon-layout-group-by::before{
+  content:""; }
+
+.bp3-icon-layout-hierarchy::before{
+  content:""; }
+
+.bp3-icon-layout-linear::before{
+  content:""; }
+
+.bp3-icon-layout-skew-grid::before{
+  content:""; }
+
+.bp3-icon-layout-sorted-clusters::before{
+  content:""; }
+
+.bp3-icon-learning::before{
+  content:""; }
+
+.bp3-icon-left-join::before{
+  content:""; }
+
+.bp3-icon-less-than::before{
+  content:""; }
+
+.bp3-icon-less-than-or-equal-to::before{
+  content:""; }
+
+.bp3-icon-lifesaver::before{
+  content:""; }
+
+.bp3-icon-lightbulb::before{
+  content:""; }
+
+.bp3-icon-link::before{
+  content:""; }
+
+.bp3-icon-list::before{
+  content:"☰"; }
+
+.bp3-icon-list-columns::before{
+  content:""; }
+
+.bp3-icon-list-detail-view::before{
+  content:""; }
+
+.bp3-icon-locate::before{
+  content:""; }
+
+.bp3-icon-lock::before{
+  content:""; }
+
+.bp3-icon-log-in::before{
+  content:""; }
+
+.bp3-icon-log-out::before{
+  content:""; }
+
+.bp3-icon-manual::before{
+  content:""; }
+
+.bp3-icon-manually-entered-data::before{
+  content:""; }
+
+.bp3-icon-map::before{
+  content:""; }
+
+.bp3-icon-map-create::before{
+  content:""; }
+
+.bp3-icon-map-marker::before{
+  content:""; }
+
+.bp3-icon-maximize::before{
+  content:""; }
+
+.bp3-icon-media::before{
+  content:""; }
+
+.bp3-icon-menu::before{
+  content:""; }
+
+.bp3-icon-menu-closed::before{
+  content:""; }
+
+.bp3-icon-menu-open::before{
+  content:""; }
+
+.bp3-icon-merge-columns::before{
+  content:""; }
+
+.bp3-icon-merge-links::before{
+  content:""; }
+
+.bp3-icon-minimize::before{
+  content:""; }
+
+.bp3-icon-minus::before{
+  content:"−"; }
+
+.bp3-icon-mobile-phone::before{
+  content:""; }
+
+.bp3-icon-mobile-video::before{
+  content:""; }
+
+.bp3-icon-moon::before{
+  content:""; }
+
+.bp3-icon-more::before{
+  content:""; }
+
+.bp3-icon-mountain::before{
+  content:""; }
+
+.bp3-icon-move::before{
+  content:""; }
+
+.bp3-icon-mugshot::before{
+  content:""; }
+
+.bp3-icon-multi-select::before{
+  content:""; }
+
+.bp3-icon-music::before{
+  content:""; }
+
+.bp3-icon-new-drawing::before{
+  content:""; }
+
+.bp3-icon-new-grid-item::before{
+  content:""; }
+
+.bp3-icon-new-layer::before{
+  content:""; }
+
+.bp3-icon-new-layers::before{
+  content:""; }
+
+.bp3-icon-new-link::before{
+  content:""; }
+
+.bp3-icon-new-object::before{
+  content:""; }
+
+.bp3-icon-new-person::before{
+  content:""; }
+
+.bp3-icon-new-prescription::before{
+  content:""; }
+
+.bp3-icon-new-text-box::before{
+  content:""; }
+
+.bp3-icon-ninja::before{
+  content:""; }
+
+.bp3-icon-not-equal-to::before{
+  content:""; }
+
+.bp3-icon-notifications::before{
+  content:""; }
+
+.bp3-icon-notifications-updated::before{
+  content:""; }
+
+.bp3-icon-numbered-list::before{
+  content:""; }
+
+.bp3-icon-numerical::before{
+  content:""; }
+
+.bp3-icon-office::before{
+  content:""; }
+
+.bp3-icon-offline::before{
+  content:""; }
+
+.bp3-icon-oil-field::before{
+  content:""; }
+
+.bp3-icon-one-column::before{
+  content:""; }
+
+.bp3-icon-outdated::before{
+  content:""; }
+
+.bp3-icon-page-layout::before{
+  content:""; }
+
+.bp3-icon-panel-stats::before{
+  content:""; }
+
+.bp3-icon-panel-table::before{
+  content:""; }
+
+.bp3-icon-paperclip::before{
+  content:""; }
+
+.bp3-icon-paragraph::before{
+  content:""; }
+
+.bp3-icon-path::before{
+  content:""; }
+
+.bp3-icon-path-search::before{
+  content:""; }
+
+.bp3-icon-pause::before{
+  content:""; }
+
+.bp3-icon-people::before{
+  content:""; }
+
+.bp3-icon-percentage::before{
+  content:""; }
+
+.bp3-icon-person::before{
+  content:""; }
+
+.bp3-icon-phone::before{
+  content:"☎"; }
+
+.bp3-icon-pie-chart::before{
+  content:""; }
+
+.bp3-icon-pin::before{
+  content:""; }
+
+.bp3-icon-pivot::before{
+  content:""; }
+
+.bp3-icon-pivot-table::before{
+  content:""; }
+
+.bp3-icon-play::before{
+  content:""; }
+
+.bp3-icon-plus::before{
+  content:"+"; }
+
+.bp3-icon-polygon-filter::before{
+  content:""; }
+
+.bp3-icon-power::before{
+  content:""; }
+
+.bp3-icon-predictive-analysis::before{
+  content:""; }
+
+.bp3-icon-prescription::before{
+  content:""; }
+
+.bp3-icon-presentation::before{
+  content:""; }
+
+.bp3-icon-print::before{
+  content:"⎙"; }
+
+.bp3-icon-projects::before{
+  content:""; }
+
+.bp3-icon-properties::before{
+  content:""; }
+
+.bp3-icon-property::before{
+  content:""; }
+
+.bp3-icon-publish-function::before{
+  content:""; }
+
+.bp3-icon-pulse::before{
+  content:""; }
+
+.bp3-icon-random::before{
+  content:""; }
+
+.bp3-icon-record::before{
+  content:""; }
+
+.bp3-icon-redo::before{
+  content:""; }
+
+.bp3-icon-refresh::before{
+  content:""; }
+
+.bp3-icon-regression-chart::before{
+  content:""; }
+
+.bp3-icon-remove::before{
+  content:""; }
+
+.bp3-icon-remove-column::before{
+  content:""; }
+
+.bp3-icon-remove-column-left::before{
+  content:""; }
+
+.bp3-icon-remove-column-right::before{
+  content:""; }
+
+.bp3-icon-remove-row-bottom::before{
+  content:""; }
+
+.bp3-icon-remove-row-top::before{
+  content:""; }
+
+.bp3-icon-repeat::before{
+  content:""; }
+
+.bp3-icon-reset::before{
+  content:""; }
+
+.bp3-icon-resolve::before{
+  content:""; }
+
+.bp3-icon-rig::before{
+  content:""; }
+
+.bp3-icon-right-join::before{
+  content:""; }
+
+.bp3-icon-ring::before{
+  content:""; }
+
+.bp3-icon-rotate-document::before{
+  content:""; }
+
+.bp3-icon-rotate-page::before{
+  content:""; }
+
+.bp3-icon-satellite::before{
+  content:""; }
+
+.bp3-icon-saved::before{
+  content:""; }
+
+.bp3-icon-scatter-plot::before{
+  content:""; }
+
+.bp3-icon-search::before{
+  content:""; }
+
+.bp3-icon-search-around::before{
+  content:""; }
+
+.bp3-icon-search-template::before{
+  content:""; }
+
+.bp3-icon-search-text::before{
+  content:""; }
+
+.bp3-icon-segmented-control::before{
+  content:""; }
+
+.bp3-icon-select::before{
+  content:""; }
+
+.bp3-icon-selection::before{
+  content:"⦿"; }
+
+.bp3-icon-send-to::before{
+  content:""; }
+
+.bp3-icon-send-to-graph::before{
+  content:""; }
+
+.bp3-icon-send-to-map::before{
+  content:""; }
+
+.bp3-icon-series-add::before{
+  content:""; }
+
+.bp3-icon-series-configuration::before{
+  content:""; }
+
+.bp3-icon-series-derived::before{
+  content:""; }
+
+.bp3-icon-series-filtered::before{
+  content:""; }
+
+.bp3-icon-series-search::before{
+  content:""; }
+
+.bp3-icon-settings::before{
+  content:""; }
+
+.bp3-icon-share::before{
+  content:""; }
+
+.bp3-icon-shield::before{
+  content:""; }
+
+.bp3-icon-shop::before{
+  content:""; }
+
+.bp3-icon-shopping-cart::before{
+  content:""; }
+
+.bp3-icon-signal-search::before{
+  content:""; }
+
+.bp3-icon-sim-card::before{
+  content:""; }
+
+.bp3-icon-slash::before{
+  content:""; }
+
+.bp3-icon-small-cross::before{
+  content:""; }
+
+.bp3-icon-small-minus::before{
+  content:""; }
+
+.bp3-icon-small-plus::before{
+  content:""; }
+
+.bp3-icon-small-tick::before{
+  content:""; }
+
+.bp3-icon-snowflake::before{
+  content:""; }
+
+.bp3-icon-social-media::before{
+  content:""; }
+
+.bp3-icon-sort::before{
+  content:""; }
+
+.bp3-icon-sort-alphabetical::before{
+  content:""; }
+
+.bp3-icon-sort-alphabetical-desc::before{
+  content:""; }
+
+.bp3-icon-sort-asc::before{
+  content:""; }
+
+.bp3-icon-sort-desc::before{
+  content:""; }
+
+.bp3-icon-sort-numerical::before{
+  content:""; }
+
+.bp3-icon-sort-numerical-desc::before{
+  content:""; }
+
+.bp3-icon-split-columns::before{
+  content:""; }
+
+.bp3-icon-square::before{
+  content:""; }
+
+.bp3-icon-stacked-chart::before{
+  content:""; }
+
+.bp3-icon-star::before{
+  content:"★"; }
+
+.bp3-icon-star-empty::before{
+  content:"☆"; }
+
+.bp3-icon-step-backward::before{
+  content:""; }
+
+.bp3-icon-step-chart::before{
+  content:""; }
+
+.bp3-icon-step-forward::before{
+  content:""; }
+
+.bp3-icon-stop::before{
+  content:""; }
+
+.bp3-icon-stopwatch::before{
+  content:""; }
+
+.bp3-icon-strikethrough::before{
+  content:""; }
+
+.bp3-icon-style::before{
+  content:""; }
+
+.bp3-icon-swap-horizontal::before{
+  content:""; }
+
+.bp3-icon-swap-vertical::before{
+  content:""; }
+
+.bp3-icon-symbol-circle::before{
+  content:""; }
+
+.bp3-icon-symbol-cross::before{
+  content:""; }
+
+.bp3-icon-symbol-diamond::before{
+  content:""; }
+
+.bp3-icon-symbol-square::before{
+  content:""; }
+
+.bp3-icon-symbol-triangle-down::before{
+  content:""; }
+
+.bp3-icon-symbol-triangle-up::before{
+  content:""; }
+
+.bp3-icon-tag::before{
+  content:""; }
+
+.bp3-icon-take-action::before{
+  content:""; }
+
+.bp3-icon-taxi::before{
+  content:""; }
+
+.bp3-icon-text-highlight::before{
+  content:""; }
+
+.bp3-icon-th::before{
+  content:""; }
+
+.bp3-icon-th-derived::before{
+  content:""; }
+
+.bp3-icon-th-disconnect::before{
+  content:""; }
+
+.bp3-icon-th-filtered::before{
+  content:""; }
+
+.bp3-icon-th-list::before{
+  content:""; }
+
+.bp3-icon-thumbs-down::before{
+  content:""; }
+
+.bp3-icon-thumbs-up::before{
+  content:""; }
+
+.bp3-icon-tick::before{
+  content:"✓"; }
+
+.bp3-icon-tick-circle::before{
+  content:""; }
+
+.bp3-icon-time::before{
+  content:"⏲"; }
+
+.bp3-icon-timeline-area-chart::before{
+  content:""; }
+
+.bp3-icon-timeline-bar-chart::before{
+  content:""; }
+
+.bp3-icon-timeline-events::before{
+  content:""; }
+
+.bp3-icon-timeline-line-chart::before{
+  content:""; }
+
+.bp3-icon-tint::before{
+  content:""; }
+
+.bp3-icon-torch::before{
+  content:""; }
+
+.bp3-icon-tractor::before{
+  content:""; }
+
+.bp3-icon-train::before{
+  content:""; }
+
+.bp3-icon-translate::before{
+  content:""; }
+
+.bp3-icon-trash::before{
+  content:""; }
+
+.bp3-icon-tree::before{
+  content:""; }
+
+.bp3-icon-trending-down::before{
+  content:""; }
+
+.bp3-icon-trending-up::before{
+  content:""; }
+
+.bp3-icon-truck::before{
+  content:""; }
+
+.bp3-icon-two-columns::before{
+  content:""; }
+
+.bp3-icon-unarchive::before{
+  content:""; }
+
+.bp3-icon-underline::before{
+  content:"⎁"; }
+
+.bp3-icon-undo::before{
+  content:"⎌"; }
+
+.bp3-icon-ungroup-objects::before{
+  content:""; }
+
+.bp3-icon-unknown-vehicle::before{
+  content:""; }
+
+.bp3-icon-unlock::before{
+  content:""; }
+
+.bp3-icon-unpin::before{
+  content:""; }
+
+.bp3-icon-unresolve::before{
+  content:""; }
+
+.bp3-icon-updated::before{
+  content:""; }
+
+.bp3-icon-upload::before{
+  content:""; }
+
+.bp3-icon-user::before{
+  content:""; }
+
+.bp3-icon-variable::before{
+  content:""; }
+
+.bp3-icon-vertical-bar-chart-asc::before{
+  content:""; }
+
+.bp3-icon-vertical-bar-chart-desc::before{
+  content:""; }
+
+.bp3-icon-vertical-distribution::before{
+  content:""; }
+
+.bp3-icon-video::before{
+  content:""; }
+
+.bp3-icon-volume-down::before{
+  content:""; }
+
+.bp3-icon-volume-off::before{
+  content:""; }
+
+.bp3-icon-volume-up::before{
+  content:""; }
+
+.bp3-icon-walk::before{
+  content:""; }
+
+.bp3-icon-warning-sign::before{
+  content:""; }
+
+.bp3-icon-waterfall-chart::before{
+  content:""; }
+
+.bp3-icon-widget::before{
+  content:""; }
+
+.bp3-icon-widget-button::before{
+  content:""; }
+
+.bp3-icon-widget-footer::before{
+  content:""; }
+
+.bp3-icon-widget-header::before{
+  content:""; }
+
+.bp3-icon-wrench::before{
+  content:""; }
+
+.bp3-icon-zoom-in::before{
+  content:""; }
+
+.bp3-icon-zoom-out::before{
+  content:""; }
+
+.bp3-icon-zoom-to-fit::before{
+  content:""; }
+.bp3-submenu > .bp3-popover-wrapper{
+  display:block; }
+
+.bp3-submenu .bp3-popover-target{
+  display:block; }
+
+.bp3-submenu.bp3-popover{
+  -webkit-box-shadow:none;
+          box-shadow:none;
+  padding:0 5px; }
+  .bp3-submenu.bp3-popover > .bp3-popover-content{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2); }
+  .bp3-dark .bp3-submenu.bp3-popover, .bp3-submenu.bp3-popover.bp3-dark{
+    -webkit-box-shadow:none;
+            box-shadow:none; }
+    .bp3-dark .bp3-submenu.bp3-popover > .bp3-popover-content, .bp3-submenu.bp3-popover.bp3-dark > .bp3-popover-content{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
+.bp3-menu{
+  margin:0;
+  border-radius:3px;
+  background:#ffffff;
+  min-width:180px;
+  padding:5px;
+  list-style:none;
+  text-align:left;
+  color:#182026; }
+
+.bp3-menu-divider{
+  display:block;
+  margin:5px;
+  border-top:1px solid rgba(16, 22, 26, 0.15); }
+  .bp3-dark .bp3-menu-divider{
+    border-top-color:rgba(255, 255, 255, 0.15); }
+
+.bp3-menu-item{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+  -webkit-box-align:start;
+      -ms-flex-align:start;
+          align-items:flex-start;
+  border-radius:2px;
+  padding:5px 7px;
+  text-decoration:none;
+  line-height:20px;
+  color:inherit;
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-menu-item > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-menu-item > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-menu-item::before,
+  .bp3-menu-item > *{
+    margin-right:7px; }
+  .bp3-menu-item:empty::before,
+  .bp3-menu-item > :last-child{
+    margin-right:0; }
+  .bp3-menu-item > .bp3-fill{
+    word-break:break-word; }
+  .bp3-menu-item:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
+    background-color:rgba(167, 182, 194, 0.3);
+    cursor:pointer;
+    text-decoration:none; }
+  .bp3-menu-item.bp3-disabled{
+    background-color:inherit;
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-dark .bp3-menu-item{
+    color:inherit; }
+    .bp3-dark .bp3-menu-item:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
+      background-color:rgba(138, 155, 168, 0.15);
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-disabled{
+      background-color:inherit;
+      color:rgba(167, 182, 194, 0.6); }
+  .bp3-menu-item.bp3-intent-primary{
+    color:#106ba3; }
+    .bp3-menu-item.bp3-intent-primary .bp3-icon{
+      color:inherit; }
+    .bp3-menu-item.bp3-intent-primary::before, .bp3-menu-item.bp3-intent-primary::after,
+    .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
+      color:#106ba3; }
+    .bp3-menu-item.bp3-intent-primary:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-menu-item.bp3-intent-primary.bp3-active{
+      background-color:#137cbd; }
+    .bp3-menu-item.bp3-intent-primary:active{
+      background-color:#106ba3; }
+    .bp3-menu-item.bp3-intent-primary:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
+    .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
+    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-primary:active, .bp3-menu-item.bp3-intent-primary:active::before, .bp3-menu-item.bp3-intent-primary:active::after,
+    .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-menu-item.bp3-intent-primary.bp3-active::after,
+    .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-menu-item.bp3-intent-success{
+    color:#0d8050; }
+    .bp3-menu-item.bp3-intent-success .bp3-icon{
+      color:inherit; }
+    .bp3-menu-item.bp3-intent-success::before, .bp3-menu-item.bp3-intent-success::after,
+    .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
+      color:#0d8050; }
+    .bp3-menu-item.bp3-intent-success:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-menu-item.bp3-intent-success.bp3-active{
+      background-color:#0f9960; }
+    .bp3-menu-item.bp3-intent-success:active{
+      background-color:#0d8050; }
+    .bp3-menu-item.bp3-intent-success:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-menu-item.bp3-intent-success:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-menu-item.bp3-intent-success:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
+    .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
+    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-success:active, .bp3-menu-item.bp3-intent-success:active::before, .bp3-menu-item.bp3-intent-success:active::after,
+    .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-menu-item.bp3-intent-success.bp3-active::after,
+    .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-menu-item.bp3-intent-warning{
+    color:#bf7326; }
+    .bp3-menu-item.bp3-intent-warning .bp3-icon{
+      color:inherit; }
+    .bp3-menu-item.bp3-intent-warning::before, .bp3-menu-item.bp3-intent-warning::after,
+    .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
+      color:#bf7326; }
+    .bp3-menu-item.bp3-intent-warning:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-menu-item.bp3-intent-warning.bp3-active{
+      background-color:#d9822b; }
+    .bp3-menu-item.bp3-intent-warning:active{
+      background-color:#bf7326; }
+    .bp3-menu-item.bp3-intent-warning:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
+    .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
+    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-warning:active, .bp3-menu-item.bp3-intent-warning:active::before, .bp3-menu-item.bp3-intent-warning:active::after,
+    .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-menu-item.bp3-intent-warning.bp3-active::after,
+    .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-menu-item.bp3-intent-danger{
+    color:#c23030; }
+    .bp3-menu-item.bp3-intent-danger .bp3-icon{
+      color:inherit; }
+    .bp3-menu-item.bp3-intent-danger::before, .bp3-menu-item.bp3-intent-danger::after,
+    .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
+      color:#c23030; }
+    .bp3-menu-item.bp3-intent-danger:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-menu-item.bp3-intent-danger.bp3-active{
+      background-color:#db3737; }
+    .bp3-menu-item.bp3-intent-danger:active{
+      background-color:#c23030; }
+    .bp3-menu-item.bp3-intent-danger:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
+    .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
+    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-danger:active, .bp3-menu-item.bp3-intent-danger:active::before, .bp3-menu-item.bp3-intent-danger:active::after,
+    .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-menu-item.bp3-intent-danger.bp3-active::after,
+    .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-menu-item::before{
+    line-height:1;
+    font-family:"Icons16", sans-serif;
+    font-size:16px;
+    font-weight:400;
+    font-style:normal;
+    -moz-osx-font-smoothing:grayscale;
+    -webkit-font-smoothing:antialiased;
+    margin-right:7px; }
+  .bp3-menu-item::before,
+  .bp3-menu-item > .bp3-icon{
+    margin-top:2px;
+    color:#5c7080; }
+  .bp3-menu-item .bp3-menu-item-label{
+    color:#5c7080; }
+  .bp3-menu-item:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
+    color:inherit; }
+  .bp3-menu-item.bp3-active, .bp3-menu-item:active{
+    background-color:rgba(115, 134, 148, 0.3); }
+  .bp3-menu-item.bp3-disabled{
+    outline:none !important;
+    background-color:inherit !important;
+    cursor:not-allowed !important;
+    color:rgba(92, 112, 128, 0.6) !important; }
+    .bp3-menu-item.bp3-disabled::before,
+    .bp3-menu-item.bp3-disabled > .bp3-icon,
+    .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
+      color:rgba(92, 112, 128, 0.6) !important; }
+  .bp3-large .bp3-menu-item{
+    padding:9px 7px;
+    line-height:22px;
+    font-size:16px; }
+    .bp3-large .bp3-menu-item .bp3-icon{
+      margin-top:3px; }
+    .bp3-large .bp3-menu-item::before{
+      line-height:1;
+      font-family:"Icons20", sans-serif;
+      font-size:20px;
+      font-weight:400;
+      font-style:normal;
+      -moz-osx-font-smoothing:grayscale;
+      -webkit-font-smoothing:antialiased;
+      margin-top:1px;
+      margin-right:10px; }
+
+button.bp3-menu-item{
+  border:none;
+  background:none;
+  width:100%;
+  text-align:left; }
+.bp3-menu-header{
+  display:block;
+  margin:5px;
+  border-top:1px solid rgba(16, 22, 26, 0.15);
+  cursor:default;
+  padding-left:2px; }
+  .bp3-dark .bp3-menu-header{
+    border-top-color:rgba(255, 255, 255, 0.15); }
+  .bp3-menu-header:first-of-type{
+    border-top:none; }
+  .bp3-menu-header > h6{
+    color:#182026;
+    font-weight:600;
+    overflow:hidden;
+    text-overflow:ellipsis;
+    white-space:nowrap;
+    word-wrap:normal;
+    margin:0;
+    padding:10px 7px 0 1px;
+    line-height:17px; }
+    .bp3-dark .bp3-menu-header > h6{
+      color:#f5f8fa; }
+  .bp3-menu-header:first-of-type > h6{
+    padding-top:0; }
+  .bp3-large .bp3-menu-header > h6{
+    padding-top:15px;
+    padding-bottom:5px;
+    font-size:18px; }
+  .bp3-large .bp3-menu-header:first-of-type > h6{
+    padding-top:0; }
+
+.bp3-dark .bp3-menu{
+  background:#30404d;
+  color:#f5f8fa; }
+
+.bp3-dark .bp3-menu-item.bp3-intent-primary{
+  color:#48aff0; }
+  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-icon{
+    color:inherit; }
+  .bp3-dark .bp3-menu-item.bp3-intent-primary::before, .bp3-dark .bp3-menu-item.bp3-intent-primary::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
+    color:#48aff0; }
+  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active{
+    background-color:#137cbd; }
+  .bp3-dark .bp3-menu-item.bp3-intent-primary:active{
+    background-color:#106ba3; }
+  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
+  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label,
+  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary:active, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
+    color:#ffffff; }
+
+.bp3-dark .bp3-menu-item.bp3-intent-success{
+  color:#3dcc91; }
+  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-icon{
+    color:inherit; }
+  .bp3-dark .bp3-menu-item.bp3-intent-success::before, .bp3-dark .bp3-menu-item.bp3-intent-success::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
+    color:#3dcc91; }
+  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active{
+    background-color:#0f9960; }
+  .bp3-dark .bp3-menu-item.bp3-intent-success:active{
+    background-color:#0d8050; }
+  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
+  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label,
+  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success:active, .bp3-dark .bp3-menu-item.bp3-intent-success:active::before, .bp3-dark .bp3-menu-item.bp3-intent-success:active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
+    color:#ffffff; }
+
+.bp3-dark .bp3-menu-item.bp3-intent-warning{
+  color:#ffb366; }
+  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-icon{
+    color:inherit; }
+  .bp3-dark .bp3-menu-item.bp3-intent-warning::before, .bp3-dark .bp3-menu-item.bp3-intent-warning::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
+    color:#ffb366; }
+  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active{
+    background-color:#d9822b; }
+  .bp3-dark .bp3-menu-item.bp3-intent-warning:active{
+    background-color:#bf7326; }
+  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
+  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label,
+  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning:active, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
+    color:#ffffff; }
+
+.bp3-dark .bp3-menu-item.bp3-intent-danger{
+  color:#ff7373; }
+  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-icon{
+    color:inherit; }
+  .bp3-dark .bp3-menu-item.bp3-intent-danger::before, .bp3-dark .bp3-menu-item.bp3-intent-danger::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
+    color:#ff7373; }
+  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active{
+    background-color:#db3737; }
+  .bp3-dark .bp3-menu-item.bp3-intent-danger:active{
+    background-color:#c23030; }
+  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
+  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label,
+  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger:active, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::after,
+  .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
+    color:#ffffff; }
+
+.bp3-dark .bp3-menu-item::before,
+.bp3-dark .bp3-menu-item > .bp3-icon{
+  color:#a7b6c2; }
+
+.bp3-dark .bp3-menu-item .bp3-menu-item-label{
+  color:#a7b6c2; }
+
+.bp3-dark .bp3-menu-item.bp3-active, .bp3-dark .bp3-menu-item:active{
+  background-color:rgba(138, 155, 168, 0.3); }
+
+.bp3-dark .bp3-menu-item.bp3-disabled{
+  color:rgba(167, 182, 194, 0.6) !important; }
+  .bp3-dark .bp3-menu-item.bp3-disabled::before,
+  .bp3-dark .bp3-menu-item.bp3-disabled > .bp3-icon,
+  .bp3-dark .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
+    color:rgba(167, 182, 194, 0.6) !important; }
+
+.bp3-dark .bp3-menu-divider,
+.bp3-dark .bp3-menu-header{
+  border-color:rgba(255, 255, 255, 0.15); }
+
+.bp3-dark .bp3-menu-header > h6{
+  color:#f5f8fa; }
+
+.bp3-label .bp3-menu{
+  margin-top:5px; }
+.bp3-navbar{
+  position:relative;
+  z-index:10;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+  background-color:#ffffff;
+  width:100%;
+  height:50px;
+  padding:0 15px; }
+  .bp3-navbar.bp3-dark,
+  .bp3-dark .bp3-navbar{
+    background-color:#394b59; }
+  .bp3-navbar.bp3-dark{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
+  .bp3-dark .bp3-navbar{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
+  .bp3-navbar.bp3-fixed-top{
+    position:fixed;
+    top:0;
+    right:0;
+    left:0; }
+
+.bp3-navbar-heading{
+  margin-right:15px;
+  font-size:16px; }
+
+.bp3-navbar-group{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  height:50px; }
+  .bp3-navbar-group.bp3-align-left{
+    float:left; }
+  .bp3-navbar-group.bp3-align-right{
+    float:right; }
+
+.bp3-navbar-divider{
+  margin:0 10px;
+  border-left:1px solid rgba(16, 22, 26, 0.15);
+  height:20px; }
+  .bp3-dark .bp3-navbar-divider{
+    border-left-color:rgba(255, 255, 255, 0.15); }
+.bp3-non-ideal-state{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+          flex-direction:column;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  width:100%;
+  height:100%;
+  text-align:center; }
+  .bp3-non-ideal-state > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-non-ideal-state > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-non-ideal-state::before,
+  .bp3-non-ideal-state > *{
+    margin-bottom:20px; }
+  .bp3-non-ideal-state:empty::before,
+  .bp3-non-ideal-state > :last-child{
+    margin-bottom:0; }
+  .bp3-non-ideal-state > *{
+    max-width:400px; }
+
+.bp3-non-ideal-state-visual{
+  color:rgba(92, 112, 128, 0.6);
+  font-size:60px; }
+  .bp3-dark .bp3-non-ideal-state-visual{
+    color:rgba(167, 182, 194, 0.6); }
+
+.bp3-overflow-list{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -ms-flex-wrap:nowrap;
+      flex-wrap:nowrap;
+  min-width:0; }
+
+.bp3-overflow-list-spacer{
+  -ms-flex-negative:1;
+      flex-shrink:1;
+  width:1px; }
+
+body.bp3-overlay-open{
+  overflow:hidden; }
+
+.bp3-overlay{
+  position:static;
+  top:0;
+  right:0;
+  bottom:0;
+  left:0;
+  z-index:20; }
+  .bp3-overlay:not(.bp3-overlay-open){
+    pointer-events:none; }
+  .bp3-overlay.bp3-overlay-container{
+    position:fixed;
+    overflow:hidden; }
+    .bp3-overlay.bp3-overlay-container.bp3-overlay-inline{
+      position:absolute; }
+  .bp3-overlay.bp3-overlay-scroll-container{
+    position:fixed;
+    overflow:auto; }
+    .bp3-overlay.bp3-overlay-scroll-container.bp3-overlay-inline{
+      position:absolute; }
+  .bp3-overlay.bp3-overlay-inline{
+    display:inline;
+    overflow:visible; }
+
+.bp3-overlay-content{
+  position:fixed;
+  z-index:20; }
+  .bp3-overlay-inline .bp3-overlay-content,
+  .bp3-overlay-scroll-container .bp3-overlay-content{
+    position:absolute; }
+
+.bp3-overlay-backdrop{
+  position:fixed;
+  top:0;
+  right:0;
+  bottom:0;
+  left:0;
+  opacity:1;
+  z-index:20;
+  background-color:rgba(16, 22, 26, 0.7);
+  overflow:auto;
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-overlay-backdrop.bp3-overlay-enter, .bp3-overlay-backdrop.bp3-overlay-appear{
+    opacity:0; }
+  .bp3-overlay-backdrop.bp3-overlay-enter-active, .bp3-overlay-backdrop.bp3-overlay-appear-active{
+    opacity:1;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-overlay-backdrop.bp3-overlay-exit{
+    opacity:1; }
+  .bp3-overlay-backdrop.bp3-overlay-exit-active{
+    opacity:0;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-overlay-backdrop:focus{
+    outline:none; }
+  .bp3-overlay-inline .bp3-overlay-backdrop{
+    position:absolute; }
+.bp3-panel-stack{
+  position:relative;
+  overflow:hidden; }
+
+.bp3-panel-stack-header{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -ms-flex-negative:0;
+      flex-shrink:0;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  z-index:1;
+  -webkit-box-shadow:0 1px rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px rgba(16, 22, 26, 0.15);
+  height:30px; }
+  .bp3-dark .bp3-panel-stack-header{
+    -webkit-box-shadow:0 1px rgba(255, 255, 255, 0.15);
+            box-shadow:0 1px rgba(255, 255, 255, 0.15); }
+  .bp3-panel-stack-header > span{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-flex:1;
+        -ms-flex:1;
+            flex:1;
+    -webkit-box-align:stretch;
+        -ms-flex-align:stretch;
+            align-items:stretch; }
+  .bp3-panel-stack-header .bp3-heading{
+    margin:0 5px; }
+
+.bp3-button.bp3-panel-stack-header-back{
+  margin-left:5px;
+  padding-left:0;
+  white-space:nowrap; }
+  .bp3-button.bp3-panel-stack-header-back .bp3-icon{
+    margin:0 2px; }
+
+.bp3-panel-stack-view{
+  position:absolute;
+  top:0;
+  right:0;
+  bottom:0;
+  left:0;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+          flex-direction:column;
+  margin-right:-1px;
+  border-right:1px solid rgba(16, 22, 26, 0.15);
+  background-color:#ffffff;
+  overflow-y:auto; }
+  .bp3-dark .bp3-panel-stack-view{
+    background-color:#30404d; }
+
+.bp3-panel-stack-push .bp3-panel-stack-enter, .bp3-panel-stack-push .bp3-panel-stack-appear{
+  -webkit-transform:translateX(100%);
+          transform:translateX(100%);
+  opacity:0; }
+
+.bp3-panel-stack-push .bp3-panel-stack-enter-active, .bp3-panel-stack-push .bp3-panel-stack-appear-active{
+  -webkit-transform:translate(0%);
+          transform:translate(0%);
+  opacity:1;
+  -webkit-transition-property:opacity, -webkit-transform;
+  transition-property:opacity, -webkit-transform;
+  transition-property:transform, opacity;
+  transition-property:transform, opacity, -webkit-transform;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
+  -webkit-transition-timing-function:ease;
+          transition-timing-function:ease;
+  -webkit-transition-delay:0;
+          transition-delay:0; }
+
+.bp3-panel-stack-push .bp3-panel-stack-exit{
+  -webkit-transform:translate(0%);
+          transform:translate(0%);
+  opacity:1; }
+
+.bp3-panel-stack-push .bp3-panel-stack-exit-active{
+  -webkit-transform:translateX(-50%);
+          transform:translateX(-50%);
+  opacity:0;
+  -webkit-transition-property:opacity, -webkit-transform;
+  transition-property:opacity, -webkit-transform;
+  transition-property:transform, opacity;
+  transition-property:transform, opacity, -webkit-transform;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
+  -webkit-transition-timing-function:ease;
+          transition-timing-function:ease;
+  -webkit-transition-delay:0;
+          transition-delay:0; }
+
+.bp3-panel-stack-pop .bp3-panel-stack-enter, .bp3-panel-stack-pop .bp3-panel-stack-appear{
+  -webkit-transform:translateX(-50%);
+          transform:translateX(-50%);
+  opacity:0; }
+
+.bp3-panel-stack-pop .bp3-panel-stack-enter-active, .bp3-panel-stack-pop .bp3-panel-stack-appear-active{
+  -webkit-transform:translate(0%);
+          transform:translate(0%);
+  opacity:1;
+  -webkit-transition-property:opacity, -webkit-transform;
+  transition-property:opacity, -webkit-transform;
+  transition-property:transform, opacity;
+  transition-property:transform, opacity, -webkit-transform;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
+  -webkit-transition-timing-function:ease;
+          transition-timing-function:ease;
+  -webkit-transition-delay:0;
+          transition-delay:0; }
+
+.bp3-panel-stack-pop .bp3-panel-stack-exit{
+  -webkit-transform:translate(0%);
+          transform:translate(0%);
+  opacity:1; }
+
+.bp3-panel-stack-pop .bp3-panel-stack-exit-active{
+  -webkit-transform:translateX(100%);
+          transform:translateX(100%);
+  opacity:0;
+  -webkit-transition-property:opacity, -webkit-transform;
+  transition-property:opacity, -webkit-transform;
+  transition-property:transform, opacity;
+  transition-property:transform, opacity, -webkit-transform;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
+  -webkit-transition-timing-function:ease;
+          transition-timing-function:ease;
+  -webkit-transition-delay:0;
+          transition-delay:0; }
+.bp3-popover{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  -webkit-transform:scale(1);
+          transform:scale(1);
+  display:inline-block;
+  z-index:20;
+  border-radius:3px; }
+  .bp3-popover .bp3-popover-arrow{
+    position:absolute;
+    width:30px;
+    height:30px; }
+    .bp3-popover .bp3-popover-arrow::before{
+      margin:5px;
+      width:20px;
+      height:20px; }
+  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover{
+    margin-top:-17px;
+    margin-bottom:17px; }
+    .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow{
+      bottom:-11px; }
+      .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(-90deg);
+                transform:rotate(-90deg); }
+  .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-popover{
+    margin-left:17px; }
+    .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-popover > .bp3-popover-arrow{
+      left:-11px; }
+      .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-popover > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(0);
+                transform:rotate(0); }
+  .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-popover{
+    margin-top:17px; }
+    .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-popover > .bp3-popover-arrow{
+      top:-11px; }
+      .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-popover > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(90deg);
+                transform:rotate(90deg); }
+  .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover{
+    margin-right:17px;
+    margin-left:-17px; }
+    .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow{
+      right:-11px; }
+      .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(180deg);
+                transform:rotate(180deg); }
+  .bp3-tether-element-attached-middle > .bp3-popover > .bp3-popover-arrow{
+    top:50%;
+    -webkit-transform:translateY(-50%);
+            transform:translateY(-50%); }
+  .bp3-tether-element-attached-center > .bp3-popover > .bp3-popover-arrow{
+    right:50%;
+    -webkit-transform:translateX(50%);
+            transform:translateX(50%); }
+  .bp3-tether-element-attached-top.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow{
+    top:-0.3934px; }
+  .bp3-tether-element-attached-right.bp3-tether-target-attached-right > .bp3-popover > .bp3-popover-arrow{
+    right:-0.3934px; }
+  .bp3-tether-element-attached-left.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow{
+    left:-0.3934px; }
+  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-bottom > .bp3-popover > .bp3-popover-arrow{
+    bottom:-0.3934px; }
+  .bp3-tether-element-attached-top.bp3-tether-element-attached-left > .bp3-popover{
+    -webkit-transform-origin:top left;
+            transform-origin:top left; }
+  .bp3-tether-element-attached-top.bp3-tether-element-attached-center > .bp3-popover{
+    -webkit-transform-origin:top center;
+            transform-origin:top center; }
+  .bp3-tether-element-attached-top.bp3-tether-element-attached-right > .bp3-popover{
+    -webkit-transform-origin:top right;
+            transform-origin:top right; }
+  .bp3-tether-element-attached-middle.bp3-tether-element-attached-left > .bp3-popover{
+    -webkit-transform-origin:center left;
+            transform-origin:center left; }
+  .bp3-tether-element-attached-middle.bp3-tether-element-attached-center > .bp3-popover{
+    -webkit-transform-origin:center center;
+            transform-origin:center center; }
+  .bp3-tether-element-attached-middle.bp3-tether-element-attached-right > .bp3-popover{
+    -webkit-transform-origin:center right;
+            transform-origin:center right; }
+  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-left > .bp3-popover{
+    -webkit-transform-origin:bottom left;
+            transform-origin:bottom left; }
+  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-center > .bp3-popover{
+    -webkit-transform-origin:bottom center;
+            transform-origin:bottom center; }
+  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-right > .bp3-popover{
+    -webkit-transform-origin:bottom right;
+            transform-origin:bottom right; }
+  .bp3-popover .bp3-popover-content{
+    background:#ffffff;
+    color:inherit; }
+  .bp3-popover .bp3-popover-arrow::before{
+    -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2);
+            box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2); }
+  .bp3-popover .bp3-popover-arrow-border{
+    fill:#10161a;
+    fill-opacity:0.1; }
+  .bp3-popover .bp3-popover-arrow-fill{
+    fill:#ffffff; }
+  .bp3-popover-enter > .bp3-popover, .bp3-popover-appear > .bp3-popover{
+    -webkit-transform:scale(0.3);
+            transform:scale(0.3); }
+  .bp3-popover-enter-active > .bp3-popover, .bp3-popover-appear-active > .bp3-popover{
+    -webkit-transform:scale(1);
+            transform:scale(1);
+    -webkit-transition-property:-webkit-transform;
+    transition-property:-webkit-transform;
+    transition-property:transform;
+    transition-property:transform, -webkit-transform;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
+    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-popover-exit > .bp3-popover{
+    -webkit-transform:scale(1);
+            transform:scale(1); }
+  .bp3-popover-exit-active > .bp3-popover{
+    -webkit-transform:scale(0.3);
+            transform:scale(0.3);
+    -webkit-transition-property:-webkit-transform;
+    transition-property:-webkit-transform;
+    transition-property:transform;
+    transition-property:transform, -webkit-transform;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
+    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-popover .bp3-popover-content{
+    position:relative;
+    border-radius:3px; }
+  .bp3-popover.bp3-popover-content-sizing .bp3-popover-content{
+    max-width:350px;
+    padding:20px; }
+  .bp3-popover-target + .bp3-overlay .bp3-popover.bp3-popover-content-sizing{
+    width:350px; }
+  .bp3-popover.bp3-minimal{
+    margin:0 !important; }
+    .bp3-popover.bp3-minimal .bp3-popover-arrow{
+      display:none; }
+    .bp3-popover.bp3-minimal.bp3-popover{
+      -webkit-transform:scale(1);
+              transform:scale(1); }
+      .bp3-popover-enter > .bp3-popover.bp3-minimal.bp3-popover, .bp3-popover-appear > .bp3-popover.bp3-minimal.bp3-popover{
+        -webkit-transform:scale(1);
+                transform:scale(1); }
+      .bp3-popover-enter-active > .bp3-popover.bp3-minimal.bp3-popover, .bp3-popover-appear-active > .bp3-popover.bp3-minimal.bp3-popover{
+        -webkit-transform:scale(1);
+                transform:scale(1);
+        -webkit-transition-property:-webkit-transform;
+        transition-property:-webkit-transform;
+        transition-property:transform;
+        transition-property:transform, -webkit-transform;
+        -webkit-transition-duration:100ms;
+                transition-duration:100ms;
+        -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+        -webkit-transition-delay:0;
+                transition-delay:0; }
+      .bp3-popover-exit > .bp3-popover.bp3-minimal.bp3-popover{
+        -webkit-transform:scale(1);
+                transform:scale(1); }
+      .bp3-popover-exit-active > .bp3-popover.bp3-minimal.bp3-popover{
+        -webkit-transform:scale(1);
+                transform:scale(1);
+        -webkit-transition-property:-webkit-transform;
+        transition-property:-webkit-transform;
+        transition-property:transform;
+        transition-property:transform, -webkit-transform;
+        -webkit-transition-duration:100ms;
+                transition-duration:100ms;
+        -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+        -webkit-transition-delay:0;
+                transition-delay:0; }
+  .bp3-popover.bp3-dark,
+  .bp3-dark .bp3-popover{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
+    .bp3-popover.bp3-dark .bp3-popover-content,
+    .bp3-dark .bp3-popover .bp3-popover-content{
+      background:#30404d;
+      color:inherit; }
+    .bp3-popover.bp3-dark .bp3-popover-arrow::before,
+    .bp3-dark .bp3-popover .bp3-popover-arrow::before{
+      -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4);
+              box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4); }
+    .bp3-popover.bp3-dark .bp3-popover-arrow-border,
+    .bp3-dark .bp3-popover .bp3-popover-arrow-border{
+      fill:#10161a;
+      fill-opacity:0.2; }
+    .bp3-popover.bp3-dark .bp3-popover-arrow-fill,
+    .bp3-dark .bp3-popover .bp3-popover-arrow-fill{
+      fill:#30404d; }
+
+.bp3-popover-arrow::before{
+  display:block;
+  position:absolute;
+  -webkit-transform:rotate(45deg);
+          transform:rotate(45deg);
+  border-radius:2px;
+  content:""; }
+
+.bp3-tether-pinned .bp3-popover-arrow{
+  display:none; }
+
+.bp3-popover-backdrop{
+  background:rgba(255, 255, 255, 0); }
+
+.bp3-transition-container{
+  opacity:1;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  z-index:20; }
+  .bp3-transition-container.bp3-popover-enter, .bp3-transition-container.bp3-popover-appear{
+    opacity:0; }
+  .bp3-transition-container.bp3-popover-enter-active, .bp3-transition-container.bp3-popover-appear-active{
+    opacity:1;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-transition-container.bp3-popover-exit{
+    opacity:1; }
+  .bp3-transition-container.bp3-popover-exit-active{
+    opacity:0;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-transition-container:focus{
+    outline:none; }
+  .bp3-transition-container.bp3-popover-leave .bp3-popover-content{
+    pointer-events:none; }
+  .bp3-transition-container[data-x-out-of-boundaries]{
+    display:none; }
+
+span.bp3-popover-target{
+  display:inline-block; }
+
+.bp3-popover-wrapper.bp3-fill{
+  width:100%; }
+
+.bp3-portal{
+  position:absolute;
+  top:0;
+  right:0;
+  left:0; }
+@-webkit-keyframes linear-progress-bar-stripes{
+  from{
+    background-position:0 0; }
+  to{
+    background-position:30px 0; } }
+@keyframes linear-progress-bar-stripes{
+  from{
+    background-position:0 0; }
+  to{
+    background-position:30px 0; } }
+
+.bp3-progress-bar{
+  display:block;
+  position:relative;
+  border-radius:40px;
+  background:rgba(92, 112, 128, 0.2);
+  width:100%;
+  height:8px;
+  overflow:hidden; }
+  .bp3-progress-bar .bp3-progress-meter{
+    position:absolute;
+    border-radius:40px;
+    background:linear-gradient(-45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%);
+    background-color:rgba(92, 112, 128, 0.8);
+    background-size:30px 30px;
+    width:100%;
+    height:100%;
+    -webkit-transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+  .bp3-progress-bar:not(.bp3-no-animation):not(.bp3-no-stripes) .bp3-progress-meter{
+    animation:linear-progress-bar-stripes 300ms linear infinite reverse; }
+  .bp3-progress-bar.bp3-no-stripes .bp3-progress-meter{
+    background-image:none; }
+
+.bp3-dark .bp3-progress-bar{
+  background:rgba(16, 22, 26, 0.5); }
+  .bp3-dark .bp3-progress-bar .bp3-progress-meter{
+    background-color:#8a9ba8; }
+
+.bp3-progress-bar.bp3-intent-primary .bp3-progress-meter{
+  background-color:#137cbd; }
+
+.bp3-progress-bar.bp3-intent-success .bp3-progress-meter{
+  background-color:#0f9960; }
+
+.bp3-progress-bar.bp3-intent-warning .bp3-progress-meter{
+  background-color:#d9822b; }
+
+.bp3-progress-bar.bp3-intent-danger .bp3-progress-meter{
+  background-color:#db3737; }
+@-webkit-keyframes skeleton-glow{
+  from{
+    border-color:rgba(206, 217, 224, 0.2);
+    background:rgba(206, 217, 224, 0.2); }
+  to{
+    border-color:rgba(92, 112, 128, 0.2);
+    background:rgba(92, 112, 128, 0.2); } }
+@keyframes skeleton-glow{
+  from{
+    border-color:rgba(206, 217, 224, 0.2);
+    background:rgba(206, 217, 224, 0.2); }
+  to{
+    border-color:rgba(92, 112, 128, 0.2);
+    background:rgba(92, 112, 128, 0.2); } }
+.bp3-skeleton{
+  border-color:rgba(206, 217, 224, 0.2) !important;
+  border-radius:2px;
+  -webkit-box-shadow:none !important;
+          box-shadow:none !important;
+  background:rgba(206, 217, 224, 0.2);
+  background-clip:padding-box !important;
+  cursor:default;
+  color:transparent !important;
+  -webkit-animation:1000ms linear infinite alternate skeleton-glow;
+          animation:1000ms linear infinite alternate skeleton-glow;
+  pointer-events:none;
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-skeleton::before, .bp3-skeleton::after,
+  .bp3-skeleton *{
+    visibility:hidden !important; }
+.bp3-slider{
+  width:100%;
+  min-width:150px;
+  height:40px;
+  position:relative;
+  outline:none;
+  cursor:default;
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-slider:hover{
+    cursor:pointer; }
+  .bp3-slider:active{
+    cursor:-webkit-grabbing;
+    cursor:grabbing; }
+  .bp3-slider.bp3-disabled{
+    opacity:0.5;
+    cursor:not-allowed; }
+  .bp3-slider.bp3-slider-unlabeled{
+    height:16px; }
+
+.bp3-slider-track,
+.bp3-slider-progress{
+  top:5px;
+  right:0;
+  left:0;
+  height:6px;
+  position:absolute; }
+
+.bp3-slider-track{
+  border-radius:3px;
+  overflow:hidden; }
+
+.bp3-slider-progress{
+  background:rgba(92, 112, 128, 0.2); }
+  .bp3-dark .bp3-slider-progress{
+    background:rgba(16, 22, 26, 0.5); }
+  .bp3-slider-progress.bp3-intent-primary{
+    background-color:#137cbd; }
+  .bp3-slider-progress.bp3-intent-success{
+    background-color:#0f9960; }
+  .bp3-slider-progress.bp3-intent-warning{
+    background-color:#d9822b; }
+  .bp3-slider-progress.bp3-intent-danger{
+    background-color:#db3737; }
+
+.bp3-slider-handle{
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-color:#f5f8fa;
+  background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
+  background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+  color:#182026;
+  position:absolute;
+  top:0;
+  left:0;
+  border-radius:3px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+  cursor:pointer;
+  width:16px;
+  height:16px; }
+  .bp3-slider-handle:hover{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+    background-clip:padding-box;
+    background-color:#ebf1f5; }
+  .bp3-slider-handle:active, .bp3-slider-handle.bp3-active{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background-color:#d8e1e8;
+    background-image:none; }
+  .bp3-slider-handle:disabled, .bp3-slider-handle.bp3-disabled{
+    outline:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background-color:rgba(206, 217, 224, 0.5);
+    background-image:none;
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6); }
+    .bp3-slider-handle:disabled.bp3-active, .bp3-slider-handle:disabled.bp3-active:hover, .bp3-slider-handle.bp3-disabled.bp3-active, .bp3-slider-handle.bp3-disabled.bp3-active:hover{
+      background:rgba(206, 217, 224, 0.7); }
+  .bp3-slider-handle:focus{
+    z-index:1; }
+  .bp3-slider-handle:hover{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+    background-clip:padding-box;
+    background-color:#ebf1f5;
+    z-index:2;
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+    cursor:-webkit-grab;
+    cursor:grab; }
+  .bp3-slider-handle.bp3-active{
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+    background-color:#d8e1e8;
+    background-image:none;
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
+    cursor:-webkit-grabbing;
+    cursor:grabbing; }
+  .bp3-disabled .bp3-slider-handle{
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:#bfccd6;
+    pointer-events:none; }
+  .bp3-dark .bp3-slider-handle{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+    background-color:#394b59;
+    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
+    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+    color:#f5f8fa; }
+    .bp3-dark .bp3-slider-handle:hover, .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
+      color:#f5f8fa; }
+    .bp3-dark .bp3-slider-handle:hover{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+      background-color:#30404d; }
+    .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+      background-color:#202b33;
+      background-image:none; }
+    .bp3-dark .bp3-slider-handle:disabled, .bp3-dark .bp3-slider-handle.bp3-disabled{
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      background-color:rgba(57, 75, 89, 0.5);
+      background-image:none;
+      color:rgba(167, 182, 194, 0.6); }
+      .bp3-dark .bp3-slider-handle:disabled.bp3-active, .bp3-dark .bp3-slider-handle.bp3-disabled.bp3-active{
+        background:rgba(57, 75, 89, 0.7); }
+    .bp3-dark .bp3-slider-handle .bp3-button-spinner .bp3-spinner-head{
+      background:rgba(16, 22, 26, 0.5);
+      stroke:#8a9ba8; }
+    .bp3-dark .bp3-slider-handle, .bp3-dark .bp3-slider-handle:hover{
+      background-color:#394b59; }
+    .bp3-dark .bp3-slider-handle.bp3-active{
+      background-color:#293742; }
+  .bp3-dark .bp3-disabled .bp3-slider-handle{
+    border-color:#5c7080;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    background:#5c7080; }
+  .bp3-slider-handle .bp3-slider-label{
+    margin-left:8px;
+    border-radius:3px;
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+    background:#394b59;
+    color:#f5f8fa; }
+    .bp3-dark .bp3-slider-handle .bp3-slider-label{
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+      background:#e1e8ed;
+      color:#394b59; }
+    .bp3-disabled .bp3-slider-handle .bp3-slider-label{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-slider-handle.bp3-start, .bp3-slider-handle.bp3-end{
+    width:8px; }
+  .bp3-slider-handle.bp3-start{
+    border-top-right-radius:0;
+    border-bottom-right-radius:0; }
+  .bp3-slider-handle.bp3-end{
+    margin-left:8px;
+    border-top-left-radius:0;
+    border-bottom-left-radius:0; }
+    .bp3-slider-handle.bp3-end .bp3-slider-label{
+      margin-left:0; }
+
+.bp3-slider-label{
+  -webkit-transform:translate(-50%, 20px);
+          transform:translate(-50%, 20px);
+  display:inline-block;
+  position:absolute;
+  padding:2px 5px;
+  vertical-align:top;
+  line-height:1;
+  font-size:12px; }
+
+.bp3-slider.bp3-vertical{
+  width:40px;
+  min-width:40px;
+  height:150px; }
+  .bp3-slider.bp3-vertical .bp3-slider-track,
+  .bp3-slider.bp3-vertical .bp3-slider-progress{
+    top:0;
+    bottom:0;
+    left:5px;
+    width:6px;
+    height:auto; }
+  .bp3-slider.bp3-vertical .bp3-slider-progress{
+    top:auto; }
+  .bp3-slider.bp3-vertical .bp3-slider-label{
+    -webkit-transform:translate(20px, 50%);
+            transform:translate(20px, 50%); }
+  .bp3-slider.bp3-vertical .bp3-slider-handle{
+    top:auto; }
+    .bp3-slider.bp3-vertical .bp3-slider-handle .bp3-slider-label{
+      margin-top:-8px;
+      margin-left:0; }
+    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end, .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
+      margin-left:0;
+      width:16px;
+      height:8px; }
+    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
+      border-top-left-radius:0;
+      border-bottom-right-radius:3px; }
+      .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start .bp3-slider-label{
+        -webkit-transform:translate(20px);
+                transform:translate(20px); }
+    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end{
+      margin-bottom:8px;
+      border-top-left-radius:3px;
+      border-bottom-left-radius:0;
+      border-bottom-right-radius:0; }
+
+@-webkit-keyframes pt-spinner-animation{
+  from{
+    -webkit-transform:rotate(0deg);
+            transform:rotate(0deg); }
+  to{
+    -webkit-transform:rotate(360deg);
+            transform:rotate(360deg); } }
+
+@keyframes pt-spinner-animation{
+  from{
+    -webkit-transform:rotate(0deg);
+            transform:rotate(0deg); }
+  to{
+    -webkit-transform:rotate(360deg);
+            transform:rotate(360deg); } }
+
+.bp3-spinner{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  overflow:visible;
+  vertical-align:middle; }
+  .bp3-spinner svg{
+    display:block; }
+  .bp3-spinner path{
+    fill-opacity:0; }
+  .bp3-spinner .bp3-spinner-head{
+    -webkit-transform-origin:center;
+            transform-origin:center;
+    -webkit-transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    stroke:rgba(92, 112, 128, 0.8);
+    stroke-linecap:round; }
+  .bp3-spinner .bp3-spinner-track{
+    stroke:rgba(92, 112, 128, 0.2); }
+
+.bp3-spinner-animation{
+  -webkit-animation:pt-spinner-animation 500ms linear infinite;
+          animation:pt-spinner-animation 500ms linear infinite; }
+  .bp3-no-spin > .bp3-spinner-animation{
+    -webkit-animation:none;
+            animation:none; }
+
+.bp3-dark .bp3-spinner .bp3-spinner-head{
+  stroke:#8a9ba8; }
+
+.bp3-dark .bp3-spinner .bp3-spinner-track{
+  stroke:rgba(16, 22, 26, 0.5); }
+
+.bp3-spinner.bp3-intent-primary .bp3-spinner-head{
+  stroke:#137cbd; }
+
+.bp3-spinner.bp3-intent-success .bp3-spinner-head{
+  stroke:#0f9960; }
+
+.bp3-spinner.bp3-intent-warning .bp3-spinner-head{
+  stroke:#d9822b; }
+
+.bp3-spinner.bp3-intent-danger .bp3-spinner-head{
+  stroke:#db3737; }
+.bp3-tabs.bp3-vertical{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex; }
+  .bp3-tabs.bp3-vertical > .bp3-tab-list{
+    -webkit-box-orient:vertical;
+    -webkit-box-direction:normal;
+        -ms-flex-direction:column;
+            flex-direction:column;
+    -webkit-box-align:start;
+        -ms-flex-align:start;
+            align-items:flex-start; }
+    .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab{
+      border-radius:3px;
+      width:100%;
+      padding:0 10px; }
+      .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab[aria-selected="true"]{
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        background-color:rgba(19, 124, 189, 0.2); }
+    .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab-indicator-wrapper .bp3-tab-indicator{
+      top:0;
+      right:0;
+      bottom:0;
+      left:0;
+      border-radius:3px;
+      background-color:rgba(19, 124, 189, 0.2);
+      height:auto; }
+  .bp3-tabs.bp3-vertical > .bp3-tab-panel{
+    margin-top:0;
+    padding-left:20px; }
+
+.bp3-tab-list{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+          flex:0 0 auto;
+  -webkit-box-align:end;
+      -ms-flex-align:end;
+          align-items:flex-end;
+  position:relative;
+  margin:0;
+  border:none;
+  padding:0;
+  list-style:none; }
+  .bp3-tab-list > *:not(:last-child){
+    margin-right:20px; }
+
+.bp3-tab{
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  word-wrap:normal;
+  -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+          flex:0 0 auto;
+  position:relative;
+  cursor:pointer;
+  max-width:100%;
+  vertical-align:top;
+  line-height:30px;
+  color:#182026;
+  font-size:14px; }
+  .bp3-tab a{
+    display:block;
+    text-decoration:none;
+    color:inherit; }
+  .bp3-tab-indicator-wrapper ~ .bp3-tab{
+    -webkit-box-shadow:none !important;
+            box-shadow:none !important;
+    background-color:transparent !important; }
+  .bp3-tab[aria-disabled="true"]{
+    cursor:not-allowed;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-tab[aria-selected="true"]{
+    border-radius:0;
+    -webkit-box-shadow:inset 0 -3px 0 #106ba3;
+            box-shadow:inset 0 -3px 0 #106ba3; }
+  .bp3-tab[aria-selected="true"], .bp3-tab:not([aria-disabled="true"]):hover{
+    color:#106ba3; }
+  .bp3-tab:focus{
+    -moz-outline-radius:0; }
+  .bp3-large > .bp3-tab{
+    line-height:40px;
+    font-size:16px; }
+
+.bp3-tab-panel{
+  margin-top:20px; }
+  .bp3-tab-panel[aria-hidden="true"]{
+    display:none; }
+
+.bp3-tab-indicator-wrapper{
+  position:absolute;
+  top:0;
+  left:0;
+  -webkit-transform:translateX(0), translateY(0);
+          transform:translateX(0), translateY(0);
+  -webkit-transition:height, width, -webkit-transform;
+  transition:height, width, -webkit-transform;
+  transition:height, transform, width;
+  transition:height, transform, width, -webkit-transform;
+  -webkit-transition-duration:200ms;
+          transition-duration:200ms;
+  -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+          transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+  pointer-events:none; }
+  .bp3-tab-indicator-wrapper .bp3-tab-indicator{
+    position:absolute;
+    right:0;
+    bottom:0;
+    left:0;
+    background-color:#106ba3;
+    height:3px; }
+  .bp3-tab-indicator-wrapper.bp3-no-animation{
+    -webkit-transition:none;
+    transition:none; }
+
+.bp3-dark .bp3-tab{
+  color:#f5f8fa; }
+  .bp3-dark .bp3-tab[aria-disabled="true"]{
+    color:rgba(167, 182, 194, 0.6); }
+  .bp3-dark .bp3-tab[aria-selected="true"]{
+    -webkit-box-shadow:inset 0 -3px 0 #48aff0;
+            box-shadow:inset 0 -3px 0 #48aff0; }
+  .bp3-dark .bp3-tab[aria-selected="true"], .bp3-dark .bp3-tab:not([aria-disabled="true"]):hover{
+    color:#48aff0; }
+
+.bp3-dark .bp3-tab-indicator{
+  background-color:#48aff0; }
+
+.bp3-flex-expander{
+  -webkit-box-flex:1;
+      -ms-flex:1 1;
+          flex:1 1; }
+.bp3-tag{
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  position:relative;
+  border:none;
+  border-radius:3px;
+  -webkit-box-shadow:none;
+          box-shadow:none;
+  background-color:#5c7080;
+  min-width:20px;
+  max-width:100%;
+  min-height:20px;
+  padding:2px 6px;
+  line-height:16px;
+  color:#f5f8fa;
+  font-size:12px; }
+  .bp3-tag.bp3-interactive{
+    cursor:pointer; }
+    .bp3-tag.bp3-interactive:hover{
+      background-color:rgba(92, 112, 128, 0.85); }
+    .bp3-tag.bp3-interactive.bp3-active, .bp3-tag.bp3-interactive:active{
+      background-color:rgba(92, 112, 128, 0.7); }
+  .bp3-tag > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-tag > .bp3-fill{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-tag::before,
+  .bp3-tag > *{
+    margin-right:4px; }
+  .bp3-tag:empty::before,
+  .bp3-tag > :last-child{
+    margin-right:0; }
+  .bp3-tag:focus{
+    outline:rgba(19, 124, 189, 0.6) auto 2px;
+    outline-offset:0;
+    -moz-outline-radius:6px; }
+  .bp3-tag.bp3-round{
+    border-radius:30px;
+    padding-right:8px;
+    padding-left:8px; }
+  .bp3-dark .bp3-tag{
+    background-color:#bfccd6;
+    color:#182026; }
+    .bp3-dark .bp3-tag.bp3-interactive{
+      cursor:pointer; }
+      .bp3-dark .bp3-tag.bp3-interactive:hover{
+        background-color:rgba(191, 204, 214, 0.85); }
+      .bp3-dark .bp3-tag.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-interactive:active{
+        background-color:rgba(191, 204, 214, 0.7); }
+    .bp3-dark .bp3-tag > .bp3-icon, .bp3-dark .bp3-tag .bp3-icon-standard, .bp3-dark .bp3-tag .bp3-icon-large{
+      fill:currentColor; }
+  .bp3-tag > .bp3-icon, .bp3-tag .bp3-icon-standard, .bp3-tag .bp3-icon-large{
+    fill:#ffffff; }
+  .bp3-tag.bp3-large,
+  .bp3-large .bp3-tag{
+    min-width:30px;
+    min-height:30px;
+    padding:0 10px;
+    line-height:20px;
+    font-size:14px; }
+    .bp3-tag.bp3-large::before,
+    .bp3-tag.bp3-large > *,
+    .bp3-large .bp3-tag::before,
+    .bp3-large .bp3-tag > *{
+      margin-right:7px; }
+    .bp3-tag.bp3-large:empty::before,
+    .bp3-tag.bp3-large > :last-child,
+    .bp3-large .bp3-tag:empty::before,
+    .bp3-large .bp3-tag > :last-child{
+      margin-right:0; }
+    .bp3-tag.bp3-large.bp3-round,
+    .bp3-large .bp3-tag.bp3-round{
+      padding-right:12px;
+      padding-left:12px; }
+  .bp3-tag.bp3-intent-primary{
+    background:#137cbd;
+    color:#ffffff; }
+    .bp3-tag.bp3-intent-primary.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-intent-primary.bp3-interactive:hover{
+        background-color:rgba(19, 124, 189, 0.85); }
+      .bp3-tag.bp3-intent-primary.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-primary.bp3-interactive:active{
+        background-color:rgba(19, 124, 189, 0.7); }
+  .bp3-tag.bp3-intent-success{
+    background:#0f9960;
+    color:#ffffff; }
+    .bp3-tag.bp3-intent-success.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-intent-success.bp3-interactive:hover{
+        background-color:rgba(15, 153, 96, 0.85); }
+      .bp3-tag.bp3-intent-success.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-success.bp3-interactive:active{
+        background-color:rgba(15, 153, 96, 0.7); }
+  .bp3-tag.bp3-intent-warning{
+    background:#d9822b;
+    color:#ffffff; }
+    .bp3-tag.bp3-intent-warning.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-intent-warning.bp3-interactive:hover{
+        background-color:rgba(217, 130, 43, 0.85); }
+      .bp3-tag.bp3-intent-warning.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-warning.bp3-interactive:active{
+        background-color:rgba(217, 130, 43, 0.7); }
+  .bp3-tag.bp3-intent-danger{
+    background:#db3737;
+    color:#ffffff; }
+    .bp3-tag.bp3-intent-danger.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-intent-danger.bp3-interactive:hover{
+        background-color:rgba(219, 55, 55, 0.85); }
+      .bp3-tag.bp3-intent-danger.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-danger.bp3-interactive:active{
+        background-color:rgba(219, 55, 55, 0.7); }
+  .bp3-tag.bp3-fill{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    width:100%; }
+  .bp3-tag.bp3-minimal > .bp3-icon, .bp3-tag.bp3-minimal .bp3-icon-standard, .bp3-tag.bp3-minimal .bp3-icon-large{
+    fill:#5c7080; }
+  .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]){
+    background-color:rgba(138, 155, 168, 0.2);
+    color:#182026; }
+    .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:hover{
+        background-color:rgba(92, 112, 128, 0.3); }
+      .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive.bp3-active, .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:active{
+        background-color:rgba(92, 112, 128, 0.4); }
+    .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]){
+      color:#f5f8fa; }
+      .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive{
+        cursor:pointer; }
+        .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:hover{
+          background-color:rgba(191, 204, 214, 0.3); }
+        .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:active{
+          background-color:rgba(191, 204, 214, 0.4); }
+      .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]) > .bp3-icon, .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]) .bp3-icon-standard, .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]) .bp3-icon-large{
+        fill:#a7b6c2; }
+  .bp3-tag.bp3-minimal.bp3-intent-primary{
+    background-color:rgba(19, 124, 189, 0.15);
+    color:#106ba3; }
+    .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:hover{
+        background-color:rgba(19, 124, 189, 0.25); }
+      .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:active{
+        background-color:rgba(19, 124, 189, 0.35); }
+    .bp3-tag.bp3-minimal.bp3-intent-primary > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-primary .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-primary .bp3-icon-large{
+      fill:#137cbd; }
+    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary{
+      background-color:rgba(19, 124, 189, 0.25);
+      color:#48aff0; }
+      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive{
+        cursor:pointer; }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:hover{
+          background-color:rgba(19, 124, 189, 0.35); }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:active{
+          background-color:rgba(19, 124, 189, 0.45); }
+  .bp3-tag.bp3-minimal.bp3-intent-success{
+    background-color:rgba(15, 153, 96, 0.15);
+    color:#0d8050; }
+    .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:hover{
+        background-color:rgba(15, 153, 96, 0.25); }
+      .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:active{
+        background-color:rgba(15, 153, 96, 0.35); }
+    .bp3-tag.bp3-minimal.bp3-intent-success > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-success .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-success .bp3-icon-large{
+      fill:#0f9960; }
+    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success{
+      background-color:rgba(15, 153, 96, 0.25);
+      color:#3dcc91; }
+      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive{
+        cursor:pointer; }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:hover{
+          background-color:rgba(15, 153, 96, 0.35); }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:active{
+          background-color:rgba(15, 153, 96, 0.45); }
+  .bp3-tag.bp3-minimal.bp3-intent-warning{
+    background-color:rgba(217, 130, 43, 0.15);
+    color:#bf7326; }
+    .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:hover{
+        background-color:rgba(217, 130, 43, 0.25); }
+      .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:active{
+        background-color:rgba(217, 130, 43, 0.35); }
+    .bp3-tag.bp3-minimal.bp3-intent-warning > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-warning .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-warning .bp3-icon-large{
+      fill:#d9822b; }
+    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning{
+      background-color:rgba(217, 130, 43, 0.25);
+      color:#ffb366; }
+      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive{
+        cursor:pointer; }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:hover{
+          background-color:rgba(217, 130, 43, 0.35); }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:active{
+          background-color:rgba(217, 130, 43, 0.45); }
+  .bp3-tag.bp3-minimal.bp3-intent-danger{
+    background-color:rgba(219, 55, 55, 0.15);
+    color:#c23030; }
+    .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive{
+      cursor:pointer; }
+      .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:hover{
+        background-color:rgba(219, 55, 55, 0.25); }
+      .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:active{
+        background-color:rgba(219, 55, 55, 0.35); }
+    .bp3-tag.bp3-minimal.bp3-intent-danger > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-danger .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-danger .bp3-icon-large{
+      fill:#db3737; }
+    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger{
+      background-color:rgba(219, 55, 55, 0.25);
+      color:#ff7373; }
+      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive{
+        cursor:pointer; }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:hover{
+          background-color:rgba(219, 55, 55, 0.35); }
+        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:active{
+          background-color:rgba(219, 55, 55, 0.45); }
+
+.bp3-tag-remove{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  opacity:0.5;
+  margin-top:-2px;
+  margin-right:-6px !important;
+  margin-bottom:-2px;
+  border:none;
+  background:none;
+  cursor:pointer;
+  padding:2px;
+  padding-left:0;
+  color:inherit; }
+  .bp3-tag-remove:hover{
+    opacity:0.8;
+    background:none;
+    text-decoration:none; }
+  .bp3-tag-remove:active{
+    opacity:1; }
+  .bp3-tag-remove:empty::before{
+    line-height:1;
+    font-family:"Icons16", sans-serif;
+    font-size:16px;
+    font-weight:400;
+    font-style:normal;
+    -moz-osx-font-smoothing:grayscale;
+    -webkit-font-smoothing:antialiased;
+    content:""; }
+  .bp3-large .bp3-tag-remove{
+    margin-right:-10px !important;
+    padding:5px;
+    padding-left:0; }
+    .bp3-large .bp3-tag-remove:empty::before{
+      line-height:1;
+      font-family:"Icons20", sans-serif;
+      font-size:20px;
+      font-weight:400;
+      font-style:normal; }
+.bp3-tag-input{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+  -webkit-box-align:start;
+      -ms-flex-align:start;
+          align-items:flex-start;
+  cursor:text;
+  height:auto;
+  min-height:30px;
+  padding-right:0;
+  padding-left:5px;
+  line-height:inherit; }
+  .bp3-tag-input > *{
+    -webkit-box-flex:0;
+        -ms-flex-positive:0;
+            flex-grow:0;
+    -ms-flex-negative:0;
+        flex-shrink:0; }
+  .bp3-tag-input > .bp3-tag-input-values{
+    -webkit-box-flex:1;
+        -ms-flex-positive:1;
+            flex-grow:1;
+    -ms-flex-negative:1;
+        flex-shrink:1; }
+  .bp3-tag-input .bp3-tag-input-icon{
+    margin-top:7px;
+    margin-right:7px;
+    margin-left:2px;
+    color:#5c7080; }
+  .bp3-tag-input .bp3-tag-input-values{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-orient:horizontal;
+    -webkit-box-direction:normal;
+        -ms-flex-direction:row;
+            flex-direction:row;
+    -ms-flex-wrap:wrap;
+        flex-wrap:wrap;
+    -webkit-box-align:center;
+        -ms-flex-align:center;
+            align-items:center;
+    -ms-flex-item-align:stretch;
+        align-self:stretch;
+    margin-top:5px;
+    margin-right:7px;
+    min-width:0; }
+    .bp3-tag-input .bp3-tag-input-values > *{
+      -webkit-box-flex:0;
+          -ms-flex-positive:0;
+              flex-grow:0;
+      -ms-flex-negative:0;
+          flex-shrink:0; }
+    .bp3-tag-input .bp3-tag-input-values > .bp3-fill{
+      -webkit-box-flex:1;
+          -ms-flex-positive:1;
+              flex-grow:1;
+      -ms-flex-negative:1;
+          flex-shrink:1; }
+    .bp3-tag-input .bp3-tag-input-values::before,
+    .bp3-tag-input .bp3-tag-input-values > *{
+      margin-right:5px; }
+    .bp3-tag-input .bp3-tag-input-values:empty::before,
+    .bp3-tag-input .bp3-tag-input-values > :last-child{
+      margin-right:0; }
+    .bp3-tag-input .bp3-tag-input-values:first-child .bp3-input-ghost:first-child{
+      padding-left:5px; }
+    .bp3-tag-input .bp3-tag-input-values > *{
+      margin-bottom:5px; }
+  .bp3-tag-input .bp3-tag{
+    overflow-wrap:break-word; }
+    .bp3-tag-input .bp3-tag.bp3-active{
+      outline:rgba(19, 124, 189, 0.6) auto 2px;
+      outline-offset:0;
+      -moz-outline-radius:6px; }
+  .bp3-tag-input .bp3-input-ghost{
+    -webkit-box-flex:1;
+        -ms-flex:1 1 auto;
+            flex:1 1 auto;
+    width:80px;
+    line-height:20px; }
+    .bp3-tag-input .bp3-input-ghost:disabled, .bp3-tag-input .bp3-input-ghost.bp3-disabled{
+      cursor:not-allowed; }
+  .bp3-tag-input .bp3-button,
+  .bp3-tag-input .bp3-spinner{
+    margin:3px;
+    margin-left:0; }
+  .bp3-tag-input .bp3-button{
+    min-width:24px;
+    min-height:24px;
+    padding:0 7px; }
+  .bp3-tag-input.bp3-large{
+    height:auto;
+    min-height:40px; }
+    .bp3-tag-input.bp3-large::before,
+    .bp3-tag-input.bp3-large > *{
+      margin-right:10px; }
+    .bp3-tag-input.bp3-large:empty::before,
+    .bp3-tag-input.bp3-large > :last-child{
+      margin-right:0; }
+    .bp3-tag-input.bp3-large .bp3-tag-input-icon{
+      margin-top:10px;
+      margin-left:5px; }
+    .bp3-tag-input.bp3-large .bp3-input-ghost{
+      line-height:30px; }
+    .bp3-tag-input.bp3-large .bp3-button{
+      min-width:30px;
+      min-height:30px;
+      padding:5px 10px;
+      margin:5px;
+      margin-left:0; }
+    .bp3-tag-input.bp3-large .bp3-spinner{
+      margin:8px;
+      margin-left:0; }
+  .bp3-tag-input.bp3-active{
+    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+    background-color:#ffffff; }
+    .bp3-tag-input.bp3-active.bp3-intent-primary{
+      -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-tag-input.bp3-active.bp3-intent-success{
+      -webkit-box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-tag-input.bp3-active.bp3-intent-warning{
+      -webkit-box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+    .bp3-tag-input.bp3-active.bp3-intent-danger{
+      -webkit-box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
+  .bp3-dark .bp3-tag-input .bp3-tag-input-icon, .bp3-tag-input.bp3-dark .bp3-tag-input-icon{
+    color:#a7b6c2; }
+  .bp3-dark .bp3-tag-input .bp3-input-ghost, .bp3-tag-input.bp3-dark .bp3-input-ghost{
+    color:#f5f8fa; }
+    .bp3-dark .bp3-tag-input .bp3-input-ghost::-webkit-input-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::-webkit-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-tag-input .bp3-input-ghost::-moz-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::-moz-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-tag-input .bp3-input-ghost:-ms-input-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost:-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-tag-input .bp3-input-ghost::-ms-input-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::-ms-input-placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+    .bp3-dark .bp3-tag-input .bp3-input-ghost::placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::placeholder{
+      color:rgba(167, 182, 194, 0.6); }
+  .bp3-dark .bp3-tag-input.bp3-active, .bp3-tag-input.bp3-dark.bp3-active{
+    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+    background-color:rgba(16, 22, 26, 0.3); }
+    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-primary, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-primary{
+      -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-success, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-success{
+      -webkit-box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-warning, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-warning{
+      -webkit-box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-danger, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-danger{
+      -webkit-box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+
+.bp3-input-ghost{
+  border:none;
+  -webkit-box-shadow:none;
+          box-shadow:none;
+  background:none;
+  padding:0; }
+  .bp3-input-ghost::-webkit-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input-ghost::-moz-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input-ghost:-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input-ghost::-ms-input-placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input-ghost::placeholder{
+    opacity:1;
+    color:rgba(92, 112, 128, 0.6); }
+  .bp3-input-ghost:focus{
+    outline:none !important; }
+.bp3-toast{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-align:start;
+      -ms-flex-align:start;
+          align-items:flex-start;
+  position:relative !important;
+  margin:20px 0 0;
+  border-radius:3px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  background-color:#ffffff;
+  min-width:300px;
+  max-width:500px;
+  pointer-events:all; }
+  .bp3-toast.bp3-toast-enter, .bp3-toast.bp3-toast-appear{
+    -webkit-transform:translateY(-40px);
+            transform:translateY(-40px); }
+  .bp3-toast.bp3-toast-enter-active, .bp3-toast.bp3-toast-appear-active{
+    -webkit-transform:translateY(0);
+            transform:translateY(0);
+    -webkit-transition-property:-webkit-transform;
+    transition-property:-webkit-transform;
+    transition-property:transform;
+    transition-property:transform, -webkit-transform;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
+    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-toast.bp3-toast-enter ~ .bp3-toast, .bp3-toast.bp3-toast-appear ~ .bp3-toast{
+    -webkit-transform:translateY(-40px);
+            transform:translateY(-40px); }
+  .bp3-toast.bp3-toast-enter-active ~ .bp3-toast, .bp3-toast.bp3-toast-appear-active ~ .bp3-toast{
+    -webkit-transform:translateY(0);
+            transform:translateY(0);
+    -webkit-transition-property:-webkit-transform;
+    transition-property:-webkit-transform;
+    transition-property:transform;
+    transition-property:transform, -webkit-transform;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
+    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-toast.bp3-toast-exit{
+    opacity:1;
+    -webkit-filter:blur(0);
+            filter:blur(0); }
+  .bp3-toast.bp3-toast-exit-active{
+    opacity:0;
+    -webkit-filter:blur(10px);
+            filter:blur(10px);
+    -webkit-transition-property:opacity, -webkit-filter;
+    transition-property:opacity, -webkit-filter;
+    transition-property:opacity, filter;
+    transition-property:opacity, filter, -webkit-filter;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-toast.bp3-toast-exit ~ .bp3-toast{
+    -webkit-transform:translateY(0);
+            transform:translateY(0); }
+  .bp3-toast.bp3-toast-exit-active ~ .bp3-toast{
+    -webkit-transform:translateY(-40px);
+            transform:translateY(-40px);
+    -webkit-transition-property:-webkit-transform;
+    transition-property:-webkit-transform;
+    transition-property:transform;
+    transition-property:transform, -webkit-transform;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:50ms;
+            transition-delay:50ms; }
+  .bp3-toast .bp3-button-group{
+    -webkit-box-flex:0;
+        -ms-flex:0 0 auto;
+            flex:0 0 auto;
+    padding:5px;
+    padding-left:0; }
+  .bp3-toast > .bp3-icon{
+    margin:12px;
+    margin-right:0;
+    color:#5c7080; }
+  .bp3-toast.bp3-dark,
+  .bp3-dark .bp3-toast{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+    background-color:#394b59; }
+    .bp3-toast.bp3-dark > .bp3-icon,
+    .bp3-dark .bp3-toast > .bp3-icon{
+      color:#a7b6c2; }
+  .bp3-toast[class*="bp3-intent-"] a{
+    color:rgba(255, 255, 255, 0.7); }
+    .bp3-toast[class*="bp3-intent-"] a:hover{
+      color:#ffffff; }
+  .bp3-toast[class*="bp3-intent-"] > .bp3-icon{
+    color:#ffffff; }
+  .bp3-toast[class*="bp3-intent-"] .bp3-button, .bp3-toast[class*="bp3-intent-"] .bp3-button::before,
+  .bp3-toast[class*="bp3-intent-"] .bp3-button .bp3-icon, .bp3-toast[class*="bp3-intent-"] .bp3-button:active{
+    color:rgba(255, 255, 255, 0.7) !important; }
+  .bp3-toast[class*="bp3-intent-"] .bp3-button:focus{
+    outline-color:rgba(255, 255, 255, 0.5); }
+  .bp3-toast[class*="bp3-intent-"] .bp3-button:hover{
+    background-color:rgba(255, 255, 255, 0.15) !important;
+    color:#ffffff !important; }
+  .bp3-toast[class*="bp3-intent-"] .bp3-button:active{
+    background-color:rgba(255, 255, 255, 0.3) !important;
+    color:#ffffff !important; }
+  .bp3-toast[class*="bp3-intent-"] .bp3-button::after{
+    background:rgba(255, 255, 255, 0.3) !important; }
+  .bp3-toast.bp3-intent-primary{
+    background-color:#137cbd;
+    color:#ffffff; }
+  .bp3-toast.bp3-intent-success{
+    background-color:#0f9960;
+    color:#ffffff; }
+  .bp3-toast.bp3-intent-warning{
+    background-color:#d9822b;
+    color:#ffffff; }
+  .bp3-toast.bp3-intent-danger{
+    background-color:#db3737;
+    color:#ffffff; }
+
+.bp3-toast-message{
+  -webkit-box-flex:1;
+      -ms-flex:1 1 auto;
+          flex:1 1 auto;
+  padding:11px;
+  word-break:break-word; }
+
+.bp3-toast-container{
+  display:-webkit-box !important;
+  display:-ms-flexbox !important;
+  display:flex !important;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+          flex-direction:column;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  position:fixed;
+  right:0;
+  left:0;
+  z-index:40;
+  overflow:hidden;
+  padding:0 20px 20px;
+  pointer-events:none; }
+  .bp3-toast-container.bp3-toast-container-top{
+    top:0;
+    bottom:auto; }
+  .bp3-toast-container.bp3-toast-container-bottom{
+    -webkit-box-orient:vertical;
+    -webkit-box-direction:reverse;
+        -ms-flex-direction:column-reverse;
+            flex-direction:column-reverse;
+    top:auto;
+    bottom:0; }
+  .bp3-toast-container.bp3-toast-container-left{
+    -webkit-box-align:start;
+        -ms-flex-align:start;
+            align-items:flex-start; }
+  .bp3-toast-container.bp3-toast-container-right{
+    -webkit-box-align:end;
+        -ms-flex-align:end;
+            align-items:flex-end; }
+
+.bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active),
+.bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active) ~ .bp3-toast, .bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active),
+.bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active) ~ .bp3-toast,
+.bp3-toast-container-bottom .bp3-toast.bp3-toast-leave-active ~ .bp3-toast{
+  -webkit-transform:translateY(60px);
+          transform:translateY(60px); }
+.bp3-tooltip{
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  -webkit-transform:scale(1);
+          transform:scale(1); }
+  .bp3-tooltip .bp3-popover-arrow{
+    position:absolute;
+    width:22px;
+    height:22px; }
+    .bp3-tooltip .bp3-popover-arrow::before{
+      margin:4px;
+      width:14px;
+      height:14px; }
+  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip{
+    margin-top:-11px;
+    margin-bottom:11px; }
+    .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow{
+      bottom:-8px; }
+      .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(-90deg);
+                transform:rotate(-90deg); }
+  .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-tooltip{
+    margin-left:11px; }
+    .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-tooltip > .bp3-popover-arrow{
+      left:-8px; }
+      .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-tooltip > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(0);
+                transform:rotate(0); }
+  .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-tooltip{
+    margin-top:11px; }
+    .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-tooltip > .bp3-popover-arrow{
+      top:-8px; }
+      .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-tooltip > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(90deg);
+                transform:rotate(90deg); }
+  .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip{
+    margin-right:11px;
+    margin-left:-11px; }
+    .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow{
+      right:-8px; }
+      .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow svg{
+        -webkit-transform:rotate(180deg);
+                transform:rotate(180deg); }
+  .bp3-tether-element-attached-middle > .bp3-tooltip > .bp3-popover-arrow{
+    top:50%;
+    -webkit-transform:translateY(-50%);
+            transform:translateY(-50%); }
+  .bp3-tether-element-attached-center > .bp3-tooltip > .bp3-popover-arrow{
+    right:50%;
+    -webkit-transform:translateX(50%);
+            transform:translateX(50%); }
+  .bp3-tether-element-attached-top.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow{
+    top:-0.22183px; }
+  .bp3-tether-element-attached-right.bp3-tether-target-attached-right > .bp3-tooltip > .bp3-popover-arrow{
+    right:-0.22183px; }
+  .bp3-tether-element-attached-left.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow{
+    left:-0.22183px; }
+  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-bottom > .bp3-tooltip > .bp3-popover-arrow{
+    bottom:-0.22183px; }
+  .bp3-tether-element-attached-top.bp3-tether-element-attached-left > .bp3-tooltip{
+    -webkit-transform-origin:top left;
+            transform-origin:top left; }
+  .bp3-tether-element-attached-top.bp3-tether-element-attached-center > .bp3-tooltip{
+    -webkit-transform-origin:top center;
+            transform-origin:top center; }
+  .bp3-tether-element-attached-top.bp3-tether-element-attached-right > .bp3-tooltip{
+    -webkit-transform-origin:top right;
+            transform-origin:top right; }
+  .bp3-tether-element-attached-middle.bp3-tether-element-attached-left > .bp3-tooltip{
+    -webkit-transform-origin:center left;
+            transform-origin:center left; }
+  .bp3-tether-element-attached-middle.bp3-tether-element-attached-center > .bp3-tooltip{
+    -webkit-transform-origin:center center;
+            transform-origin:center center; }
+  .bp3-tether-element-attached-middle.bp3-tether-element-attached-right > .bp3-tooltip{
+    -webkit-transform-origin:center right;
+            transform-origin:center right; }
+  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-left > .bp3-tooltip{
+    -webkit-transform-origin:bottom left;
+            transform-origin:bottom left; }
+  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-center > .bp3-tooltip{
+    -webkit-transform-origin:bottom center;
+            transform-origin:bottom center; }
+  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-right > .bp3-tooltip{
+    -webkit-transform-origin:bottom right;
+            transform-origin:bottom right; }
+  .bp3-tooltip .bp3-popover-content{
+    background:#394b59;
+    color:#f5f8fa; }
+  .bp3-tooltip .bp3-popover-arrow::before{
+    -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2);
+            box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2); }
+  .bp3-tooltip .bp3-popover-arrow-border{
+    fill:#10161a;
+    fill-opacity:0.1; }
+  .bp3-tooltip .bp3-popover-arrow-fill{
+    fill:#394b59; }
+  .bp3-popover-enter > .bp3-tooltip, .bp3-popover-appear > .bp3-tooltip{
+    -webkit-transform:scale(0.8);
+            transform:scale(0.8); }
+  .bp3-popover-enter-active > .bp3-tooltip, .bp3-popover-appear-active > .bp3-tooltip{
+    -webkit-transform:scale(1);
+            transform:scale(1);
+    -webkit-transition-property:-webkit-transform;
+    transition-property:-webkit-transform;
+    transition-property:transform;
+    transition-property:transform, -webkit-transform;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-popover-exit > .bp3-tooltip{
+    -webkit-transform:scale(1);
+            transform:scale(1); }
+  .bp3-popover-exit-active > .bp3-tooltip{
+    -webkit-transform:scale(0.8);
+            transform:scale(0.8);
+    -webkit-transition-property:-webkit-transform;
+    transition-property:-webkit-transform;
+    transition-property:transform;
+    transition-property:transform, -webkit-transform;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-tooltip .bp3-popover-content{
+    padding:10px 12px; }
+  .bp3-tooltip.bp3-dark,
+  .bp3-dark .bp3-tooltip{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
+    .bp3-tooltip.bp3-dark .bp3-popover-content,
+    .bp3-dark .bp3-tooltip .bp3-popover-content{
+      background:#e1e8ed;
+      color:#394b59; }
+    .bp3-tooltip.bp3-dark .bp3-popover-arrow::before,
+    .bp3-dark .bp3-tooltip .bp3-popover-arrow::before{
+      -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4);
+              box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4); }
+    .bp3-tooltip.bp3-dark .bp3-popover-arrow-border,
+    .bp3-dark .bp3-tooltip .bp3-popover-arrow-border{
+      fill:#10161a;
+      fill-opacity:0.2; }
+    .bp3-tooltip.bp3-dark .bp3-popover-arrow-fill,
+    .bp3-dark .bp3-tooltip .bp3-popover-arrow-fill{
+      fill:#e1e8ed; }
+  .bp3-tooltip.bp3-intent-primary .bp3-popover-content{
+    background:#137cbd;
+    color:#ffffff; }
+  .bp3-tooltip.bp3-intent-primary .bp3-popover-arrow-fill{
+    fill:#137cbd; }
+  .bp3-tooltip.bp3-intent-success .bp3-popover-content{
+    background:#0f9960;
+    color:#ffffff; }
+  .bp3-tooltip.bp3-intent-success .bp3-popover-arrow-fill{
+    fill:#0f9960; }
+  .bp3-tooltip.bp3-intent-warning .bp3-popover-content{
+    background:#d9822b;
+    color:#ffffff; }
+  .bp3-tooltip.bp3-intent-warning .bp3-popover-arrow-fill{
+    fill:#d9822b; }
+  .bp3-tooltip.bp3-intent-danger .bp3-popover-content{
+    background:#db3737;
+    color:#ffffff; }
+  .bp3-tooltip.bp3-intent-danger .bp3-popover-arrow-fill{
+    fill:#db3737; }
+
+.bp3-tooltip-indicator{
+  border-bottom:dotted 1px;
+  cursor:help; }
+.bp3-tree .bp3-icon, .bp3-tree .bp3-icon-standard, .bp3-tree .bp3-icon-large{
+  color:#5c7080; }
+  .bp3-tree .bp3-icon.bp3-intent-primary, .bp3-tree .bp3-icon-standard.bp3-intent-primary, .bp3-tree .bp3-icon-large.bp3-intent-primary{
+    color:#137cbd; }
+  .bp3-tree .bp3-icon.bp3-intent-success, .bp3-tree .bp3-icon-standard.bp3-intent-success, .bp3-tree .bp3-icon-large.bp3-intent-success{
+    color:#0f9960; }
+  .bp3-tree .bp3-icon.bp3-intent-warning, .bp3-tree .bp3-icon-standard.bp3-intent-warning, .bp3-tree .bp3-icon-large.bp3-intent-warning{
+    color:#d9822b; }
+  .bp3-tree .bp3-icon.bp3-intent-danger, .bp3-tree .bp3-icon-standard.bp3-intent-danger, .bp3-tree .bp3-icon-large.bp3-intent-danger{
+    color:#db3737; }
+
+.bp3-tree-node-list{
+  margin:0;
+  padding-left:0;
+  list-style:none; }
+
+.bp3-tree-root{
+  position:relative;
+  background-color:transparent;
+  cursor:default;
+  padding-left:0; }
+
+.bp3-tree-node-content-0{
+  padding-left:0px; }
+
+.bp3-tree-node-content-1{
+  padding-left:23px; }
+
+.bp3-tree-node-content-2{
+  padding-left:46px; }
+
+.bp3-tree-node-content-3{
+  padding-left:69px; }
+
+.bp3-tree-node-content-4{
+  padding-left:92px; }
+
+.bp3-tree-node-content-5{
+  padding-left:115px; }
+
+.bp3-tree-node-content-6{
+  padding-left:138px; }
+
+.bp3-tree-node-content-7{
+  padding-left:161px; }
+
+.bp3-tree-node-content-8{
+  padding-left:184px; }
+
+.bp3-tree-node-content-9{
+  padding-left:207px; }
+
+.bp3-tree-node-content-10{
+  padding-left:230px; }
+
+.bp3-tree-node-content-11{
+  padding-left:253px; }
+
+.bp3-tree-node-content-12{
+  padding-left:276px; }
+
+.bp3-tree-node-content-13{
+  padding-left:299px; }
+
+.bp3-tree-node-content-14{
+  padding-left:322px; }
+
+.bp3-tree-node-content-15{
+  padding-left:345px; }
+
+.bp3-tree-node-content-16{
+  padding-left:368px; }
+
+.bp3-tree-node-content-17{
+  padding-left:391px; }
+
+.bp3-tree-node-content-18{
+  padding-left:414px; }
+
+.bp3-tree-node-content-19{
+  padding-left:437px; }
+
+.bp3-tree-node-content-20{
+  padding-left:460px; }
+
+.bp3-tree-node-content{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  width:100%;
+  height:30px;
+  padding-right:5px; }
+  .bp3-tree-node-content:hover{
+    background-color:rgba(191, 204, 214, 0.4); }
+
+.bp3-tree-node-caret,
+.bp3-tree-node-caret-none{
+  min-width:30px; }
+
+.bp3-tree-node-caret{
+  color:#5c7080;
+  -webkit-transform:rotate(0deg);
+          transform:rotate(0deg);
+  cursor:pointer;
+  padding:7px;
+  -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+  .bp3-tree-node-caret:hover{
+    color:#182026; }
+  .bp3-dark .bp3-tree-node-caret{
+    color:#a7b6c2; }
+    .bp3-dark .bp3-tree-node-caret:hover{
+      color:#f5f8fa; }
+  .bp3-tree-node-caret.bp3-tree-node-caret-open{
+    -webkit-transform:rotate(90deg);
+            transform:rotate(90deg); }
+  .bp3-tree-node-caret.bp3-icon-standard::before{
+    content:""; }
+
+.bp3-tree-node-icon{
+  position:relative;
+  margin-right:7px; }
+
+.bp3-tree-node-label{
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  word-wrap:normal;
+  -webkit-box-flex:1;
+      -ms-flex:1 1 auto;
+          flex:1 1 auto;
+  position:relative;
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-tree-node-label span{
+    display:inline; }
+
+.bp3-tree-node-secondary-label{
+  padding:0 5px;
+  -webkit-user-select:none;
+     -moz-user-select:none;
+      -ms-user-select:none;
+          user-select:none; }
+  .bp3-tree-node-secondary-label .bp3-popover-wrapper,
+  .bp3-tree-node-secondary-label .bp3-popover-target{
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex;
+    -webkit-box-align:center;
+        -ms-flex-align:center;
+            align-items:center; }
+
+.bp3-tree-node.bp3-disabled .bp3-tree-node-content{
+  background-color:inherit;
+  cursor:not-allowed;
+  color:rgba(92, 112, 128, 0.6); }
+
+.bp3-tree-node.bp3-disabled .bp3-tree-node-caret,
+.bp3-tree-node.bp3-disabled .bp3-tree-node-icon{
+  cursor:not-allowed;
+  color:rgba(92, 112, 128, 0.6); }
+
+.bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
+  background-color:#137cbd; }
+  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content,
+  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon, .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon-standard, .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon-large{
+    color:#ffffff; }
+  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-tree-node-caret::before{
+    color:rgba(255, 255, 255, 0.7); }
+  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-tree-node-caret:hover::before{
+    color:#ffffff; }
+
+.bp3-dark .bp3-tree-node-content:hover{
+  background-color:rgba(92, 112, 128, 0.3); }
+
+.bp3-dark .bp3-tree .bp3-icon, .bp3-dark .bp3-tree .bp3-icon-standard, .bp3-dark .bp3-tree .bp3-icon-large{
+  color:#a7b6c2; }
+  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-primary, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-primary, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-primary{
+    color:#137cbd; }
+  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-success, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-success, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-success{
+    color:#0f9960; }
+  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-warning, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-warning, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-warning{
+    color:#d9822b; }
+  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-danger, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-danger, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-danger{
+    color:#db3737; }
+
+.bp3-dark .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
+  background-color:#137cbd; }
+/*!
+
+Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0.
+
+*/
+.bp3-omnibar{
+  -webkit-filter:blur(0);
+          filter:blur(0);
+  opacity:1;
+  top:20vh;
+  left:calc(50% - 250px);
+  z-index:21;
+  border-radius:3px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  background-color:#ffffff;
+  width:500px; }
+  .bp3-omnibar.bp3-overlay-enter, .bp3-omnibar.bp3-overlay-appear{
+    -webkit-filter:blur(20px);
+            filter:blur(20px);
+    opacity:0.2; }
+  .bp3-omnibar.bp3-overlay-enter-active, .bp3-omnibar.bp3-overlay-appear-active{
+    -webkit-filter:blur(0);
+            filter:blur(0);
+    opacity:1;
+    -webkit-transition-property:opacity, -webkit-filter;
+    transition-property:opacity, -webkit-filter;
+    transition-property:filter, opacity;
+    transition-property:filter, opacity, -webkit-filter;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-omnibar.bp3-overlay-exit{
+    -webkit-filter:blur(0);
+            filter:blur(0);
+    opacity:1; }
+  .bp3-omnibar.bp3-overlay-exit-active{
+    -webkit-filter:blur(20px);
+            filter:blur(20px);
+    opacity:0.2;
+    -webkit-transition-property:opacity, -webkit-filter;
+    transition-property:opacity, -webkit-filter;
+    transition-property:filter, opacity;
+    transition-property:filter, opacity, -webkit-filter;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
+    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
+    -webkit-transition-delay:0;
+            transition-delay:0; }
+  .bp3-omnibar .bp3-input{
+    border-radius:0;
+    background-color:transparent; }
+    .bp3-omnibar .bp3-input, .bp3-omnibar .bp3-input:focus{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-omnibar .bp3-menu{
+    border-radius:0;
+    -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
+            box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
+    background-color:transparent;
+    max-height:calc(60vh - 40px);
+    overflow:auto; }
+    .bp3-omnibar .bp3-menu:empty{
+      display:none; }
+  .bp3-dark .bp3-omnibar, .bp3-omnibar.bp3-dark{
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+    background-color:#30404d; }
+
+.bp3-omnibar-overlay .bp3-overlay-backdrop{
+  background-color:rgba(16, 22, 26, 0.2); }
+
+.bp3-select-popover .bp3-popover-content{
+  padding:5px; }
+
+.bp3-select-popover .bp3-input-group{
+  margin-bottom:0; }
+
+.bp3-select-popover .bp3-menu{
+  max-width:400px;
+  max-height:300px;
+  overflow:auto;
+  padding:0; }
+  .bp3-select-popover .bp3-menu:not(:first-child){
+    padding-top:5px; }
+
+.bp3-multi-select{
+  min-width:150px; }
+
+.bp3-multi-select-popover .bp3-menu{
+  max-width:400px;
+  max-height:300px;
+  overflow:auto; }
+
+.bp3-select-popover .bp3-popover-content{
+  padding:5px; }
+
+.bp3-select-popover .bp3-input-group{
+  margin-bottom:0; }
+
+.bp3-select-popover .bp3-menu{
+  max-width:400px;
+  max-height:300px;
+  overflow:auto;
+  padding:0; }
+  .bp3-select-popover .bp3-menu:not(:first-child){
+    padding-top:5px; }
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensureUiComponents() in @jupyterlab/buildutils */
+
+/**
+ * (DEPRECATED) Support for consuming icons as CSS background images
+ */
+
+/* Icons urls */
+
+:root {
+  --jp-icon-add: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE5IDEzaC02djZoLTJ2LTZINXYtMmg2VjVoMnY2aDZ2MnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-bug: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIwIDhoLTIuODFjLS40NS0uNzgtMS4wNy0xLjQ1LTEuODItMS45NkwxNyA0LjQxIDE1LjU5IDNsLTIuMTcgMi4xN0MxMi45NiA1LjA2IDEyLjQ5IDUgMTIgNWMtLjQ5IDAtLjk2LjA2LTEuNDEuMTdMOC40MSAzIDcgNC40MWwxLjYyIDEuNjNDNy44OCA2LjU1IDcuMjYgNy4yMiA2LjgxIDhINHYyaDIuMDljLS4wNS4zMy0uMDkuNjYtLjA5IDF2MUg0djJoMnYxYzAgLjM0LjA0LjY3LjA5IDFINHYyaDIuODFjMS4wNCAxLjc5IDIuOTcgMyA1LjE5IDNzNC4xNS0xLjIxIDUuMTktM0gyMHYtMmgtMi4wOWMuMDUtLjMzLjA5LS42Ni4wOS0xdi0xaDJ2LTJoLTJ2LTFjMC0uMzQtLjA0LS42Ny0uMDktMUgyMFY4em0tNiA4aC00di0yaDR2MnptMC00aC00di0yaDR2MnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-build: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE0LjkgMTcuNDVDMTYuMjUgMTcuNDUgMTcuMzUgMTYuMzUgMTcuMzUgMTVDMTcuMzUgMTMuNjUgMTYuMjUgMTIuNTUgMTQuOSAxMi41NUMxMy41NCAxMi41NSAxMi40NSAxMy42NSAxMi40NSAxNUMxMi40NSAxNi4zNSAxMy41NCAxNy40NSAxNC45IDE3LjQ1Wk0yMC4xIDE1LjY4TDIxLjU4IDE2Ljg0QzIxLjcxIDE2Ljk1IDIxLjc1IDE3LjEzIDIxLjY2IDE3LjI5TDIwLjI2IDE5LjcxQzIwLjE3IDE5Ljg2IDIwIDE5LjkyIDE5LjgzIDE5Ljg2TDE4LjA5IDE5LjE2QzE3LjczIDE5LjQ0IDE3LjMzIDE5LjY3IDE2LjkxIDE5Ljg1TDE2LjY0IDIxLjdDMTYuNjIgMjEuODcgMTYuNDcgMjIgMTYuMyAyMkgxMy41QzEzLjMyIDIyIDEzLjE4IDIxLjg3IDEzLjE1IDIxLjdMMTIuODkgMTkuODVDMTIuNDYgMTkuNjcgMTIuMDcgMTkuNDQgMTEuNzEgMTkuMTZMOS45NjAwMiAxOS44NkM5LjgxMDAyIDE5LjkyIDkuNjIwMDIgMTkuODYgOS41NDAwMiAxOS43MUw4LjE0MDAyIDE3LjI5QzguMDUwMDIgMTcuMTMgOC4wOTAwMiAxNi45NSA4LjIyMDAyIDE2Ljg0TDkuNzAwMDIgMTUuNjhMOS42NTAwMSAxNUw5LjcwMDAyIDE0LjMxTDguMjIwMDIgMTMuMTZDOC4wOTAwMiAxMy4wNSA4LjA1MDAyIDEyLjg2IDguMTQwMDIgMTIuNzFMOS41NDAwMiAxMC4yOUM5LjYyMDAyIDEwLjEzIDkuODEwMDIgMTAuMDcgOS45NjAwMiAxMC4xM0wxMS43MSAxMC44NEMxMi4wNyAxMC41NiAxMi40NiAxMC4zMiAxMi44OSAxMC4xNUwxMy4xNSA4LjI4OTk4QzEzLjE4IDguMTI5OTggMTMuMzIgNy45OTk5OCAxMy41IDcuOTk5OThIMTYuM0MxNi40NyA3Ljk5OTk4IDE2LjYyIDguMTI5OTggMTYuNjQgOC4yODk5OEwxNi45MSAxMC4xNUMxNy4zMyAxMC4zMiAxNy43MyAxMC41NiAxOC4wOSAxMC44NEwxOS44MyAxMC4xM0MyMCAxMC4wNyAyMC4xNyAxMC4xMyAyMC4yNiAxMC4yOUwyMS42NiAxMi43MUMyMS43NSAxMi44NiAyMS43MSAxMy4wNSAyMS41OCAxMy4xNkwyMC4xIDE0LjMxTDIwLjE1IDE1TDIwLjEgMTUuNjhaIi8+CiAgICA8cGF0aCBkPSJNNy4zMjk2NiA3LjQ0NDU0QzguMDgzMSA3LjAwOTU0IDguMzM5MzIgNi4wNTMzMiA3LjkwNDMyIDUuMjk5ODhDNy40NjkzMiA0LjU0NjQzIDYuNTA4MSA0LjI4MTU2IDUuNzU0NjYgNC43MTY1NkM1LjM5MTc2IDQuOTI2MDggNS4xMjY5NSA1LjI3MTE4IDUuMDE4NDkgNS42NzU5NEM0LjkxMDA0IDYuMDgwNzEgNC45NjY4MiA2LjUxMTk4IDUuMTc2MzQgNi44NzQ4OEM1LjYxMTM0IDcuNjI4MzIgNi41NzYyMiA3Ljg3OTU0IDcuMzI5NjYgNy40NDQ1NFpNOS42NTcxOCA0Ljc5NTkzTDEwLjg2NzIgNC45NTE3OUMxMC45NjI4IDQuOTc3NDEgMTEuMDQwMiA1LjA3MTMzIDExLjAzODIgNS4xODc5M0wxMS4wMzg4IDYuOTg4OTNDMTEuMDQ1NSA3LjEwMDU0IDEwLjk2MTYgNy4xOTUxOCAxMC44NTUgNy4yMTA1NEw5LjY2MDAxIDcuMzgwODNMOS4yMzkxNSA4LjEzMTg4TDkuNjY5NjEgOS4yNTc0NUM5LjcwNzI5IDkuMzYyNzEgOS42NjkzNCA5LjQ3Njk5IDkuNTc0MDggOS41MzE5OUw4LjAxNTIzIDEwLjQzMkM3LjkxMTMxIDEwLjQ5MiA3Ljc5MzM3IDEwLjQ2NzcgNy43MjEwNSAxMC4zODI0TDYuOTg3NDggOS40MzE4OEw2LjEwOTMxIDkuNDMwODNMNS4zNDcwNCAxMC4zOTA1QzUuMjg5MDkgMTAuNDcwMiA1LjE3MzgzIDEwLjQ5MDUgNS4wNzE4NyAxMC40MzM5TDMuNTEyNDUgOS41MzI5M0MzLjQxMDQ5IDkuNDc2MzMgMy4zNzY0NyA5LjM1NzQxIDMuNDEwNzUgOS4yNTY3OUwzLjg2MzQ3IDguMTQwOTNMMy42MTc0OSA3Ljc3NDg4TDMuNDIzNDcgNy4zNzg4M0wyLjIzMDc1IDcuMjEyOTdDMi4xMjY0NyA3LjE5MjM1IDIuMDQwNDkgNy4xMDM0MiAyLjA0MjQ1IDYuOTg2ODJMMi4wNDE4NyA1LjE4NTgyQzIuMDQzODMgNS4wNjkyMiAyLjExOTA5IDQuOTc5NTggMi4yMTcwNCA0Ljk2OTIyTDMuNDIwNjUgNC43OTM5M0wzLjg2NzQ5IDQuMDI3ODhMMy40MTEwNSAyLjkxNzMxQzMuMzczMzcgMi44MTIwNCAzLjQxMTMxIDIuNjk3NzYgMy41MTUyMyAyLjYzNzc2TDUuMDc0MDggMS43Mzc3NkM1LjE2OTM0IDEuNjgyNzYgNS4yODcyOSAxLjcwNzA0IDUuMzU5NjEgMS43OTIzMUw2LjExOTE1IDIuNzI3ODhMNi45ODAwMSAyLjczODkzTDcuNzI0OTYgMS43ODkyMkM3Ljc5MTU2IDEuNzA0NTggNy45MTU0OCAxLjY3OTIyIDguMDA4NzkgMS43NDA4Mkw5LjU2ODIxIDIuNjQxODJDOS42NzAxNyAyLjY5ODQyIDkuNzEyODUgMi44MTIzNCA5LjY4NzIzIDIuOTA3OTdMOS4yMTcxOCA0LjAzMzgzTDkuNDYzMTYgNC4zOTk4OEw5LjY1NzE4IDQuNzk1OTNaIi8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-caret-down-empty-thin: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwIDIwIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSIgc2hhcGUtcmVuZGVyaW5nPSJnZW9tZXRyaWNQcmVjaXNpb24iPgoJCTxwb2x5Z29uIGNsYXNzPSJzdDEiIHBvaW50cz0iOS45LDEzLjYgMy42LDcuNCA0LjQsNi42IDkuOSwxMi4yIDE1LjQsNi43IDE2LjEsNy40ICIvPgoJPC9nPgo8L3N2Zz4K);
+  --jp-icon-caret-down-empty: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiIHNoYXBlLXJlbmRlcmluZz0iZ2VvbWV0cmljUHJlY2lzaW9uIj4KICAgIDxwYXRoIGQ9Ik01LjIsNS45TDksOS43bDMuOC0zLjhsMS4yLDEuMmwtNC45LDVsLTQuOS01TDUuMiw1Ljl6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-caret-down: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiIHNoYXBlLXJlbmRlcmluZz0iZ2VvbWV0cmljUHJlY2lzaW9uIj4KICAgIDxwYXRoIGQ9Ik01LjIsNy41TDksMTEuMmwzLjgtMy44SDUuMnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-caret-left: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSIgc2hhcGUtcmVuZGVyaW5nPSJnZW9tZXRyaWNQcmVjaXNpb24iPgoJCTxwYXRoIGQ9Ik0xMC44LDEyLjhMNy4xLDlsMy44LTMuOGwwLDcuNkgxMC44eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-caret-right: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiIHNoYXBlLXJlbmRlcmluZz0iZ2VvbWV0cmljUHJlY2lzaW9uIj4KICAgIDxwYXRoIGQ9Ik03LjIsNS4yTDEwLjksOWwtMy44LDMuOFY1LjJINy4yeiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-caret-up-empty-thin: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwIDIwIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSIgc2hhcGUtcmVuZGVyaW5nPSJnZW9tZXRyaWNQcmVjaXNpb24iPgoJCTxwb2x5Z29uIGNsYXNzPSJzdDEiIHBvaW50cz0iMTUuNCwxMy4zIDkuOSw3LjcgNC40LDEzLjIgMy42LDEyLjUgOS45LDYuMyAxNi4xLDEyLjYgIi8+Cgk8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-caret-up: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSIgc2hhcGUtcmVuZGVyaW5nPSJnZW9tZXRyaWNQcmVjaXNpb24iPgoJCTxwYXRoIGQ9Ik01LjIsMTAuNUw5LDYuOGwzLjgsMy44SDUuMnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-case-sensitive: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwIDIwIj4KICA8ZyBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiM0MTQxNDEiPgogICAgPHJlY3QgeD0iMiIgeT0iMiIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgPC9nPgogIDxnIGNsYXNzPSJqcC1pY29uLWFjY2VudDIiIGZpbGw9IiNGRkYiPgogICAgPHBhdGggZD0iTTcuNiw4aDAuOWwzLjUsOGgtMS4xTDEwLDE0SDZsLTAuOSwySDRMNy42LDh6IE04LDkuMUw2LjQsMTNoMy4yTDgsOS4xeiIvPgogICAgPHBhdGggZD0iTTE2LjYsOS44Yy0wLjIsMC4xLTAuNCwwLjEtMC43LDAuMWMtMC4yLDAtMC40LTAuMS0wLjYtMC4yYy0wLjEtMC4xLTAuMi0wLjQtMC4yLTAuNyBjLTAuMywwLjMtMC42LDAuNS0wLjksMC43Yy0wLjMsMC4xLTAuNywwLjItMS4xLDAuMmMtMC4zLDAtMC41LDAtMC43LTAuMWMtMC4yLTAuMS0wLjQtMC4yLTAuNi0wLjNjLTAuMi0wLjEtMC4zLTAuMy0wLjQtMC41IGMtMC4xLTAuMi0wLjEtMC40LTAuMS0wLjdjMC0wLjMsMC4xLTAuNiwwLjItMC44YzAuMS0wLjIsMC4zLTAuNCwwLjQtMC41QzEyLDcsMTIuMiw2LjksMTIuNSw2LjhjMC4yLTAuMSwwLjUtMC4xLDAuNy0wLjIgYzAuMy0wLjEsMC41LTAuMSwwLjctMC4xYzAuMiwwLDAuNC0wLjEsMC42LTAuMWMwLjIsMCwwLjMtMC4xLDAuNC0wLjJjMC4xLTAuMSwwLjItMC4yLDAuMi0wLjRjMC0xLTEuMS0xLTEuMy0xIGMtMC40LDAtMS40LDAtMS40LDEuMmgtMC45YzAtMC40LDAuMS0wLjcsMC4yLTFjMC4xLTAuMiwwLjMtMC40LDAuNS0wLjZjMC4yLTAuMiwwLjUtMC4zLDAuOC0wLjNDMTMuMyw0LDEzLjYsNCwxMy45LDQgYzAuMywwLDAuNSwwLDAuOCwwLjFjMC4zLDAsMC41LDAuMSwwLjcsMC4yYzAuMiwwLjEsMC40LDAuMywwLjUsMC41QzE2LDUsMTYsNS4yLDE2LDUuNnYyLjljMCwwLjIsMCwwLjQsMCwwLjUgYzAsMC4xLDAuMSwwLjIsMC4zLDAuMmMwLjEsMCwwLjIsMCwwLjMsMFY5Ljh6IE0xNS4yLDYuOWMtMS4yLDAuNi0zLjEsMC4yLTMuMSwxLjRjMCwxLjQsMy4xLDEsMy4xLTAuNVY2Ljl6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-check: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTkgMTYuMTdMNC44MyAxMmwtMS40MiAxLjQxTDkgMTkgMjEgN2wtMS40MS0xLjQxeiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-circle-empty: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyIDJDNi40NyAyIDIgNi40NyAyIDEyczQuNDcgMTAgMTAgMTAgMTAtNC40NyAxMC0xMFMxNy41MyAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-circle: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPGNpcmNsZSBjeD0iOSIgY3k9IjkiIHI9IjgiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-clear: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8bWFzayBpZD0iZG9udXRIb2xlIj4KICAgIDxyZWN0IHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0id2hpdGUiIC8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI4IiBmaWxsPSJibGFjayIvPgogIDwvbWFzaz4KCiAgPGcgY2xhc3M9ImpwLWljb24zIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxyZWN0IGhlaWdodD0iMTgiIHdpZHRoPSIyIiB4PSIxMSIgeT0iMyIgdHJhbnNmb3JtPSJyb3RhdGUoMzE1LCAxMiwgMTIpIi8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgbWFzaz0idXJsKCNkb251dEhvbGUpIi8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-close: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1ub25lIGpwLWljb24tc2VsZWN0YWJsZS1pbnZlcnNlIGpwLWljb24zLWhvdmVyIiBmaWxsPSJub25lIj4KICAgIDxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjExIi8+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIGpwLWljb24tYWNjZW50Mi1ob3ZlciIgZmlsbD0iIzYxNjE2MSI+CiAgICA8cGF0aCBkPSJNMTkgNi40MUwxNy41OSA1IDEyIDEwLjU5IDYuNDEgNSA1IDYuNDEgMTAuNTkgMTIgNSAxNy41OSA2LjQxIDE5IDEyIDEzLjQxIDE3LjU5IDE5IDE5IDE3LjU5IDEzLjQxIDEyeiIvPgogIDwvZz4KCiAgPGcgY2xhc3M9ImpwLWljb24tbm9uZSBqcC1pY29uLWJ1c3kiIGZpbGw9Im5vbmUiPgogICAgPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iNyIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-console: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwMCAyMDAiPgogIDxnIGNsYXNzPSJqcC1pY29uLWJyYW5kMSBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiMwMjg4RDEiPgogICAgPHBhdGggZD0iTTIwIDE5LjhoMTYwdjE1OS45SDIweiIvPgogIDwvZz4KICA8ZyBjbGFzcz0ianAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNmZmYiPgogICAgPHBhdGggZD0iTTEwNSAxMjcuM2g0MHYxMi44aC00MHpNNTEuMSA3N0w3NCA5OS45bC0yMy4zIDIzLjMgMTAuNSAxMC41IDIzLjMtMjMuM0w5NSA5OS45IDg0LjUgODkuNCA2MS42IDY2LjV6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-copy: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTExLjksMUgzLjJDMi40LDEsMS43LDEuNywxLjcsMi41djEwLjJoMS41VjIuNWg4LjdWMXogTTE0LjEsMy45aC04Yy0wLjgsMC0xLjUsMC43LTEuNSwxLjV2MTAuMmMwLDAuOCwwLjcsMS41LDEuNSwxLjVoOCBjMC44LDAsMS41LTAuNywxLjUtMS41VjUuNEMxNS41LDQuNiwxNC45LDMuOSwxNC4xLDMuOXogTTE0LjEsMTUuNWgtOFY1LjRoOFYxNS41eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-cut: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTkuNjQgNy42NGMuMjMtLjUuMzYtMS4wNS4zNi0xLjY0IDAtMi4yMS0xLjc5LTQtNC00UzIgMy43OSAyIDZzMS43OSA0IDQgNGMuNTkgMCAxLjE0LS4xMyAxLjY0LS4zNkwxMCAxMmwtMi4zNiAyLjM2QzcuMTQgMTQuMTMgNi41OSAxNCA2IDE0Yy0yLjIxIDAtNCAxLjc5LTQgNHMxLjc5IDQgNCA0IDQtMS43OSA0LTRjMC0uNTktLjEzLTEuMTQtLjM2LTEuNjRMMTIgMTRsNyA3aDN2LTFMOS42NCA3LjY0ek02IDhjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTAgMTJjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTYtNy41Yy0uMjggMC0uNS0uMjItLjUtLjVzLjIyLS41LjUtLjUuNS4yMi41LjUtLjIyLjUtLjUuNXpNMTkgM2wtNiA2IDIgMiA3LTdWM3oiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-download: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE5IDloLTRWM0g5djZINWw3IDcgNy03ek01IDE4djJoMTR2LTJINXoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-edit: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTMgMTcuMjVWMjFoMy43NUwxNy44MSA5Ljk0bC0zLjc1LTMuNzVMMyAxNy4yNXpNMjAuNzEgNy4wNGMuMzktLjM5LjM5LTEuMDIgMC0xLjQxbC0yLjM0LTIuMzRjLS4zOS0uMzktMS4wMi0uMzktMS40MSAwbC0xLjgzIDEuODMgMy43NSAzLjc1IDEuODMtMS44M3oiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-ellipses: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPGNpcmNsZSBjeD0iNSIgY3k9IjEyIiByPSIyIi8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIyIi8+CiAgICA8Y2lyY2xlIGN4PSIxOSIgY3k9IjEyIiByPSIyIi8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-extension: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIwLjUgMTFIMTlWN2MwLTEuMS0uOS0yLTItMmgtNFYzLjVDMTMgMi4xMiAxMS44OCAxIDEwLjUgMVM4IDIuMTIgOCAzLjVWNUg0Yy0xLjEgMC0xLjk5LjktMS45OSAydjMuOEgzLjVjMS40OSAwIDIuNyAxLjIxIDIuNyAyLjdzLTEuMjEgMi43LTIuNyAyLjdIMlYyMGMwIDEuMS45IDIgMiAyaDMuOHYtMS41YzAtMS40OSAxLjIxLTIuNyAyLjctMi43IDEuNDkgMCAyLjcgMS4yMSAyLjcgMi43VjIySDE3YzEuMSAwIDItLjkgMi0ydi00aDEuNWMxLjM4IDAgMi41LTEuMTIgMi41LTIuNVMyMS44OCAxMSAyMC41IDExeiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-fast-forward: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTQgMThsOC41LTZMNCA2djEyem05LTEydjEybDguNS02TDEzIDZ6Ii8+CiAgICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-file-upload: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTkgMTZoNnYtNmg0bC03LTctNyA3aDR6bS00IDJoMTR2Mkg1eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-file: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTkuMyA4LjJsLTUuNS01LjVjLS4zLS4zLS43LS41LTEuMi0uNUgzLjljLS44LjEtMS42LjktMS42IDEuOHYxNC4xYzAgLjkuNyAxLjYgMS42IDEuNmgxNC4yYy45IDAgMS42LS43IDEuNi0xLjZWOS40Yy4xLS41LS4xLS45LS40LTEuMnptLTUuOC0zLjNsMy40IDMuNmgtMy40VjQuOXptMy45IDEyLjdINC43Yy0uMSAwLS4yIDAtLjItLjJWNC43YzAtLjIuMS0uMy4yLS4zaDcuMnY0LjRzMCAuOC4zIDEuMWMuMy4zIDEuMS4zIDEuMS4zaDQuM3Y3LjJzLS4xLjItLjIuMnoiLz4KPC9zdmc+Cg==);
+  --jp-icon-filter-list: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEwIDE4aDR2LTJoLTR2MnpNMyA2djJoMThWNkgzem0zIDdoMTJ2LTJINnYyeiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-folder: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY4YzAtMS4xLS45LTItMi0yaC04bC0yLTJ6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-html5: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDUxMiA1MTIiPgogIDxwYXRoIGNsYXNzPSJqcC1pY29uMCBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiMwMDAiIGQ9Ik0xMDguNCAwaDIzdjIyLjhoMjEuMlYwaDIzdjY5aC0yM1Y0NmgtMjF2MjNoLTIzLjJNMjA2IDIzaC0yMC4zVjBoNjMuN3YyM0gyMjl2NDZoLTIzbTUzLjUtNjloMjQuMWwxNC44IDI0LjNMMzEzLjIgMGgyNC4xdjY5aC0yM1YzNC44bC0xNi4xIDI0LjgtMTYuMS0yNC44VjY5aC0yMi42bTg5LjItNjloMjN2NDYuMmgzMi42VjY5aC01NS42Ii8+CiAgPHBhdGggY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iI2U0NGQyNiIgZD0iTTEwNy42IDQ3MWwtMzMtMzcwLjRoMzYyLjhsLTMzIDM3MC4yTDI1NS43IDUxMiIvPgogIDxwYXRoIGNsYXNzPSJqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNmMTY1MjkiIGQ9Ik0yNTYgNDgwLjVWMTMxaDE0OC4zTDM3NiA0NDciLz4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNlYmViZWIiIGQ9Ik0xNDIgMTc2LjNoMTE0djQ1LjRoLTY0LjJsNC4yIDQ2LjVoNjB2NDUuM0gxNTQuNG0yIDIyLjhIMjAybDMuMiAzNi4zIDUwLjggMTMuNnY0Ny40bC05My4yLTI2Ii8+CiAgPHBhdGggY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZS1pbnZlcnNlIiBmaWxsPSIjZmZmIiBkPSJNMzY5LjYgMTc2LjNIMjU1Ljh2NDUuNGgxMDkuNm0tNC4xIDQ2LjVIMjU1Ljh2NDUuNGg1NmwtNS4zIDU5LTUwLjcgMTMuNnY0Ny4ybDkzLTI1LjgiLz4KPC9zdmc+Cg==);
+  --jp-icon-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1icmFuZDQganAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNGRkYiIGQ9Ik0yLjIgMi4yaDE3LjV2MTcuNUgyLjJ6Ii8+CiAgPHBhdGggY2xhc3M9ImpwLWljb24tYnJhbmQwIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzNGNTFCNSIgZD0iTTIuMiAyLjJ2MTcuNWgxNy41bC4xLTE3LjVIMi4yem0xMi4xIDIuMmMxLjIgMCAyLjIgMSAyLjIgMi4ycy0xIDIuMi0yLjIgMi4yLTIuMi0xLTIuMi0yLjIgMS0yLjIgMi4yLTIuMnpNNC40IDE3LjZsMy4zLTguOCAzLjMgNi42IDIuMi0zLjIgNC40IDUuNEg0LjR6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-inspector: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMjAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY2YzAtMS4xLS45LTItMi0yem0tNSAxNEg0di00aDExdjR6bTAtNUg0VjloMTF2NHptNSA1aC00VjloNHY5eiIvPgo8L3N2Zz4K);
+  --jp-icon-json: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMSBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNGOUE4MjUiPgogICAgPHBhdGggZD0iTTIwLjIgMTEuOGMtMS42IDAtMS43LjUtMS43IDEgMCAuNC4xLjkuMSAxLjMuMS41LjEuOS4xIDEuMyAwIDEuNy0xLjQgMi4zLTMuNSAyLjNoLS45di0xLjloLjVjMS4xIDAgMS40IDAgMS40LS44IDAtLjMgMC0uNi0uMS0xIDAtLjQtLjEtLjgtLjEtMS4yIDAtMS4zIDAtMS44IDEuMy0yLTEuMy0uMi0xLjMtLjctMS4zLTIgMC0uNC4xLS44LjEtMS4yLjEtLjQuMS0uNy4xLTEgMC0uOC0uNC0uNy0xLjQtLjhoLS41VjQuMWguOWMyLjIgMCAzLjUuNyAzLjUgMi4zIDAgLjQtLjEuOS0uMSAxLjMtLjEuNS0uMS45LS4xIDEuMyAwIC41LjIgMSAxLjcgMXYxLjh6TTEuOCAxMC4xYzEuNiAwIDEuNy0uNSAxLjctMSAwLS40LS4xLS45LS4xLTEuMy0uMS0uNS0uMS0uOS0uMS0xLjMgMC0xLjYgMS40LTIuMyAzLjUtMi4zaC45djEuOWgtLjVjLTEgMC0xLjQgMC0xLjQuOCAwIC4zIDAgLjYuMSAxIDAgLjIuMS42LjEgMSAwIDEuMyAwIDEuOC0xLjMgMkM2IDExLjIgNiAxMS43IDYgMTNjMCAuNC0uMS44LS4xIDEuMi0uMS4zLS4xLjctLjEgMSAwIC44LjMuOCAxLjQuOGguNXYxLjloLS45Yy0yLjEgMC0zLjUtLjYtMy41LTIuMyAwLS40LjEtLjkuMS0xLjMuMS0uNS4xLS45LjEtMS4zIDAtLjUtLjItMS0xLjctMXYtMS45eiIvPgogICAgPGNpcmNsZSBjeD0iMTEiIGN5PSIxMy44IiByPSIyLjEiLz4KICAgIDxjaXJjbGUgY3g9IjExIiBjeT0iOC4yIiByPSIyLjEiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-jupyter-favicon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUyIiBoZWlnaHQ9IjE2NSIgdmlld0JveD0iMCAwIDE1MiAxNjUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCIgZmlsbD0iI0YzNzcyNiI+CiAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjA3ODk0NywgMTEwLjU4MjkyNykiIGQ9Ik03NS45NDIyODQyLDI5LjU4MDQ1NjEgQzQzLjMwMjM5NDcsMjkuNTgwNDU2MSAxNC43OTY3ODMyLDE3LjY1MzQ2MzQgMCwwIEM1LjUxMDgzMjExLDE1Ljg0MDY4MjkgMTUuNzgxNTM4OSwyOS41NjY3NzMyIDI5LjM5MDQ5NDcsMzkuMjc4NDE3MSBDNDIuOTk5Nyw0OC45ODk4NTM3IDU5LjI3MzcsNTQuMjA2NzgwNSA3NS45NjA1Nzg5LDU0LjIwNjc4MDUgQzkyLjY0NzQ1NzksNTQuMjA2NzgwNSAxMDguOTIxNDU4LDQ4Ljk4OTg1MzcgMTIyLjUzMDY2MywzOS4yNzg0MTcxIEMxMzYuMTM5NDUzLDI5LjU2Njc3MzIgMTQ2LjQxMDI4NCwxNS44NDA2ODI5IDE1MS45MjExNTgsMCBDMTM3LjA4Nzg2OCwxNy42NTM0NjM0IDEwOC41ODI1ODksMjkuNTgwNDU2MSA3NS45NDIyODQyLDI5LjU4MDQ1NjEgTDc1Ljk0MjI4NDIsMjkuNTgwNDU2MSBaIiAvPgogICAgPHBhdGggdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4wMzczNjgsIDAuNzA0ODc4KSIgZD0iTTc1Ljk3ODQ1NzksMjQuNjI2NDA3MyBDMTA4LjYxODc2MywyNC42MjY0MDczIDEzNy4xMjQ0NTgsMzYuNTUzNDQxNSAxNTEuOTIxMTU4LDU0LjIwNjc4MDUgQzE0Ni40MTAyODQsMzguMzY2MjIyIDEzNi4xMzk0NTMsMjQuNjQwMTMxNyAxMjIuNTMwNjYzLDE0LjkyODQ4NzggQzEwOC45MjE0NTgsNS4yMTY4NDM5IDkyLjY0NzQ1NzksMCA3NS45NjA1Nzg5LDAgQzU5LjI3MzcsMCA0Mi45OTk3LDUuMjE2ODQzOSAyOS4zOTA0OTQ3LDE0LjkyODQ4NzggQzE1Ljc4MTUzODksMjQuNjQwMTMxNyA1LjUxMDgzMjExLDM4LjM2NjIyMiAwLDU0LjIwNjc4MDUgQzE0LjgzMzA4MTYsMzYuNTg5OTI5MyA0My4zMzg1Njg0LDI0LjYyNjQwNzMgNzUuOTc4NDU3OSwyNC42MjY0MDczIEw3NS45Nzg0NTc5LDI0LjYyNjQwNzMgWiIgLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-jupyter: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iNTEiIHZpZXdCb3g9IjAgMCAzOSA1MSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTYzOCAtMjI4MSkiPgogICAgPGcgY2xhc3M9ImpwLWljb24td2FybjAiIGZpbGw9IiNGMzc3MjYiPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM5Ljc0IDIzMTEuOTgpIiBkPSJNIDE4LjI2NDYgNy4xMzQxMUMgMTAuNDE0NSA3LjEzNDExIDMuNTU4NzIgNC4yNTc2IDAgMEMgMS4zMjUzOSAzLjgyMDQgMy43OTU1NiA3LjEzMDgxIDcuMDY4NiA5LjQ3MzAzQyAxMC4zNDE3IDExLjgxNTIgMTQuMjU1NyAxMy4wNzM0IDE4LjI2OSAxMy4wNzM0QyAyMi4yODIzIDEzLjA3MzQgMjYuMTk2MyAxMS44MTUyIDI5LjQ2OTQgOS40NzMwM0MgMzIuNzQyNCA3LjEzMDgxIDM1LjIxMjYgMy44MjA0IDM2LjUzOCAwQyAzMi45NzA1IDQuMjU3NiAyNi4xMTQ4IDcuMTM0MTEgMTguMjY0NiA3LjEzNDExWiIvPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM5LjczIDIyODUuNDgpIiBkPSJNIDE4LjI3MzMgNS45MzkzMUMgMjYuMTIzNSA1LjkzOTMxIDMyLjk3OTMgOC44MTU4MyAzNi41MzggMTMuMDczNEMgMzUuMjEyNiA5LjI1MzAzIDMyLjc0MjQgNS45NDI2MiAyOS40Njk0IDMuNjAwNEMgMjYuMTk2MyAxLjI1ODE4IDIyLjI4MjMgMCAxOC4yNjkgMEMgMTQuMjU1NyAwIDEwLjM0MTcgMS4yNTgxOCA3LjA2ODYgMy42MDA0QyAzLjc5NTU2IDUuOTQyNjIgMS4zMjUzOSA5LjI1MzAzIDAgMTMuMDczNEMgMy41Njc0NSA4LjgyNDYzIDEwLjQyMzIgNS45MzkzMSAxOC4yNzMzIDUuOTM5MzFaIi8+CiAgICA8L2c+CiAgICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjY5LjMgMjI4MS4zMSkiIGQ9Ik0gNS44OTM1MyAyLjg0NEMgNS45MTg4OSAzLjQzMTY1IDUuNzcwODUgNC4wMTM2NyA1LjQ2ODE1IDQuNTE2NDVDIDUuMTY1NDUgNS4wMTkyMiA0LjcyMTY4IDUuNDIwMTUgNC4xOTI5OSA1LjY2ODUxQyAzLjY2NDMgNS45MTY4OCAzLjA3NDQ0IDYuMDAxNTEgMi40OTgwNSA1LjkxMTcxQyAxLjkyMTY2IDUuODIxOSAxLjM4NDYzIDUuNTYxNyAwLjk1NDg5OCA1LjE2NDAxQyAwLjUyNTE3IDQuNzY2MzMgMC4yMjIwNTYgNC4yNDkwMyAwLjA4MzkwMzcgMy42Nzc1N0MgLTAuMDU0MjQ4MyAzLjEwNjExIC0wLjAyMTIzIDIuNTA2MTcgMC4xNzg3ODEgMS45NTM2NEMgMC4zNzg3OTMgMS40MDExIDAuNzM2ODA5IDAuOTIwODE3IDEuMjA3NTQgMC41NzM1MzhDIDEuNjc4MjYgMC4yMjYyNTkgMi4yNDA1NSAwLjAyNzU5MTkgMi44MjMyNiAwLjAwMjY3MjI5QyAzLjYwMzg5IC0wLjAzMDcxMTUgNC4zNjU3MyAwLjI0OTc4OSA0Ljk0MTQyIDAuNzgyNTUxQyA1LjUxNzExIDEuMzE1MzEgNS44NTk1NiAyLjA1Njc2IDUuODkzNTMgMi44NDRaIi8+CiAgICAgIDxwYXRoIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE2MzkuOCAyMzIzLjgxKSIgZD0iTSA3LjQyNzg5IDMuNTgzMzhDIDcuNDYwMDggNC4zMjQzIDcuMjczNTUgNS4wNTgxOSA2Ljg5MTkzIDUuNjkyMTNDIDYuNTEwMzEgNi4zMjYwNyA1Ljk1MDc1IDYuODMxNTYgNS4yODQxMSA3LjE0NDZDIDQuNjE3NDcgNy40NTc2MyAzLjg3MzcxIDcuNTY0MTQgMy4xNDcwMiA3LjQ1MDYzQyAyLjQyMDMyIDcuMzM3MTIgMS43NDMzNiA3LjAwODcgMS4yMDE4NCA2LjUwNjk1QyAwLjY2MDMyOCA2LjAwNTIgMC4yNzg2MSA1LjM1MjY4IDAuMTA1MDE3IDQuNjMyMDJDIC0wLjA2ODU3NTcgMy45MTEzNSAtMC4wMjYyMzYxIDMuMTU0OTQgMC4yMjY2NzUgMi40NTg1NkMgMC40Nzk1ODcgMS43NjIxNyAwLjkzMTY5NyAxLjE1NzEzIDEuNTI1NzYgMC43MjAwMzNDIDIuMTE5ODMgMC4yODI5MzUgMi44MjkxNCAwLjAzMzQzOTUgMy41NjM4OSAwLjAwMzEzMzQ0QyA0LjU0NjY3IC0wLjAzNzQwMzMgNS41MDUyOSAwLjMxNjcwNiA2LjIyOTYxIDAuOTg3ODM1QyA2Ljk1MzkzIDEuNjU4OTYgNy4zODQ4NCAyLjU5MjM1IDcuNDI3ODkgMy41ODMzOEwgNy40Mjc4OSAzLjU4MzM4WiIvPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM4LjM2IDIyODYuMDYpIiBkPSJNIDIuMjc0NzEgNC4zOTYyOUMgMS44NDM2MyA0LjQxNTA4IDEuNDE2NzEgNC4zMDQ0NSAxLjA0Nzk5IDQuMDc4NDNDIDAuNjc5MjY4IDMuODUyNCAwLjM4NTMyOCAzLjUyMTE0IDAuMjAzMzcxIDMuMTI2NTZDIDAuMDIxNDEzNiAyLjczMTk4IC0wLjA0MDM3OTggMi4yOTE4MyAwLjAyNTgxMTYgMS44NjE4MUMgMC4wOTIwMDMxIDEuNDMxOCAwLjI4MzIwNCAxLjAzMTI2IDAuNTc1MjEzIDAuNzEwODgzQyAwLjg2NzIyMiAwLjM5MDUxIDEuMjQ2OTEgMC4xNjQ3MDggMS42NjYyMiAwLjA2MjA1OTJDIDIuMDg1NTMgLTAuMDQwNTg5NyAyLjUyNTYxIC0wLjAxNTQ3MTQgMi45MzA3NiAwLjEzNDIzNUMgMy4zMzU5MSAwLjI4Mzk0MSAzLjY4NzkyIDAuNTUxNTA1IDMuOTQyMjIgMC45MDMwNkMgNC4xOTY1MiAxLjI1NDYyIDQuMzQxNjkgMS42NzQzNiA0LjM1OTM1IDIuMTA5MTZDIDQuMzgyOTkgMi42OTEwNyA0LjE3Njc4IDMuMjU4NjkgMy43ODU5NyAzLjY4NzQ2QyAzLjM5NTE2IDQuMTE2MjQgMi44NTE2NiA0LjM3MTE2IDIuMjc0NzEgNC4zOTYyOUwgMi4yNzQ3MSA0LjM5NjI5WiIvPgogICAgPC9nPgogIDwvZz4+Cjwvc3ZnPgo=);
+  --jp-icon-jupyterlab-wordmark: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIHZpZXdCb3g9IjAgMCAxODYwLjggNDc1Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiM0RTRFNEUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQ4MC4xMzY0MDEsIDY0LjI3MTQ5MykiPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4wMDAwMDAsIDU4Ljg3NTU2NikiPgogICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjA4NzYwMywgMC4xNDAyOTQpIj4KICAgICAgICA8cGF0aCBkPSJNLTQyNi45LDE2OS44YzAsNDguNy0zLjcsNjQuNy0xMy42LDc2LjRjLTEwLjgsMTAtMjUsMTUuNS0zOS43LDE1LjVsMy43LDI5IGMyMi44LDAuMyw0NC44LTcuOSw2MS45LTIzLjFjMTcuOC0xOC41LDI0LTQ0LjEsMjQtODMuM1YwSC00Mjd2MTcwLjFMLTQyNi45LDE2OS44TC00MjYuOSwxNjkuOHoiLz4KICAgICAgPC9nPgogICAgPC9nPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTU1LjA0NTI5NiwgNTYuODM3MTA0KSI+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEuNTYyNDUzLCAxLjc5OTg0MikiPgogICAgICAgIDxwYXRoIGQ9Ik0tMzEyLDE0OGMwLDIxLDAsMzkuNSwxLjcsNTUuNGgtMzEuOGwtMi4xLTMzLjNoLTAuOGMtNi43LDExLjYtMTYuNCwyMS4zLTI4LDI3LjkgYy0xMS42LDYuNi0yNC44LDEwLTM4LjIsOS44Yy0zMS40LDAtNjktMTcuNy02OS04OVYwaDM2LjR2MTEyLjdjMCwzOC43LDExLjYsNjQuNyw0NC42LDY0LjdjMTAuMy0wLjIsMjAuNC0zLjUsMjguOS05LjQgYzguNS01LjksMTUuMS0xNC4zLDE4LjktMjMuOWMyLjItNi4xLDMuMy0xMi41LDMuMy0xOC45VjAuMmgzNi40VjE0OEgtMzEyTC0zMTIsMTQ4eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzOTAuMDEzMzIyLCA1My40Nzk2MzgpIj4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMS43MDY0NTgsIDAuMjMxNDI1KSI+CiAgICAgICAgPHBhdGggZD0iTS00NzguNiw3MS40YzAtMjYtMC44LTQ3LTEuNy02Ni43aDMyLjdsMS43LDM0LjhoMC44YzcuMS0xMi41LDE3LjUtMjIuOCwzMC4xLTI5LjcgYzEyLjUtNywyNi43LTEwLjMsNDEtOS44YzQ4LjMsMCw4NC43LDQxLjcsODQuNywxMDMuM2MwLDczLjEtNDMuNywxMDkuMi05MSwxMDkuMmMtMTIuMSwwLjUtMjQuMi0yLjItMzUtNy44IGMtMTAuOC01LjYtMTkuOS0xMy45LTI2LjYtMjQuMmgtMC44VjI5MWgtMzZ2LTIyMEwtNDc4LjYsNzEuNEwtNDc4LjYsNzEuNHogTS00NDIuNiwxMjUuNmMwLjEsNS4xLDAuNiwxMC4xLDEuNywxNS4xIGMzLDEyLjMsOS45LDIzLjMsMTkuOCwzMS4xYzkuOSw3LjgsMjIuMSwxMi4xLDM0LjcsMTIuMWMzOC41LDAsNjAuNy0zMS45LDYwLjctNzguNWMwLTQwLjctMjEuMS03NS42LTU5LjUtNzUuNiBjLTEyLjksMC40LTI1LjMsNS4xLTM1LjMsMTMuNGMtOS45LDguMy0xNi45LDE5LjctMTkuNiwzMi40Yy0xLjUsNC45LTIuMywxMC0yLjUsMTUuMVYxMjUuNkwtNDQyLjYsMTI1LjZMLTQ0Mi42LDEyNS42eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSg2MDYuNzQwNzI2LCA1Ni44MzcxMDQpIj4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC43NTEyMjYsIDEuOTg5Mjk5KSI+CiAgICAgICAgPHBhdGggZD0iTS00NDAuOCwwbDQzLjcsMTIwLjFjNC41LDEzLjQsOS41LDI5LjQsMTIuOCw0MS43aDAuOGMzLjctMTIuMiw3LjktMjcuNywxMi44LTQyLjQgbDM5LjctMTE5LjJoMzguNUwtMzQ2LjksMTQ1Yy0yNiw2OS43LTQzLjcsMTA1LjQtNjguNiwxMjcuMmMtMTIuNSwxMS43LTI3LjksMjAtNDQuNiwyMy45bC05LjEtMzEuMSBjMTEuNy0zLjksMjIuNS0xMC4xLDMxLjgtMTguMWMxMy4yLTExLjEsMjMuNy0yNS4yLDMwLjYtNDEuMmMxLjUtMi44LDIuNS01LjcsMi45LTguOGMtMC4zLTMuMy0xLjItNi42LTIuNS05LjdMLTQ4MC4yLDAuMSBoMzkuN0wtNDQwLjgsMEwtNDQwLjgsMHoiLz4KICAgICAgPC9nPgogICAgPC9nPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoODIyLjc0ODEwNCwgMC4wMDAwMDApIj4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMS40NjQwNTAsIDAuMzc4OTE0KSI+CiAgICAgICAgPHBhdGggZD0iTS00MTMuNywwdjU4LjNoNTJ2MjguMmgtNTJWMTk2YzAsMjUsNywzOS41LDI3LjMsMzkuNWM3LjEsMC4xLDE0LjItMC43LDIxLjEtMi41IGwxLjcsMjcuN2MtMTAuMywzLjctMjEuMyw1LjQtMzIuMiw1Yy03LjMsMC40LTE0LjYtMC43LTIxLjMtMy40Yy02LjgtMi43LTEyLjktNi44LTE3LjktMTIuMWMtMTAuMy0xMC45LTE0LjEtMjktMTQuMS01Mi45IFY4Ni41aC0zMVY1OC4zaDMxVjkuNkwtNDEzLjcsMEwtNDEzLjcsMHoiLz4KICAgICAgPC9nPgogICAgPC9nPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOTc0LjQzMzI4NiwgNTMuNDc5NjM4KSI+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTkwMDM0LCAwLjYxMDMzOSkiPgogICAgICAgIDxwYXRoIGQ9Ik0tNDQ1LjgsMTEzYzAuOCw1MCwzMi4yLDcwLjYsNjguNiw3MC42YzE5LDAuNiwzNy45LTMsNTUuMy0xMC41bDYuMiwyNi40IGMtMjAuOSw4LjktNDMuNSwxMy4xLTY2LjIsMTIuNmMtNjEuNSwwLTk4LjMtNDEuMi05OC4zLTEwMi41Qy00ODAuMiw0OC4yLTQ0NC43LDAtMzg2LjUsMGM2NS4yLDAsODIuNyw1OC4zLDgyLjcsOTUuNyBjLTAuMSw1LjgtMC41LDExLjUtMS4yLDE3LjJoLTE0MC42SC00NDUuOEwtNDQ1LjgsMTEzeiBNLTMzOS4yLDg2LjZjMC40LTIzLjUtOS41LTYwLjEtNTAuNC02MC4xIGMtMzYuOCwwLTUyLjgsMzQuNC01NS43LDYwLjFILTMzOS4yTC0zMzkuMiw4Ni42TC0zMzkuMiw4Ni42eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMjAxLjk2MTA1OCwgNTMuNDc5NjM4KSI+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEuMTc5NjQwLCAwLjcwNTA2OCkiPgogICAgICAgIDxwYXRoIGQ9Ik0tNDc4LjYsNjhjMC0yMy45LTAuNC00NC41LTEuNy02My40aDMxLjhsMS4yLDM5LjloMS43YzkuMS0yNy4zLDMxLTQ0LjUsNTUuMy00NC41IGMzLjUtMC4xLDcsMC40LDEwLjMsMS4ydjM0LjhjLTQuMS0wLjktOC4yLTEuMy0xMi40LTEuMmMtMjUuNiwwLTQzLjcsMTkuNy00OC43LDQ3LjRjLTEsNS43LTEuNiwxMS41LTEuNywxNy4ydjEwOC4zaC0zNlY2OCBMLTQ3OC42LDY4eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCIgZmlsbD0iI0YzNzcyNiI+CiAgICA8cGF0aCBkPSJNMTM1Mi4zLDMyNi4yaDM3VjI4aC0zN1YzMjYuMnogTTE2MDQuOCwzMjYuMmMtMi41LTEzLjktMy40LTMxLjEtMy40LTQ4Ljd2LTc2IGMwLTQwLjctMTUuMS04My4xLTc3LjMtODMuMWMtMjUuNiwwLTUwLDcuMS02Ni44LDE4LjFsOC40LDI0LjRjMTQuMy05LjIsMzQtMTUuMSw1My0xNS4xYzQxLjYsMCw0Ni4yLDMwLjIsNDYuMiw0N3Y0LjIgYy03OC42LTAuNC0xMjIuMywyNi41LTEyMi4zLDc1LjZjMCwyOS40LDIxLDU4LjQsNjIuMiw1OC40YzI5LDAsNTAuOS0xNC4zLDYyLjItMzAuMmgxLjNsMi45LDI1LjZIMTYwNC44eiBNMTU2NS43LDI1Ny43IGMwLDMuOC0wLjgsOC0yLjEsMTEuOGMtNS45LDE3LjItMjIuNywzNC00OS4yLDM0Yy0xOC45LDAtMzQuOS0xMS4zLTM0LjktMzUuM2MwLTM5LjUsNDUuOC00Ni42LDg2LjItNDUuOFYyNTcuN3ogTTE2OTguNSwzMjYuMiBsMS43LTMzLjZoMS4zYzE1LjEsMjYuOSwzOC43LDM4LjIsNjguMSwzOC4yYzQ1LjQsMCw5MS4yLTM2LjEsOTEuMi0xMDguOGMwLjQtNjEuNy0zNS4zLTEwMy43LTg1LjctMTAzLjcgYy0zMi44LDAtNTYuMywxNC43LTY5LjMsMzcuNGgtMC44VjI4aC0zNi42djI0NS43YzAsMTguMS0wLjgsMzguNi0xLjcsNTIuNUgxNjk4LjV6IE0xNzA0LjgsMjA4LjJjMC01LjksMS4zLTEwLjksMi4xLTE1LjEgYzcuNi0yOC4xLDMxLjEtNDUuNCw1Ni4zLTQ1LjRjMzkuNSwwLDYwLjUsMzQuOSw2MC41LDc1LjZjMCw0Ni42LTIzLjEsNzguMS02MS44LDc4LjFjLTI2LjksMC00OC4zLTE3LjYtNTUuNS00My4zIGMtMC44LTQuMi0xLjctOC44LTEuNy0xMy40VjIwOC4yeiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-kernel: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgZmlsbD0iIzYxNjE2MSIgZD0iTTE1IDlIOXY2aDZWOXptLTIgNGgtMnYtMmgydjJ6bTgtMlY5aC0yVjdjMC0xLjEtLjktMi0yLTJoLTJWM2gtMnYyaC0yVjNIOXYySDdjLTEuMSAwLTIgLjktMiAydjJIM3YyaDJ2MkgzdjJoMnYyYzAgMS4xLjkgMiAyIDJoMnYyaDJ2LTJoMnYyaDJ2LTJoMmMxLjEgMCAyLS45IDItMnYtMmgydi0yaC0ydi0yaDJ6bS00IDZIN1Y3aDEwdjEweiIvPgo8L3N2Zz4K);
+  --jp-icon-keyboard: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMjAgNUg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMTdjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY3YzAtMS4xLS45LTItMi0yem0tOSAzaDJ2MmgtMlY4em0wIDNoMnYyaC0ydi0yek04IDhoMnYySDhWOHptMCAzaDJ2Mkg4di0yem0tMSAySDV2LTJoMnYyem0wLTNINVY4aDJ2MnptOSA3SDh2LTJoOHYyem0wLTRoLTJ2LTJoMnYyem0wLTNoLTJWOGgydjJ6bTMgM2gtMnYtMmgydjJ6bTAtM2gtMlY4aDJ2MnoiLz4KPC9zdmc+Cg==);
+  --jp-icon-launcher: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTkgMTlINVY1aDdWM0g1YTIgMiAwIDAwLTIgMnYxNGEyIDIgMCAwMDIgMmgxNGMxLjEgMCAyLS45IDItMnYtN2gtMnY3ek0xNCAzdjJoMy41OWwtOS44MyA5LjgzIDEuNDEgMS40MUwxOSA2LjQxVjEwaDJWM2gtN3oiLz4KPC9zdmc+Cg==);
+  --jp-icon-line-form: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxwYXRoIGZpbGw9IndoaXRlIiBkPSJNNS44OCA0LjEyTDEzLjc2IDEybC03Ljg4IDcuODhMOCAyMmwxMC0xMEw4IDJ6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-link: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTMuOSAxMmMwLTEuNzEgMS4zOS0zLjEgMy4xLTMuMWg0VjdIN2MtMi43NiAwLTUgMi4yNC01IDVzMi4yNCA1IDUgNWg0di0xLjlIN2MtMS43MSAwLTMuMS0xLjM5LTMuMS0zLjF6TTggMTNoOHYtMkg4djJ6bTktNmgtNHYxLjloNGMxLjcxIDAgMy4xIDEuMzkgMy4xIDMuMXMtMS4zOSAzLjEtMy4xIDMuMWgtNFYxN2g0YzIuNzYgMCA1LTIuMjQgNS01cy0yLjI0LTUtNS01eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-list: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiM2MTYxNjEiIGQ9Ik0xOSA1djE0SDVWNWgxNG0xLjEtMkgzLjljLS41IDAtLjkuNC0uOS45djE2LjJjMCAuNC40LjkuOS45aDE2LjJjLjQgMCAuOS0uNS45LS45VjMuOWMwLS41LS41LS45LS45LS45ek0xMSA3aDZ2MmgtNlY3em0wIDRoNnYyaC02di0yem0wIDRoNnYyaC02ek03IDdoMnYySDd6bTAgNGgydjJIN3ptMCA0aDJ2Mkg3eiIvPgo8L3N2Zz4=);
+  --jp-icon-listings-info: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pg0KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJDYXBhXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgNTAuOTc4IDUwLjk3OCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNTAuOTc4IDUwLjk3ODsiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPGc+DQoJPGc+DQoJCTxnPg0KCQkJPHBhdGggc3R5bGU9ImZpbGw6IzAxMDAwMjsiIGQ9Ik00My41Miw3LjQ1OEMzOC43MTEsMi42NDgsMzIuMzA3LDAsMjUuNDg5LDBDMTguNjcsMCwxMi4yNjYsMi42NDgsNy40NTgsNy40NTgNCgkJCQljLTkuOTQzLDkuOTQxLTkuOTQzLDI2LjExOSwwLDM2LjA2MmM0LjgwOSw0LjgwOSwxMS4yMTIsNy40NTYsMTguMDMxLDcuNDU4YzAsMCwwLjAwMSwwLDAuMDAyLDANCgkJCQljNi44MTYsMCwxMy4yMjEtMi42NDgsMTguMDI5LTcuNDU4YzQuODA5LTQuODA5LDcuNDU3LTExLjIxMiw3LjQ1Ny0xOC4wM0M1MC45NzcsMTguNjcsNDguMzI4LDEyLjI2Niw0My41Miw3LjQ1OHoNCgkJCQkgTTQyLjEwNiw0Mi4xMDVjLTQuNDMyLDQuNDMxLTEwLjMzMiw2Ljg3Mi0xNi42MTUsNi44NzJoLTAuMDAyYy02LjI4NS0wLjAwMS0xMi4xODctMi40NDEtMTYuNjE3LTYuODcyDQoJCQkJYy05LjE2Mi05LjE2My05LjE2Mi0yNC4wNzEsMC0zMy4yMzNDMTMuMzAzLDQuNDQsMTkuMjA0LDIsMjUuNDg5LDJjNi4yODQsMCwxMi4xODYsMi40NCwxNi42MTcsNi44NzINCgkJCQljNC40MzEsNC40MzEsNi44NzEsMTAuMzMyLDYuODcxLDE2LjYxN0M0OC45NzcsMzEuNzcyLDQ2LjUzNiwzNy42NzUsNDIuMTA2LDQyLjEwNXoiLz4NCgkJPC9nPg0KCQk8Zz4NCgkJCTxwYXRoIHN0eWxlPSJmaWxsOiMwMTAwMDI7IiBkPSJNMjMuNTc4LDMyLjIxOGMtMC4wMjMtMS43MzQsMC4xNDMtMy4wNTksMC40OTYtMy45NzJjMC4zNTMtMC45MTMsMS4xMS0xLjk5NywyLjI3Mi0zLjI1Mw0KCQkJCWMwLjQ2OC0wLjUzNiwwLjkyMy0xLjA2MiwxLjM2Ny0xLjU3NWMwLjYyNi0wLjc1MywxLjEwNC0xLjQ3OCwxLjQzNi0yLjE3NWMwLjMzMS0wLjcwNywwLjQ5NS0xLjU0MSwwLjQ5NS0yLjUNCgkJCQljMC0xLjA5Ni0wLjI2LTIuMDg4LTAuNzc5LTIuOTc5Yy0wLjU2NS0wLjg3OS0xLjUwMS0xLjMzNi0yLjgwNi0xLjM2OWMtMS44MDIsMC4wNTctMi45ODUsMC42NjctMy41NSwxLjgzMg0KCQkJCWMtMC4zMDEsMC41MzUtMC41MDMsMS4xNDEtMC42MDcsMS44MTRjLTAuMTM5LDAuNzA3LTAuMjA3LDEuNDMyLTAuMjA3LDIuMTc0aC0yLjkzN2MtMC4wOTEtMi4yMDgsMC40MDctNC4xMTQsMS40OTMtNS43MTkNCgkJCQljMS4wNjItMS42NCwyLjg1NS0yLjQ4MSw1LjM3OC0yLjUyN2MyLjE2LDAuMDIzLDMuODc0LDAuNjA4LDUuMTQxLDEuNzU4YzEuMjc4LDEuMTYsMS45MjksMi43NjQsMS45NSw0LjgxMQ0KCQkJCWMwLDEuMTQyLTAuMTM3LDIuMTExLTAuNDEsMi45MTFjLTAuMzA5LDAuODQ1LTAuNzMxLDEuNTkzLTEuMjY4LDIuMjQzYy0wLjQ5MiwwLjY1LTEuMDY4LDEuMzE4LTEuNzMsMi4wMDINCgkJCQljLTAuNjUsMC42OTctMS4zMTMsMS40NzktMS45ODcsMi4zNDZjLTAuMjM5LDAuMzc3LTAuNDI5LDAuNzc3LTAuNTY1LDEuMTk5Yy0wLjE2LDAuOTU5LTAuMjE3LDEuOTUxLTAuMTcxLDIuOTc5DQoJCQkJQzI2LjU4OSwzMi4yMTgsMjMuNTc4LDMyLjIxOCwyMy41NzgsMzIuMjE4eiBNMjMuNTc4LDM4LjIydi0zLjQ4NGgzLjA3NnYzLjQ4NEgyMy41Nzh6Ii8+DQoJCTwvZz4NCgk8L2c+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8L3N2Zz4NCg==);
+  --jp-icon-markdown: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDAganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjN0IxRkEyIiBkPSJNNSAxNC45aDEybC02LjEgNnptOS40LTYuOGMwLTEuMy0uMS0yLjktLjEtNC41LS40IDEuNC0uOSAyLjktMS4zIDQuM2wtMS4zIDQuM2gtMkw4LjUgNy45Yy0uNC0xLjMtLjctMi45LTEtNC4zLS4xIDEuNi0uMSAzLjItLjIgNC42TDcgMTIuNEg0LjhsLjctMTFoMy4zTDEwIDVjLjQgMS4yLjcgMi43IDEgMy45LjMtMS4yLjctMi42IDEtMy45bDEuMi0zLjdoMy4zbC42IDExaC0yLjRsLS4zLTQuMnoiLz4KPC9zdmc+Cg==);
+  --jp-icon-new-folder: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIwIDZoLThsLTItMkg0Yy0xLjExIDAtMS45OS44OS0xLjk5IDJMMiAxOGMwIDEuMTEuODkgMiAyIDJoMTZjMS4xMSAwIDItLjg5IDItMlY4YzAtMS4xMS0uODktMi0yLTJ6bS0xIDhoLTN2M2gtMnYtM2gtM3YtMmgzVjloMnYzaDN2MnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-not-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI1IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMTkgMTcuMTg0NCAyLjk2OTY4IDE0LjMwMzIgMS44NjA5NCAxMS40NDA5WiIvPgogICAgPHBhdGggY2xhc3M9ImpwLWljb24yIiBzdHJva2U9IiMzMzMzMzMiIHN0cm9rZS13aWR0aD0iMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOS4zMTU5MiA5LjMyMDMxKSIgZD0iTTcuMzY4NDIgMEwwIDcuMzY0NzkiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDkuMzE1OTIgMTYuNjgzNikgc2NhbGUoMSAtMSkiIGQ9Ik03LjM2ODQyIDBMMCA3LjM2NDc5Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-notebook: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNFRjZDMDAiPgogICAgPHBhdGggZD0iTTE4LjcgMy4zdjE1LjRIMy4zVjMuM2gxNS40bTEuNS0xLjVIMS44djE4LjNoMTguM2wuMS0xOC4zeiIvPgogICAgPHBhdGggZD0iTTE2LjUgMTYuNWwtNS40LTQuMy01LjYgNC4zdi0xMWgxMXoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-palette: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE4IDEzVjIwSDRWNkg5LjAyQzkuMDcgNS4yOSA5LjI0IDQuNjIgOS41IDRINEMyLjkgNCAyIDQuOSAyIDZWMjBDMiAyMS4xIDIuOSAyMiA0IDIySDE4QzE5LjEgMjIgMjAgMjEuMSAyMCAyMFYxNUwxOCAxM1pNMTkuMyA4Ljg5QzE5Ljc0IDguMTkgMjAgNy4zOCAyMCA2LjVDMjAgNC4wMSAxNy45OSAyIDE1LjUgMkMxMy4wMSAyIDExIDQuMDEgMTEgNi41QzExIDguOTkgMTMuMDEgMTEgMTUuNDkgMTFDMTYuMzcgMTEgMTcuMTkgMTAuNzQgMTcuODggMTAuM0wyMSAxMy40MkwyMi40MiAxMkwxOS4zIDguODlaTTE1LjUgOUMxNC4xMiA5IDEzIDcuODggMTMgNi41QzEzIDUuMTIgMTQuMTIgNCAxNS41IDRDMTYuODggNCAxOCA1LjEyIDE4IDYuNUMxOCA3Ljg4IDE2Ljg4IDkgMTUuNSA5WiIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDZIOS4wMTg5NEM5LjAwNjM5IDYuMTY1MDIgOSA2LjMzMTc2IDkgNi41QzkgOC44MTU3NyAxMC4yMTEgMTAuODQ4NyAxMi4wMzQzIDEySDlWMTRIMTZWMTIuOTgxMUMxNi41NzAzIDEyLjkzNzcgMTcuMTIgMTIuODIwNyAxNy42Mzk2IDEyLjYzOTZMMTggMTNWMjBINFY2Wk04IDhINlYxMEg4VjhaTTYgMTJIOFYxNEg2VjEyWk04IDE2SDZWMThIOFYxNlpNOSAxNkgxNlYxOEg5VjE2WiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-paste: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTE5IDJoLTQuMThDMTQuNC44NCAxMy4zIDAgMTIgMGMtMS4zIDAtMi40Ljg0LTIuODIgMkg1Yy0xLjEgMC0yIC45LTIgMnYxNmMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjRjMC0xLjEtLjktMi0yLTJ6bS03IDBjLjU1IDAgMSAuNDUgMSAxcy0uNDUgMS0xIDEtMS0uNDUtMS0xIC40NS0xIDEtMXptNyAxOEg1VjRoMnYzaDEwVjRoMnYxNnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-python: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1icmFuZDAganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMEQ0N0ExIj4KICAgIDxwYXRoIGQ9Ik0xMS4xIDYuOVY1LjhINi45YzAtLjUgMC0xLjMuMi0xLjYuNC0uNy44LTEuMSAxLjctMS40IDEuNy0uMyAyLjUtLjMgMy45LS4xIDEgLjEgMS45LjkgMS45IDEuOXY0LjJjMCAuNS0uOSAxLjYtMiAxLjZIOC44Yy0xLjUgMC0yLjQgMS40LTIuNCAyLjh2Mi4ySDQuN0MzLjUgMTUuMSAzIDE0IDMgMTMuMVY5Yy0uMS0xIC42LTIgMS44LTIgMS41LS4xIDYuMy0uMSA2LjMtLjF6Ii8+CiAgICA8cGF0aCBkPSJNMTAuOSAxNS4xdjEuMWg0LjJjMCAuNSAwIDEuMy0uMiAxLjYtLjQuNy0uOCAxLjEtMS43IDEuNC0xLjcuMy0yLjUuMy0zLjkuMS0xLS4xLTEuOS0uOS0xLjktMS45di00LjJjMC0uNS45LTEuNiAyLTEuNmgzLjhjMS41IDAgMi40LTEuNCAyLjQtMi44VjYuNmgxLjdDMTguNSA2LjkgMTkgOCAxOSA4LjlWMTNjMCAxLS43IDIuMS0xLjkgMi4xaC02LjJ6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-r-kernel: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjE5NkYzIiBkPSJNNC40IDIuNWMxLjItLjEgMi45LS4zIDQuOS0uMyAyLjUgMCA0LjEuNCA1LjIgMS4zIDEgLjcgMS41IDEuOSAxLjUgMy41IDAgMi0xLjQgMy41LTIuOSA0LjEgMS4yLjQgMS43IDEuNiAyLjIgMyAuNiAxLjkgMSAzLjkgMS4zIDQuNmgtMy44Yy0uMy0uNC0uOC0xLjctMS4yLTMuN3MtMS4yLTIuNi0yLjYtMi42aC0uOXY2LjRINC40VjIuNXptMy43IDYuOWgxLjRjMS45IDAgMi45LS45IDIuOS0yLjNzLTEtMi4zLTIuOC0yLjNjLS43IDAtMS4zIDAtMS42LjJ2NC41aC4xdi0uMXoiLz4KPC9zdmc+Cg==);
+  --jp-icon-react: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMTUwIDE1MCA1NDEuOSAyOTUuMyI+CiAgPGcgY2xhc3M9ImpwLWljb24tYnJhbmQyIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzYxREFGQiI+CiAgICA8cGF0aCBkPSJNNjY2LjMgMjk2LjVjMC0zMi41LTQwLjctNjMuMy0xMDMuMS04Mi40IDE0LjQtNjMuNiA4LTExNC4yLTIwLjItMTMwLjQtNi41LTMuOC0xNC4xLTUuNi0yMi40LTUuNnYyMi4zYzQuNiAwIDguMy45IDExLjQgMi42IDEzLjYgNy44IDE5LjUgMzcuNSAxNC45IDc1LjctMS4xIDkuNC0yLjkgMTkuMy01LjEgMjkuNC0xOS42LTQuOC00MS04LjUtNjMuNS0xMC45LTEzLjUtMTguNS0yNy41LTM1LjMtNDEuNi01MCAzMi42LTMwLjMgNjMuMi00Ni45IDg0LTQ2LjlWNzhjLTI3LjUgMC02My41IDE5LjYtOTkuOSA1My42LTM2LjQtMzMuOC03Mi40LTUzLjItOTkuOS01My4ydjIyLjNjMjAuNyAwIDUxLjQgMTYuNSA4NCA0Ni42LTE0IDE0LjctMjggMzEuNC00MS4zIDQ5LjktMjIuNiAyLjQtNDQgNi4xLTYzLjYgMTEtMi4zLTEwLTQtMTkuNy01LjItMjktNC43LTM4LjIgMS4xLTY3LjkgMTQuNi03NS44IDMtMS44IDYuOS0yLjYgMTEuNS0yLjZWNzguNWMtOC40IDAtMTYgMS44LTIyLjYgNS42LTI4LjEgMTYuMi0zNC40IDY2LjctMTkuOSAxMzAuMS02Mi4yIDE5LjItMTAyLjcgNDkuOS0xMDIuNyA4Mi4zIDAgMzIuNSA0MC43IDYzLjMgMTAzLjEgODIuNC0xNC40IDYzLjYtOCAxMTQuMiAyMC4yIDEzMC40IDYuNSAzLjggMTQuMSA1LjYgMjIuNSA1LjYgMjcuNSAwIDYzLjUtMTkuNiA5OS45LTUzLjYgMzYuNCAzMy44IDcyLjQgNTMuMiA5OS45IDUzLjIgOC40IDAgMTYtMS44IDIyLjYtNS42IDI4LjEtMTYuMiAzNC40LTY2LjcgMTkuOS0xMzAuMSA2Mi0xOS4xIDEwMi41LTQ5LjkgMTAyLjUtODIuM3ptLTEzMC4yLTY2LjdjLTMuNyAxMi45LTguMyAyNi4yLTEzLjUgMzkuNS00LjEtOC04LjQtMTYtMTMuMS0yNC00LjYtOC05LjUtMTUuOC0xNC40LTIzLjQgMTQuMiAyLjEgMjcuOSA0LjcgNDEgNy45em0tNDUuOCAxMDYuNWMtNy44IDEzLjUtMTUuOCAyNi4zLTI0LjEgMzguMi0xNC45IDEuMy0zMCAyLTQ1LjIgMi0xNS4xIDAtMzAuMi0uNy00NS0xLjktOC4zLTExLjktMTYuNC0yNC42LTI0LjItMzgtNy42LTEzLjEtMTQuNS0yNi40LTIwLjgtMzkuOCA2LjItMTMuNCAxMy4yLTI2LjggMjAuNy0zOS45IDcuOC0xMy41IDE1LjgtMjYuMyAyNC4xLTM4LjIgMTQuOS0xLjMgMzAtMiA0NS4yLTIgMTUuMSAwIDMwLjIuNyA0NSAxLjkgOC4zIDExLjkgMTYuNCAyNC42IDI0LjIgMzggNy42IDEzLjEgMTQuNSAyNi40IDIwLjggMzkuOC02LjMgMTMuNC0xMy4yIDI2LjgtMjAuNyAzOS45em0zMi4zLTEzYzUuNCAxMy40IDEwIDI2LjggMTMuOCAzOS44LTEzLjEgMy4yLTI2LjkgNS45LTQxLjIgOCA0LjktNy43IDkuOC0xNS42IDE0LjQtMjMuNyA0LjYtOCA4LjktMTYuMSAxMy0yNC4xek00MjEuMiA0MzBjLTkuMy05LjYtMTguNi0yMC4zLTI3LjgtMzIgOSAuNCAxOC4yLjcgMjcuNS43IDkuNCAwIDE4LjctLjIgMjcuOC0uNy05IDExLjctMTguMyAyMi40LTI3LjUgMzJ6bS03NC40LTU4LjljLTE0LjItMi4xLTI3LjktNC43LTQxLTcuOSAzLjctMTIuOSA4LjMtMjYuMiAxMy41LTM5LjUgNC4xIDggOC40IDE2IDEzLjEgMjQgNC43IDggOS41IDE1LjggMTQuNCAyMy40ek00MjAuNyAxNjNjOS4zIDkuNiAxOC42IDIwLjMgMjcuOCAzMi05LS40LTE4LjItLjctMjcuNS0uNy05LjQgMC0xOC43LjItMjcuOC43IDktMTEuNyAxOC4zLTIyLjQgMjcuNS0zMnptLTc0IDU4LjljLTQuOSA3LjctOS44IDE1LjYtMTQuNCAyMy43LTQuNiA4LTguOSAxNi0xMyAyNC01LjQtMTMuNC0xMC0yNi44LTEzLjgtMzkuOCAxMy4xLTMuMSAyNi45LTUuOCA0MS4yLTcuOXptLTkwLjUgMTI1LjJjLTM1LjQtMTUuMS01OC4zLTM0LjktNTguMy01MC42IDAtMTUuNyAyMi45LTM1LjYgNTguMy01MC42IDguNi0zLjcgMTgtNyAyNy43LTEwLjEgNS43IDE5LjYgMTMuMiA0MCAyMi41IDYwLjktOS4yIDIwLjgtMTYuNiA0MS4xLTIyLjIgNjAuNi05LjktMy4xLTE5LjMtNi41LTI4LTEwLjJ6TTMxMCA0OTBjLTEzLjYtNy44LTE5LjUtMzcuNS0xNC45LTc1LjcgMS4xLTkuNCAyLjktMTkuMyA1LjEtMjkuNCAxOS42IDQuOCA0MSA4LjUgNjMuNSAxMC45IDEzLjUgMTguNSAyNy41IDM1LjMgNDEuNiA1MC0zMi42IDMwLjMtNjMuMiA0Ni45LTg0IDQ2LjktNC41LS4xLTguMy0xLTExLjMtMi43em0yMzcuMi03Ni4yYzQuNyAzOC4yLTEuMSA2Ny45LTE0LjYgNzUuOC0zIDEuOC02LjkgMi42LTExLjUgMi42LTIwLjcgMC01MS40LTE2LjUtODQtNDYuNiAxNC0xNC43IDI4LTMxLjQgNDEuMy00OS45IDIyLjYtMi40IDQ0LTYuMSA2My42LTExIDIuMyAxMC4xIDQuMSAxOS44IDUuMiAyOS4xem0zOC41LTY2LjdjLTguNiAzLjctMTggNy0yNy43IDEwLjEtNS43LTE5LjYtMTMuMi00MC0yMi41LTYwLjkgOS4yLTIwLjggMTYuNi00MS4xIDIyLjItNjAuNiA5LjkgMy4xIDE5LjMgNi41IDI4LjEgMTAuMiAzNS40IDE1LjEgNTguMyAzNC45IDU4LjMgNTAuNi0uMSAxNS43LTIzIDM1LjYtNTguNCA1MC42ek0zMjAuOCA3OC40eiIvPgogICAgPGNpcmNsZSBjeD0iNDIwLjkiIGN5PSIyOTYuNSIgcj0iNDUuNyIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-refresh: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTkgMTMuNWMtMi40OSAwLTQuNS0yLjAxLTQuNS00LjVTNi41MSA0LjUgOSA0LjVjMS4yNCAwIDIuMzYuNTIgMy4xNyAxLjMzTDEwIDhoNVYzbC0xLjc2IDEuNzZDMTIuMTUgMy42OCAxMC42NiAzIDkgMyA1LjY5IDMgMy4wMSA1LjY5IDMuMDEgOVM1LjY5IDE1IDkgMTVjMi45NyAwIDUuNDMtMi4xNiA1LjktNWgtMS41MmMtLjQ2IDItMi4yNCAzLjUtNC4zOCAzLjV6Ii8+CiAgICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-regex: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwIDIwIj4KICA8ZyBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiM0MTQxNDEiPgogICAgPHJlY3QgeD0iMiIgeT0iMiIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbi1hY2NlbnQyIiBmaWxsPSIjRkZGIj4KICAgIDxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjUuNSIgY3k9IjE0LjUiIHI9IjEuNSIvPgogICAgPHJlY3QgeD0iMTIiIHk9IjQiIGNsYXNzPSJzdDIiIHdpZHRoPSIxIiBoZWlnaHQ9IjgiLz4KICAgIDxyZWN0IHg9IjguNSIgeT0iNy41IiB0cmFuc2Zvcm09Im1hdHJpeCgwLjg2NiAtMC41IDAuNSAwLjg2NiAtMi4zMjU1IDcuMzIxOSkiIGNsYXNzPSJzdDIiIHdpZHRoPSI4IiBoZWlnaHQ9IjEiLz4KICAgIDxyZWN0IHg9IjEyIiB5PSI0IiB0cmFuc2Zvcm09Im1hdHJpeCgwLjUgLTAuODY2IDAuODY2IDAuNSAtMC42Nzc5IDE0LjgyNTIpIiBjbGFzcz0ic3QyIiB3aWR0aD0iMSIgaGVpZ2h0PSI4Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-run: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTggNXYxNGwxMS03eiIvPgogICAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-running: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDUxMiA1MTIiPgogIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICA8cGF0aCBkPSJNMjU2IDhDMTE5IDggOCAxMTkgOCAyNTZzMTExIDI0OCAyNDggMjQ4IDI0OC0xMTEgMjQ4LTI0OFMzOTMgOCAyNTYgOHptOTYgMzI4YzAgOC44LTcuMiAxNi0xNiAxNkgxNzZjLTguOCAwLTE2LTcuMi0xNi0xNlYxNzZjMC04LjggNy4yLTE2IDE2LTE2aDE2MGM4LjggMCAxNiA3LjIgMTYgMTZ2MTYweiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-save: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTE3IDNINWMtMS4xMSAwLTIgLjktMiAydjE0YzAgMS4xLjg5IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjdsLTQtNHptLTUgMTZjLTEuNjYgMC0zLTEuMzQtMy0zczEuMzQtMyAzLTMgMyAxLjM0IDMgMy0xLjM0IDMtMyAzem0zLTEwSDVWNWgxMHY0eiIvPgogICAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-search: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyLjEsMTAuOWgtMC43bC0wLjItMC4yYzAuOC0wLjksMS4zLTIuMiwxLjMtMy41YzAtMy0yLjQtNS40LTUuNC01LjRTMS44LDQuMiwxLjgsNy4xczIuNCw1LjQsNS40LDUuNCBjMS4zLDAsMi41LTAuNSwzLjUtMS4zbDAuMiwwLjJ2MC43bDQuMSw0LjFsMS4yLTEuMkwxMi4xLDEwLjl6IE03LjEsMTAuOWMtMi4xLDAtMy43LTEuNy0zLjctMy43czEuNy0zLjcsMy43LTMuN3MzLjcsMS43LDMuNywzLjcgUzkuMiwxMC45LDcuMSwxMC45eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-settings: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTkuNDMgMTIuOThjLjA0LS4zMi4wNy0uNjQuMDctLjk4cy0uMDMtLjY2LS4wNy0uOThsMi4xMS0xLjY1Yy4xOS0uMTUuMjQtLjQyLjEyLS42NGwtMi0zLjQ2Yy0uMTItLjIyLS4zOS0uMy0uNjEtLjIybC0yLjQ5IDFjLS41Mi0uNC0xLjA4LS43My0xLjY5LS45OGwtLjM4LTIuNjVBLjQ4OC40ODggMCAwMDE0IDJoLTRjLS4yNSAwLS40Ni4xOC0uNDkuNDJsLS4zOCAyLjY1Yy0uNjEuMjUtMS4xNy41OS0xLjY5Ljk4bC0yLjQ5LTFjLS4yMy0uMDktLjQ5IDAtLjYxLjIybC0yIDMuNDZjLS4xMy4yMi0uMDcuNDkuMTIuNjRsMi4xMSAxLjY1Yy0uMDQuMzItLjA3LjY1LS4wNy45OHMuMDMuNjYuMDcuOThsLTIuMTEgMS42NWMtLjE5LjE1LS4yNC40Mi0uMTIuNjRsMiAzLjQ2Yy4xMi4yMi4zOS4zLjYxLjIybDIuNDktMWMuNTIuNCAxLjA4LjczIDEuNjkuOThsLjM4IDIuNjVjLjAzLjI0LjI0LjQyLjQ5LjQyaDRjLjI1IDAgLjQ2LS4xOC40OS0uNDJsLjM4LTIuNjVjLjYxLS4yNSAxLjE3LS41OSAxLjY5LS45OGwyLjQ5IDFjLjIzLjA5LjQ5IDAgLjYxLS4yMmwyLTMuNDZjLjEyLS4yMi4wNy0uNDktLjEyLS42NGwtMi4xMS0xLjY1ek0xMiAxNS41Yy0xLjkzIDAtMy41LTEuNTctMy41LTMuNXMxLjU3LTMuNSAzLjUtMy41IDMuNSAxLjU3IDMuNSAzLjUtMS41NyAzLjUtMy41IDMuNXoiLz4KPC9zdmc+Cg==);
+  --jp-icon-spreadsheet: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNENBRjUwIiBkPSJNMi4yIDIuMnYxNy42aDE3LjZWMi4ySDIuMnptMTUuNCA3LjdoLTUuNVY0LjRoNS41djUuNXpNOS45IDQuNHY1LjVINC40VjQuNGg1LjV6bS01LjUgNy43aDUuNXY1LjVINC40di01LjV6bTcuNyA1LjV2LTUuNWg1LjV2NS41aC01LjV6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-stop: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik02IDZoMTJ2MTJINnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-tab: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIxIDNIM2MtMS4xIDAtMiAuOS0yIDJ2MTRjMCAxLjEuOSAyIDIgMmgxOGMxLjEgMCAyLS45IDItMlY1YzAtMS4xLS45LTItMi0yem0wIDE2SDNWNWgxMHY0aDh2MTB6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-terminal: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiA+CiAgICA8cmVjdCBjbGFzcz0ianAtaWNvbjIganAtaWNvbi1zZWxlY3RhYmxlIiB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMikiIGZpbGw9IiMzMzMzMzMiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uLWFjY2VudDIganAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGQ9Ik01LjA1NjY0IDguNzYxNzJDNS4wNTY2NCA4LjU5NzY2IDUuMDMxMjUgOC40NTMxMiA0Ljk4MDQ3IDguMzI4MTJDNC45MzM1OSA4LjE5OTIyIDQuODU1NDcgOC4wODIwMyA0Ljc0NjA5IDcuOTc2NTZDNC42NDA2MiA3Ljg3MTA5IDQuNSA3Ljc3NTM5IDQuMzI0MjIgNy42ODk0NUM0LjE1MjM0IDcuNTk5NjEgMy45NDMzNiA3LjUxMTcyIDMuNjk3MjcgNy40MjU3OEMzLjMwMjczIDcuMjg1MTYgMi45NDMzNiA3LjEzNjcyIDIuNjE5MTQgNi45ODA0N0MyLjI5NDkyIDYuODI0MjIgMi4wMTc1OCA2LjY0MjU4IDEuNzg3MTEgNi40MzU1NUMxLjU2MDU1IDYuMjI4NTIgMS4zODQ3NyA1Ljk4ODI4IDEuMjU5NzcgNS43MTQ4NEMxLjEzNDc3IDUuNDM3NSAxLjA3MjI3IDUuMTA5MzggMS4wNzIyNyA0LjczMDQ3QzEuMDcyMjcgNC4zOTg0NCAxLjEyODkxIDQuMDk1NyAxLjI0MjE5IDMuODIyMjdDMS4zNTU0NyAzLjU0NDkyIDEuNTE1NjIgMy4zMDQ2OSAxLjcyMjY2IDMuMTAxNTZDMS45Mjk2OSAyLjg5ODQ0IDIuMTc5NjkgMi43MzQzNyAyLjQ3MjY2IDIuNjA5MzhDMi43NjU2MiAyLjQ4NDM4IDMuMDkxOCAyLjQwNDMgMy40NTExNyAyLjM2OTE0VjEuMTA5MzhINC4zODg2N1YyLjM4MDg2QzQuNzQwMjMgMi40Mjc3MyA1LjA1NjY0IDIuNTIzNDQgNS4zMzc4OSAyLjY2Nzk3QzUuNjE5MTQgMi44MTI1IDUuODU3NDIgMy4wMDE5NSA2LjA1MjczIDMuMjM2MzNDNi4yNTE5NSAzLjQ2NjggNi40MDQzIDMuNzQwMjMgNi41MDk3NyA0LjA1NjY0QzYuNjE5MTQgNC4zNjkxNCA2LjY3MzgzIDQuNzIwNyA2LjY3MzgzIDUuMTExMzNINS4wNDQ5MkM1LjA0NDkyIDQuNjM4NjcgNC45Mzc1IDQuMjgxMjUgNC43MjI2NiA0LjAzOTA2QzQuNTA3ODEgMy43OTI5NyA0LjIxNjggMy42Njk5MiAzLjg0OTYxIDMuNjY5OTJDMy42NTAzOSAzLjY2OTkyIDMuNDc2NTYgMy42OTcyNyAzLjMyODEyIDMuNzUxOTVDMy4xODM1OSAzLjgwMjczIDMuMDY0NDUgMy44NzY5NSAyLjk3MDcgMy45NzQ2MUMyLjg3Njk1IDQuMDY4MzYgMi44MDY2NCA0LjE3OTY5IDIuNzU5NzcgNC4zMDg1OUMyLjcxNjggNC40Mzc1IDIuNjk1MzEgNC41NzgxMiAyLjY5NTMxIDQuNzMwNDdDMi42OTUzMSA0Ljg4MjgxIDIuNzE2OCA1LjAxOTUzIDIuNzU5NzcgNS4xNDA2MkMyLjgwNjY0IDUuMjU3ODEgMi44ODI4MSA1LjM2NzE5IDIuOTg4MjggNS40Njg3NUMzLjA5NzY2IDUuNTcwMzEgMy4yNDAyMyA1LjY2Nzk3IDMuNDE2MDIgNS43NjE3MkMzLjU5MTggNS44NTE1NiAzLjgxMDU1IDUuOTQzMzYgNC4wNzIyNyA2LjAzNzExQzQuNDY2OCA2LjE4NTU1IDQuODI0MjIgNi4zMzk4NCA1LjE0NDUzIDYuNUM1LjQ2NDg0IDYuNjU2MjUgNS43MzgyOCA2LjgzOTg0IDUuOTY0ODQgNy4wNTA3OEM2LjE5NTMxIDcuMjU3ODEgNi4zNzEwOSA3LjUgNi40OTIxOSA3Ljc3NzM0QzYuNjE3MTkgOC4wNTA3OCA2LjY3OTY5IDguMzc1IDYuNjc5NjkgOC43NUM2LjY3OTY5IDkuMDkzNzUgNi42MjMwNSA5LjQwNDMgNi41MDk3NyA5LjY4MTY0QzYuMzk2NDggOS45NTUwOCA2LjIzNDM4IDEwLjE5MTQgNi4wMjM0NCAxMC4zOTA2QzUuODEyNSAxMC41ODk4IDUuNTU4NTkgMTAuNzUgNS4yNjE3MiAxMC44NzExQzQuOTY0ODQgMTAuOTg4MyA0LjYzMjgxIDExLjA2NDUgNC4yNjU2MiAxMS4wOTk2VjEyLjI0OEgzLjMzMzk4VjExLjA5OTZDMy4wMDE5NSAxMS4wNjg0IDIuNjc5NjkgMTAuOTk2MSAyLjM2NzE5IDEwLjg4MjhDMi4wNTQ2OSAxMC43NjU2IDEuNzc3MzQgMTAuNTk3NyAxLjUzNTE2IDEwLjM3ODlDMS4yOTY4OCAxMC4xNjAyIDEuMTA1NDcgOS44ODQ3NyAwLjk2MDkzOCA5LjU1MjczQzAuODE2NDA2IDkuMjE2OCAwLjc0NDE0MSA4LjgxNDQ1IDAuNzQ0MTQxIDguMzQ1N0gyLjM3ODkxQzIuMzc4OTEgOC42MjY5NSAyLjQxOTkyIDguODYzMjggMi41MDE5NSA5LjA1NDY5QzIuNTgzOTggOS4yNDIxOSAyLjY4OTQ1IDkuMzkyNTggMi44MTgzNiA5LjUwNTg2QzIuOTUxMTcgOS42MTUyMyAzLjEwMTU2IDkuNjkzMzYgMy4yNjk1MyA5Ljc0MDIzQzMuNDM3NSA5Ljc4NzExIDMuNjA5MzggOS44MTA1NSAzLjc4NTE2IDkuODEwNTVDNC4yMDMxMiA5LjgxMDU1IDQuNTE5NTMgOS43MTI4OSA0LjczNDM4IDkuNTE3NThDNC45NDkyMiA5LjMyMjI3IDUuMDU2NjQgOS4wNzAzMSA1LjA1NjY0IDguNzYxNzJaTTEzLjQxOCAxMi4yNzE1SDguMDc0MjJWMTFIMTMuNDE4VjEyLjI3MTVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzLjk1MjY0IDYpIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K);
+  --jp-icon-text-editor: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMiAxNy4xODQ0IDIuOTY5NjggMTQuMzAzMiAxLjg2MDk0IDExLjQ0MDlaIi8+CiAgICA8cGF0aCBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiMzMzMzMzMiIHN0cm9rZT0iIzMzMzMzMyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOCA5Ljg2NzE5KSIgZD0iTTIuODYwMTUgNC44NjUzNUwwLjcyNjU0OSAyLjk5OTU5TDAgMy42MzA0NUwyLjg2MDE1IDYuMTMxNTdMOCAwLjYzMDg3Mkw3LjI3ODU3IDBMMi44NjAxNSA0Ljg2NTM1WiIvPgo8L3N2Zz4K);
+  --jp-icon-undo: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyLjUgOGMtMi42NSAwLTUuMDUuOTktNi45IDIuNkwyIDd2OWg5bC0zLjYyLTMuNjJjMS4zOS0xLjE2IDMuMTYtMS44OCA1LjEyLTEuODggMy41NCAwIDYuNTUgMi4zMSA3LjYgNS41bDIuMzctLjc4QzIxLjA4IDExLjAzIDE3LjE1IDggMTIuNSA4eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-vega: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbjEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjEyMTIxIj4KICAgIDxwYXRoIGQ9Ik0xMC42IDUuNGwyLjItMy4ySDIuMnY3LjNsNC02LjZ6Ii8+CiAgICA8cGF0aCBkPSJNMTUuOCAyLjJsLTQuNCA2LjZMNyA2LjNsLTQuOCA4djUuNWgxNy42VjIuMmgtNHptLTcgMTUuNEg1LjV2LTQuNGgzLjN2NC40em00LjQgMEg5LjhWOS44aDMuNHY3Ljh6bTQuNCAwaC0zLjRWNi41aDMuNHYxMS4xeiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-yaml: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1jb250cmFzdDIganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjRDgxQjYwIj4KICAgIDxwYXRoIGQ9Ik03LjIgMTguNnYtNS40TDMgNS42aDMuM2wxLjQgMy4xYy4zLjkuNiAxLjYgMSAyLjUuMy0uOC42LTEuNiAxLTIuNWwxLjQtMy4xaDMuNGwtNC40IDcuNnY1LjVsLTIuOS0uMXoiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MCIgY3g9IjE3LjYiIGN5PSIxNi41IiByPSIyLjEiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MCIgY3g9IjE3LjYiIGN5PSIxMSIgcj0iMi4xIi8+CiAgPC9nPgo8L3N2Zz4K);
+}
+
+/* Icon CSS class declarations */
+
+.jp-AddIcon {
+  background-image: var(--jp-icon-add);
+}
+.jp-BugIcon {
+  background-image: var(--jp-icon-bug);
+}
+.jp-BuildIcon {
+  background-image: var(--jp-icon-build);
+}
+.jp-CaretDownEmptyIcon {
+  background-image: var(--jp-icon-caret-down-empty);
+}
+.jp-CaretDownEmptyThinIcon {
+  background-image: var(--jp-icon-caret-down-empty-thin);
+}
+.jp-CaretDownIcon {
+  background-image: var(--jp-icon-caret-down);
+}
+.jp-CaretLeftIcon {
+  background-image: var(--jp-icon-caret-left);
+}
+.jp-CaretRightIcon {
+  background-image: var(--jp-icon-caret-right);
+}
+.jp-CaretUpEmptyThinIcon {
+  background-image: var(--jp-icon-caret-up-empty-thin);
+}
+.jp-CaretUpIcon {
+  background-image: var(--jp-icon-caret-up);
+}
+.jp-CaseSensitiveIcon {
+  background-image: var(--jp-icon-case-sensitive);
+}
+.jp-CheckIcon {
+  background-image: var(--jp-icon-check);
+}
+.jp-CircleEmptyIcon {
+  background-image: var(--jp-icon-circle-empty);
+}
+.jp-CircleIcon {
+  background-image: var(--jp-icon-circle);
+}
+.jp-ClearIcon {
+  background-image: var(--jp-icon-clear);
+}
+.jp-CloseIcon {
+  background-image: var(--jp-icon-close);
+}
+.jp-ConsoleIcon {
+  background-image: var(--jp-icon-console);
+}
+.jp-CopyIcon {
+  background-image: var(--jp-icon-copy);
+}
+.jp-CutIcon {
+  background-image: var(--jp-icon-cut);
+}
+.jp-DownloadIcon {
+  background-image: var(--jp-icon-download);
+}
+.jp-EditIcon {
+  background-image: var(--jp-icon-edit);
+}
+.jp-EllipsesIcon {
+  background-image: var(--jp-icon-ellipses);
+}
+.jp-ExtensionIcon {
+  background-image: var(--jp-icon-extension);
+}
+.jp-FastForwardIcon {
+  background-image: var(--jp-icon-fast-forward);
+}
+.jp-FileIcon {
+  background-image: var(--jp-icon-file);
+}
+.jp-FileUploadIcon {
+  background-image: var(--jp-icon-file-upload);
+}
+.jp-FilterListIcon {
+  background-image: var(--jp-icon-filter-list);
+}
+.jp-FolderIcon {
+  background-image: var(--jp-icon-folder);
+}
+.jp-Html5Icon {
+  background-image: var(--jp-icon-html5);
+}
+.jp-ImageIcon {
+  background-image: var(--jp-icon-image);
+}
+.jp-InspectorIcon {
+  background-image: var(--jp-icon-inspector);
+}
+.jp-JsonIcon {
+  background-image: var(--jp-icon-json);
+}
+.jp-JupyterFaviconIcon {
+  background-image: var(--jp-icon-jupyter-favicon);
+}
+.jp-JupyterIcon {
+  background-image: var(--jp-icon-jupyter);
+}
+.jp-JupyterlabWordmarkIcon {
+  background-image: var(--jp-icon-jupyterlab-wordmark);
+}
+.jp-KernelIcon {
+  background-image: var(--jp-icon-kernel);
+}
+.jp-KeyboardIcon {
+  background-image: var(--jp-icon-keyboard);
+}
+.jp-LauncherIcon {
+  background-image: var(--jp-icon-launcher);
+}
+.jp-LineFormIcon {
+  background-image: var(--jp-icon-line-form);
+}
+.jp-LinkIcon {
+  background-image: var(--jp-icon-link);
+}
+.jp-ListIcon {
+  background-image: var(--jp-icon-list);
+}
+.jp-ListingsInfoIcon {
+  background-image: var(--jp-icon-listings-info);
+}
+.jp-MarkdownIcon {
+  background-image: var(--jp-icon-markdown);
+}
+.jp-NewFolderIcon {
+  background-image: var(--jp-icon-new-folder);
+}
+.jp-NotTrustedIcon {
+  background-image: var(--jp-icon-not-trusted);
+}
+.jp-NotebookIcon {
+  background-image: var(--jp-icon-notebook);
+}
+.jp-PaletteIcon {
+  background-image: var(--jp-icon-palette);
+}
+.jp-PasteIcon {
+  background-image: var(--jp-icon-paste);
+}
+.jp-PythonIcon {
+  background-image: var(--jp-icon-python);
+}
+.jp-RKernelIcon {
+  background-image: var(--jp-icon-r-kernel);
+}
+.jp-ReactIcon {
+  background-image: var(--jp-icon-react);
+}
+.jp-RefreshIcon {
+  background-image: var(--jp-icon-refresh);
+}
+.jp-RegexIcon {
+  background-image: var(--jp-icon-regex);
+}
+.jp-RunIcon {
+  background-image: var(--jp-icon-run);
+}
+.jp-RunningIcon {
+  background-image: var(--jp-icon-running);
+}
+.jp-SaveIcon {
+  background-image: var(--jp-icon-save);
+}
+.jp-SearchIcon {
+  background-image: var(--jp-icon-search);
+}
+.jp-SettingsIcon {
+  background-image: var(--jp-icon-settings);
+}
+.jp-SpreadsheetIcon {
+  background-image: var(--jp-icon-spreadsheet);
+}
+.jp-StopIcon {
+  background-image: var(--jp-icon-stop);
+}
+.jp-TabIcon {
+  background-image: var(--jp-icon-tab);
+}
+.jp-TerminalIcon {
+  background-image: var(--jp-icon-terminal);
+}
+.jp-TextEditorIcon {
+  background-image: var(--jp-icon-text-editor);
+}
+.jp-TrustedIcon {
+  background-image: var(--jp-icon-trusted);
+}
+.jp-UndoIcon {
+  background-image: var(--jp-icon-undo);
+}
+.jp-VegaIcon {
+  background-image: var(--jp-icon-vega);
+}
+.jp-YamlIcon {
+  background-image: var(--jp-icon-yaml);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/**
+ * (DEPRECATED) Support for consuming icons as CSS background images
+ */
+
+:root {
+  --jp-icon-search-white: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyLjEsMTAuOWgtMC43bC0wLjItMC4yYzAuOC0wLjksMS4zLTIuMiwxLjMtMy41YzAtMy0yLjQtNS40LTUuNC01LjRTMS44LDQuMiwxLjgsNy4xczIuNCw1LjQsNS40LDUuNCBjMS4zLDAsMi41LTAuNSwzLjUtMS4zbDAuMiwwLjJ2MC43bDQuMSw0LjFsMS4yLTEuMkwxMi4xLDEwLjl6IE03LjEsMTAuOWMtMi4xLDAtMy43LTEuNy0zLjctMy43czEuNy0zLjcsMy43LTMuN3MzLjcsMS43LDMuNywzLjcgUzkuMiwxMC45LDcuMSwxMC45eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+}
+
+.jp-Icon,
+.jp-MaterialIcon {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.jp-Icon-cover {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+/**
+ * (DEPRECATED) Support for specific CSS icon sizes
+ */
+
+.jp-Icon-16 {
+  background-size: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.jp-Icon-18 {
+  background-size: 18px;
+  min-width: 18px;
+  min-height: 18px;
+}
+
+.jp-Icon-20 {
+  background-size: 20px;
+  min-width: 20px;
+  min-height: 20px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/**
+ * Support for icons as inline SVG HTMLElements
+ */
+
+/* recolor the primary elements of an icon */
+.jp-icon0[fill] {
+  fill: var(--jp-inverse-layout-color0);
+}
+.jp-icon1[fill] {
+  fill: var(--jp-inverse-layout-color1);
+}
+.jp-icon2[fill] {
+  fill: var(--jp-inverse-layout-color2);
+}
+.jp-icon3[fill] {
+  fill: var(--jp-inverse-layout-color3);
+}
+.jp-icon4[fill] {
+  fill: var(--jp-inverse-layout-color4);
+}
+
+.jp-icon0[stroke] {
+  stroke: var(--jp-inverse-layout-color0);
+}
+.jp-icon1[stroke] {
+  stroke: var(--jp-inverse-layout-color1);
+}
+.jp-icon2[stroke] {
+  stroke: var(--jp-inverse-layout-color2);
+}
+.jp-icon3[stroke] {
+  stroke: var(--jp-inverse-layout-color3);
+}
+.jp-icon4[stroke] {
+  stroke: var(--jp-inverse-layout-color4);
+}
+/* recolor the accent elements of an icon */
+.jp-icon-accent0[fill] {
+  fill: var(--jp-layout-color0);
+}
+.jp-icon-accent1[fill] {
+  fill: var(--jp-layout-color1);
+}
+.jp-icon-accent2[fill] {
+  fill: var(--jp-layout-color2);
+}
+.jp-icon-accent3[fill] {
+  fill: var(--jp-layout-color3);
+}
+.jp-icon-accent4[fill] {
+  fill: var(--jp-layout-color4);
+}
+
+.jp-icon-accent0[stroke] {
+  stroke: var(--jp-layout-color0);
+}
+.jp-icon-accent1[stroke] {
+  stroke: var(--jp-layout-color1);
+}
+.jp-icon-accent2[stroke] {
+  stroke: var(--jp-layout-color2);
+}
+.jp-icon-accent3[stroke] {
+  stroke: var(--jp-layout-color3);
+}
+.jp-icon-accent4[stroke] {
+  stroke: var(--jp-layout-color4);
+}
+/* set the color of an icon to transparent */
+.jp-icon-none[fill] {
+  fill: none;
+}
+
+.jp-icon-none[stroke] {
+  stroke: none;
+}
+/* brand icon colors. Same for light and dark */
+.jp-icon-brand0[fill] {
+  fill: var(--jp-brand-color0);
+}
+.jp-icon-brand1[fill] {
+  fill: var(--jp-brand-color1);
+}
+.jp-icon-brand2[fill] {
+  fill: var(--jp-brand-color2);
+}
+.jp-icon-brand3[fill] {
+  fill: var(--jp-brand-color3);
+}
+.jp-icon-brand4[fill] {
+  fill: var(--jp-brand-color4);
+}
+
+.jp-icon-brand0[stroke] {
+  stroke: var(--jp-brand-color0);
+}
+.jp-icon-brand1[stroke] {
+  stroke: var(--jp-brand-color1);
+}
+.jp-icon-brand2[stroke] {
+  stroke: var(--jp-brand-color2);
+}
+.jp-icon-brand3[stroke] {
+  stroke: var(--jp-brand-color3);
+}
+.jp-icon-brand4[stroke] {
+  stroke: var(--jp-brand-color4);
+}
+/* warn icon colors. Same for light and dark */
+.jp-icon-warn0[fill] {
+  fill: var(--jp-warn-color0);
+}
+.jp-icon-warn1[fill] {
+  fill: var(--jp-warn-color1);
+}
+.jp-icon-warn2[fill] {
+  fill: var(--jp-warn-color2);
+}
+.jp-icon-warn3[fill] {
+  fill: var(--jp-warn-color3);
+}
+
+.jp-icon-warn0[stroke] {
+  stroke: var(--jp-warn-color0);
+}
+.jp-icon-warn1[stroke] {
+  stroke: var(--jp-warn-color1);
+}
+.jp-icon-warn2[stroke] {
+  stroke: var(--jp-warn-color2);
+}
+.jp-icon-warn3[stroke] {
+  stroke: var(--jp-warn-color3);
+}
+/* icon colors that contrast well with each other and most backgrounds */
+.jp-icon-contrast0[fill] {
+  fill: var(--jp-icon-contrast-color0);
+}
+.jp-icon-contrast1[fill] {
+  fill: var(--jp-icon-contrast-color1);
+}
+.jp-icon-contrast2[fill] {
+  fill: var(--jp-icon-contrast-color2);
+}
+.jp-icon-contrast3[fill] {
+  fill: var(--jp-icon-contrast-color3);
+}
+
+.jp-icon-contrast0[stroke] {
+  stroke: var(--jp-icon-contrast-color0);
+}
+.jp-icon-contrast1[stroke] {
+  stroke: var(--jp-icon-contrast-color1);
+}
+.jp-icon-contrast2[stroke] {
+  stroke: var(--jp-icon-contrast-color2);
+}
+.jp-icon-contrast3[stroke] {
+  stroke: var(--jp-icon-contrast-color3);
+}
+
+/* CSS for icons in selected items in the settings editor */
+#setting-editor .jp-PluginList .jp-mod-selected .jp-icon-selectable[fill] {
+  fill: #fff;
+}
+#setting-editor
+  .jp-PluginList
+  .jp-mod-selected
+  .jp-icon-selectable-inverse[fill] {
+  fill: var(--jp-brand-color1);
+}
+
+/* CSS for icons in selected filebrowser listing items */
+.jp-DirListing-item.jp-mod-selected .jp-icon-selectable[fill] {
+  fill: #fff;
+}
+.jp-DirListing-item.jp-mod-selected .jp-icon-selectable-inverse[fill] {
+  fill: var(--jp-brand-color1);
+}
+
+/* CSS for icons in selected tabs in the sidebar tab manager */
+#tab-manager .lm-TabBar-tab.jp-mod-active .jp-icon-selectable[fill] {
+  fill: #fff;
+}
+
+#tab-manager .lm-TabBar-tab.jp-mod-active .jp-icon-selectable-inverse[fill] {
+  fill: var(--jp-brand-color1);
+}
+#tab-manager
+  .lm-TabBar-tab.jp-mod-active
+  .jp-icon-hover
+  :hover
+  .jp-icon-selectable[fill] {
+  fill: var(--jp-brand-color1);
+}
+
+#tab-manager
+  .lm-TabBar-tab.jp-mod-active
+  .jp-icon-hover
+  :hover
+  .jp-icon-selectable-inverse[fill] {
+  fill: #fff;
+}
+
+/**
+ * TODO: come up with non css-hack solution for showing the busy icon on top
+ *  of the close icon
+ * CSS for complex behavior of close icon of tabs in the sidebar tab manager
+ */
+#tab-manager
+  .lm-TabBar-tab.jp-mod-dirty
+  > .lm-TabBar-tabCloseIcon
+  > :not(:hover)
+  > .jp-icon3[fill] {
+  fill: none;
+}
+#tab-manager
+  .lm-TabBar-tab.jp-mod-dirty
+  > .lm-TabBar-tabCloseIcon
+  > :not(:hover)
+  > .jp-icon-busy[fill] {
+  fill: var(--jp-inverse-layout-color3);
+}
+
+#tab-manager
+  .lm-TabBar-tab.jp-mod-dirty.jp-mod-active
+  > .lm-TabBar-tabCloseIcon
+  > :not(:hover)
+  > .jp-icon-busy[fill] {
+  fill: #fff;
+}
+
+/**
+* TODO: come up with non css-hack solution for showing the busy icon on top
+*  of the close icon
+* CSS for complex behavior of close icon of tabs in the main area tabbar
+*/
+.lm-DockPanel-tabBar
+  .lm-TabBar-tab.lm-mod-closable.jp-mod-dirty
+  > .lm-TabBar-tabCloseIcon
+  > :not(:hover)
+  > .jp-icon3[fill] {
+  fill: none;
+}
+.lm-DockPanel-tabBar
+  .lm-TabBar-tab.lm-mod-closable.jp-mod-dirty
+  > .lm-TabBar-tabCloseIcon
+  > :not(:hover)
+  > .jp-icon-busy[fill] {
+  fill: var(--jp-inverse-layout-color3);
+}
+
+/* CSS for icons in status bar */
+#jp-main-statusbar .jp-mod-selected .jp-icon-selectable[fill] {
+  fill: #fff;
+}
+
+#jp-main-statusbar .jp-mod-selected .jp-icon-selectable-inverse[fill] {
+  fill: var(--jp-brand-color1);
+}
+/* special handling for splash icon CSS. While the theme CSS reloads during
+   splash, the splash icon can loose theming. To prevent that, we set a
+   default for its color variable */
+:root {
+  --jp-warn-color0: var(--md-orange-700);
+}
+
+/* not sure what to do with this one, used in filebrowser listing */
+.jp-DragIcon {
+  margin-right: 4px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/**
+ * Support for alt colors for icons as inline SVG HTMLElements
+ */
+
+/* alt recolor the primary elements of an icon */
+.jp-icon-alt .jp-icon0[fill] {
+  fill: var(--jp-layout-color0);
+}
+.jp-icon-alt .jp-icon1[fill] {
+  fill: var(--jp-layout-color1);
+}
+.jp-icon-alt .jp-icon2[fill] {
+  fill: var(--jp-layout-color2);
+}
+.jp-icon-alt .jp-icon3[fill] {
+  fill: var(--jp-layout-color3);
+}
+.jp-icon-alt .jp-icon4[fill] {
+  fill: var(--jp-layout-color4);
+}
+
+.jp-icon-alt .jp-icon0[stroke] {
+  stroke: var(--jp-layout-color0);
+}
+.jp-icon-alt .jp-icon1[stroke] {
+  stroke: var(--jp-layout-color1);
+}
+.jp-icon-alt .jp-icon2[stroke] {
+  stroke: var(--jp-layout-color2);
+}
+.jp-icon-alt .jp-icon3[stroke] {
+  stroke: var(--jp-layout-color3);
+}
+.jp-icon-alt .jp-icon4[stroke] {
+  stroke: var(--jp-layout-color4);
+}
+
+/* alt recolor the accent elements of an icon */
+.jp-icon-alt .jp-icon-accent0[fill] {
+  fill: var(--jp-inverse-layout-color0);
+}
+.jp-icon-alt .jp-icon-accent1[fill] {
+  fill: var(--jp-inverse-layout-color1);
+}
+.jp-icon-alt .jp-icon-accent2[fill] {
+  fill: var(--jp-inverse-layout-color2);
+}
+.jp-icon-alt .jp-icon-accent3[fill] {
+  fill: var(--jp-inverse-layout-color3);
+}
+.jp-icon-alt .jp-icon-accent4[fill] {
+  fill: var(--jp-inverse-layout-color4);
+}
+
+.jp-icon-alt .jp-icon-accent0[stroke] {
+  stroke: var(--jp-inverse-layout-color0);
+}
+.jp-icon-alt .jp-icon-accent1[stroke] {
+  stroke: var(--jp-inverse-layout-color1);
+}
+.jp-icon-alt .jp-icon-accent2[stroke] {
+  stroke: var(--jp-inverse-layout-color2);
+}
+.jp-icon-alt .jp-icon-accent3[stroke] {
+  stroke: var(--jp-inverse-layout-color3);
+}
+.jp-icon-alt .jp-icon-accent4[stroke] {
+  stroke: var(--jp-inverse-layout-color4);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-icon-hoverShow:not(:hover) svg {
+  display: none !important;
+}
+
+/**
+ * Support for hover colors for icons as inline SVG HTMLElements
+ */
+
+/**
+ * regular colors
+ */
+
+/* recolor the primary elements of an icon */
+.jp-icon-hover :hover .jp-icon0-hover[fill] {
+  fill: var(--jp-inverse-layout-color0);
+}
+.jp-icon-hover :hover .jp-icon1-hover[fill] {
+  fill: var(--jp-inverse-layout-color1);
+}
+.jp-icon-hover :hover .jp-icon2-hover[fill] {
+  fill: var(--jp-inverse-layout-color2);
+}
+.jp-icon-hover :hover .jp-icon3-hover[fill] {
+  fill: var(--jp-inverse-layout-color3);
+}
+.jp-icon-hover :hover .jp-icon4-hover[fill] {
+  fill: var(--jp-inverse-layout-color4);
+}
+
+.jp-icon-hover :hover .jp-icon0-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color0);
+}
+.jp-icon-hover :hover .jp-icon1-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color1);
+}
+.jp-icon-hover :hover .jp-icon2-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color2);
+}
+.jp-icon-hover :hover .jp-icon3-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color3);
+}
+.jp-icon-hover :hover .jp-icon4-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color4);
+}
+
+/* recolor the accent elements of an icon */
+.jp-icon-hover :hover .jp-icon-accent0-hover[fill] {
+  fill: var(--jp-layout-color0);
+}
+.jp-icon-hover :hover .jp-icon-accent1-hover[fill] {
+  fill: var(--jp-layout-color1);
+}
+.jp-icon-hover :hover .jp-icon-accent2-hover[fill] {
+  fill: var(--jp-layout-color2);
+}
+.jp-icon-hover :hover .jp-icon-accent3-hover[fill] {
+  fill: var(--jp-layout-color3);
+}
+.jp-icon-hover :hover .jp-icon-accent4-hover[fill] {
+  fill: var(--jp-layout-color4);
+}
+
+.jp-icon-hover :hover .jp-icon-accent0-hover[stroke] {
+  stroke: var(--jp-layout-color0);
+}
+.jp-icon-hover :hover .jp-icon-accent1-hover[stroke] {
+  stroke: var(--jp-layout-color1);
+}
+.jp-icon-hover :hover .jp-icon-accent2-hover[stroke] {
+  stroke: var(--jp-layout-color2);
+}
+.jp-icon-hover :hover .jp-icon-accent3-hover[stroke] {
+  stroke: var(--jp-layout-color3);
+}
+.jp-icon-hover :hover .jp-icon-accent4-hover[stroke] {
+  stroke: var(--jp-layout-color4);
+}
+
+/* set the color of an icon to transparent */
+.jp-icon-hover :hover .jp-icon-none-hover[fill] {
+  fill: none;
+}
+
+.jp-icon-hover :hover .jp-icon-none-hover[stroke] {
+  stroke: none;
+}
+
+/**
+ * inverse colors
+ */
+
+/* inverse recolor the primary elements of an icon */
+.jp-icon-hover.jp-icon-alt :hover .jp-icon0-hover[fill] {
+  fill: var(--jp-layout-color0);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon1-hover[fill] {
+  fill: var(--jp-layout-color1);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon2-hover[fill] {
+  fill: var(--jp-layout-color2);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon3-hover[fill] {
+  fill: var(--jp-layout-color3);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon4-hover[fill] {
+  fill: var(--jp-layout-color4);
+}
+
+.jp-icon-hover.jp-icon-alt :hover .jp-icon0-hover[stroke] {
+  stroke: var(--jp-layout-color0);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon1-hover[stroke] {
+  stroke: var(--jp-layout-color1);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon2-hover[stroke] {
+  stroke: var(--jp-layout-color2);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon3-hover[stroke] {
+  stroke: var(--jp-layout-color3);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon4-hover[stroke] {
+  stroke: var(--jp-layout-color4);
+}
+
+/* inverse recolor the accent elements of an icon */
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent0-hover[fill] {
+  fill: var(--jp-inverse-layout-color0);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent1-hover[fill] {
+  fill: var(--jp-inverse-layout-color1);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent2-hover[fill] {
+  fill: var(--jp-inverse-layout-color2);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent3-hover[fill] {
+  fill: var(--jp-inverse-layout-color3);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent4-hover[fill] {
+  fill: var(--jp-inverse-layout-color4);
+}
+
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent0-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color0);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent1-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color1);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent2-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color2);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent3-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color3);
+}
+.jp-icon-hover.jp-icon-alt :hover .jp-icon-accent4-hover[stroke] {
+  stroke: var(--jp-inverse-layout-color4);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* Sibling imports */
+
+/* Override Blueprint's _reset.scss styles */
+html {
+  box-sizing: unset;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: unset;
+}
+
+body {
+  color: unset;
+  font-family: var(--jp-ui-font-family);
+}
+
+p {
+  margin-top: unset;
+  margin-bottom: unset;
+}
+
+small {
+  font-size: unset;
+}
+
+strong {
+  font-weight: unset;
+}
+
+/* Override Blueprint's _typography.scss styles */
+a {
+  text-decoration: unset;
+  color: unset;
+}
+a:hover {
+  text-decoration: unset;
+  color: unset;
+}
+
+/* Override Blueprint's _accessibility.scss styles */
+:focus {
+  outline: unset;
+  outline-offset: unset;
+  -moz-outline-radius: unset;
+}
+
+/* Styles for ui-components */
+.jp-Button {
+  border-radius: var(--jp-border-radius);
+  padding: 0px 12px;
+  font-size: var(--jp-ui-font-size1);
+}
+
+/* Use our own theme for hover styles */
+button.jp-Button.bp3-button.bp3-minimal:hover {
+  background-color: var(--jp-layout-color2);
+}
+.jp-Button.minimal {
+  color: unset !important;
+}
+
+.jp-Button.jp-ToolbarButtonComponent {
+  text-transform: none;
+}
+
+.jp-InputGroup input {
+  box-sizing: border-box;
+  border-radius: 0;
+  background-color: transparent;
+  color: var(--jp-ui-font-color0);
+  box-shadow: inset 0 0 0 var(--jp-border-width) var(--jp-input-border-color);
+}
+
+.jp-InputGroup input:focus {
+  box-shadow: inset 0 0 0 var(--jp-border-width)
+      var(--jp-input-active-box-shadow-color),
+    inset 0 0 0 3px var(--jp-input-active-box-shadow-color);
+}
+
+.jp-InputGroup input::placeholder,
+input::placeholder {
+  color: var(--jp-ui-font-color3);
+}
+
+.jp-BPIcon {
+  display: inline-block;
+  vertical-align: middle;
+  margin: auto;
+}
+
+/* Stop blueprint futzing with our icon fills */
+.bp3-icon.jp-BPIcon > svg:not([fill]) {
+  fill: var(--jp-inverse-layout-color3);
+}
+
+.jp-InputGroupAction {
+  padding: 6px;
+}
+
+.jp-HTMLSelect.jp-DefaultStyle select {
+  background-color: initial;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--jp-ui-font-color0);
+  display: block;
+  font-size: var(--jp-ui-font-size1);
+  height: 24px;
+  line-height: 14px;
+  padding: 0 25px 0 10px;
+  text-align: left;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+}
+
+/* Use our own theme for hover and option styles */
+.jp-HTMLSelect.jp-DefaultStyle select:hover,
+.jp-HTMLSelect.jp-DefaultStyle select > option {
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color0);
+}
+select {
+  box-sizing: border-box;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-Collapse {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  border-top: 1px solid var(--jp-border-color2);
+  border-bottom: 1px solid var(--jp-border-color2);
+}
+
+.jp-Collapse-header {
+  padding: 1px 12px;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
+  font-size: var(--jp-ui-font-size2);
+}
+
+.jp-Collapse-header:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.jp-Collapse-contents {
+  padding: 0px 12px 0px 12px;
+  background-color: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+  overflow: auto;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Variables
+|----------------------------------------------------------------------------*/
+
+:root {
+  --jp-private-commandpalette-search-height: 28px;
+}
+
+/*-----------------------------------------------------------------------------
+| Overall styles
+|----------------------------------------------------------------------------*/
+
+.lm-CommandPalette {
+  padding-bottom: 0px;
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color1);
+  /* This is needed so that all font sizing of children done in ems is
+   * relative to this base size */
+  font-size: var(--jp-ui-font-size1);
+}
+
+/*-----------------------------------------------------------------------------
+| Search
+|----------------------------------------------------------------------------*/
+
+.lm-CommandPalette-search {
+  padding: 4px;
+  background-color: var(--jp-layout-color1);
+  z-index: 2;
+}
+
+.lm-CommandPalette-wrapper {
+  overflow: overlay;
+  padding: 0px 9px;
+  background-color: var(--jp-input-active-background);
+  height: 30px;
+  box-shadow: inset 0 0 0 var(--jp-border-width) var(--jp-input-border-color);
+}
+
+.lm-CommandPalette.lm-mod-focused .lm-CommandPalette-wrapper {
+  box-shadow: inset 0 0 0 1px var(--jp-input-active-box-shadow-color),
+    inset 0 0 0 3px var(--jp-input-active-box-shadow-color);
+}
+
+.lm-CommandPalette-wrapper::after {
+  content: ' ';
+  color: white;
+  background-color: var(--jp-brand-color1);
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  height: 30px;
+  width: 10px;
+  padding: 0px 10px;
+  background-image: var(--jp-icon-search-white);
+  background-size: 20px;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.lm-CommandPalette-input {
+  background: transparent;
+  width: calc(100% - 18px);
+  float: left;
+  border: none;
+  outline: none;
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color0);
+  line-height: var(--jp-private-commandpalette-search-height);
+}
+
+.lm-CommandPalette-input::-webkit-input-placeholder,
+.lm-CommandPalette-input::-moz-placeholder,
+.lm-CommandPalette-input:-ms-input-placeholder {
+  color: var(--jp-ui-font-color3);
+  font-size: var(--jp-ui-font-size1);
+}
+
+/*-----------------------------------------------------------------------------
+| Results
+|----------------------------------------------------------------------------*/
+
+.lm-CommandPalette-header:first-child {
+  margin-top: 0px;
+}
+
+.lm-CommandPalette-header {
+  border-bottom: solid var(--jp-border-width) var(--jp-border-color2);
+  color: var(--jp-ui-font-color1);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--jp-ui-font-size0);
+  font-weight: 600;
+  letter-spacing: 1px;
+  margin-top: 8px;
+  padding: 8px 0 8px 12px;
+  text-transform: uppercase;
+}
+
+.lm-CommandPalette-header.lm-mod-active {
+  background: var(--jp-layout-color2);
+}
+
+.lm-CommandPalette-header > mark {
+  background-color: transparent;
+  font-weight: bold;
+  color: var(--jp-ui-font-color1);
+}
+
+.lm-CommandPalette-item {
+  padding: 4px 12px 4px 4px;
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  font-weight: 400;
+  display: flex;
+}
+
+.lm-CommandPalette-item.lm-mod-disabled {
+  color: var(--jp-ui-font-color3);
+}
+
+.lm-CommandPalette-item.lm-mod-active {
+  background: var(--jp-layout-color3);
+}
+
+.lm-CommandPalette-item.lm-mod-active:hover:not(.lm-mod-disabled) {
+  background: var(--jp-layout-color4);
+}
+
+.lm-CommandPalette-item:hover:not(.lm-mod-active):not(.lm-mod-disabled) {
+  background: var(--jp-layout-color2);
+}
+
+.lm-CommandPalette-itemContent {
+  overflow: hidden;
+}
+
+.lm-CommandPalette-itemLabel > mark {
+  color: var(--jp-ui-font-color0);
+  background-color: transparent;
+  font-weight: bold;
+}
+
+.lm-CommandPalette-item.lm-mod-disabled mark {
+  color: var(--jp-ui-font-color3);
+}
+
+.lm-CommandPalette-item .lm-CommandPalette-itemIcon {
+  margin: 0 4px 0 0;
+  position: relative;
+  width: 16px;
+  top: 2px;
+  flex: 0 0 auto;
+}
+
+.lm-CommandPalette-item.lm-mod-disabled .lm-CommandPalette-itemIcon {
+  opacity: 0.4;
+}
+
+.lm-CommandPalette-item .lm-CommandPalette-itemShortcut {
+  flex: 0 0 auto;
+}
+
+.lm-CommandPalette-itemCaption {
+  display: none;
+}
+
+.lm-CommandPalette-content {
+  background-color: var(--jp-layout-color1);
+}
+
+.lm-CommandPalette-content:empty:after {
+  content: 'No results';
+  margin: auto;
+  margin-top: 20px;
+  width: 100px;
+  display: block;
+  font-size: var(--jp-ui-font-size2);
+  font-family: var(--jp-ui-font-family);
+  font-weight: lighter;
+}
+
+.lm-CommandPalette-emptyMessage {
+  text-align: center;
+  margin-top: 24px;
+  line-height: 1.32;
+  padding: 0px 8px;
+  color: var(--jp-content-font-color3);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2017, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-Dialog {
+  position: absolute;
+  z-index: 10000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  top: 0px;
+  left: 0px;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--jp-dialog-background);
+}
+
+.jp-Dialog-content {
+  display: flex;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  background: var(--jp-layout-color1);
+  padding: 24px;
+  padding-bottom: 12px;
+  min-width: 300px;
+  min-height: 150px;
+  max-width: 1000px;
+  max-height: 500px;
+  box-sizing: border-box;
+  box-shadow: var(--jp-elevation-z20);
+  word-wrap: break-word;
+  border-radius: var(--jp-border-radius);
+  /* This is needed so that all font sizing of children done in ems is
+   * relative to this base size */
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color1);
+}
+
+.jp-Dialog-button {
+  overflow: visible;
+}
+
+button.jp-Dialog-button:focus {
+  outline: 1px solid var(--jp-brand-color1);
+  outline-offset: 4px;
+  -moz-outline-radius: 0px;
+}
+
+button.jp-Dialog-button:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.jp-Dialog-header {
+  flex: 0 0 auto;
+  padding-bottom: 12px;
+  font-size: var(--jp-ui-font-size3);
+  font-weight: 400;
+  color: var(--jp-ui-font-color0);
+}
+
+.jp-Dialog-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  font-size: var(--jp-ui-font-size1);
+  background: var(--jp-layout-color1);
+  overflow: auto;
+}
+
+.jp-Dialog-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  margin-left: -12px;
+  margin-right: -12px;
+  padding: 12px;
+}
+
+.jp-Dialog-title {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.jp-Dialog-body > .jp-select-wrapper {
+  width: 100%;
+}
+
+.jp-Dialog-body > button {
+  padding: 0px 16px;
+}
+
+.jp-Dialog-body > label {
+  line-height: 1.4;
+  color: var(--jp-ui-font-color0);
+}
+
+.jp-Dialog-button.jp-mod-styled:not(:last-child) {
+  margin-right: 12px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-HoverBox {
+  position: fixed;
+}
+
+.jp-HoverBox.jp-mod-outofview {
+  display: none;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-IFrame {
+  width: 100%;
+  height: 100%;
+}
+
+.jp-IFrame > iframe {
+  border: none;
+}
+
+/*
+When drag events occur, `p-mod-override-cursor` is added to the body.
+Because iframes steal all cursor events, the following two rules are necessary
+to suppress pointer events while resize drags are occurring. There may be a
+better solution to this problem.
+*/
+body.lm-mod-override-cursor .jp-IFrame {
+  position: relative;
+}
+
+body.lm-mod-override-cursor .jp-IFrame:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: transparent;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-MainAreaWidget > :focus {
+  outline: none;
+}
+
+/**
+ * google-material-color v1.2.6
+ * https://github.com/danlevan/google-material-color
+ */
+:root {
+  --md-red-50: #ffebee;
+  --md-red-100: #ffcdd2;
+  --md-red-200: #ef9a9a;
+  --md-red-300: #e57373;
+  --md-red-400: #ef5350;
+  --md-red-500: #f44336;
+  --md-red-600: #e53935;
+  --md-red-700: #d32f2f;
+  --md-red-800: #c62828;
+  --md-red-900: #b71c1c;
+  --md-red-A100: #ff8a80;
+  --md-red-A200: #ff5252;
+  --md-red-A400: #ff1744;
+  --md-red-A700: #d50000;
+
+  --md-pink-50: #fce4ec;
+  --md-pink-100: #f8bbd0;
+  --md-pink-200: #f48fb1;
+  --md-pink-300: #f06292;
+  --md-pink-400: #ec407a;
+  --md-pink-500: #e91e63;
+  --md-pink-600: #d81b60;
+  --md-pink-700: #c2185b;
+  --md-pink-800: #ad1457;
+  --md-pink-900: #880e4f;
+  --md-pink-A100: #ff80ab;
+  --md-pink-A200: #ff4081;
+  --md-pink-A400: #f50057;
+  --md-pink-A700: #c51162;
+
+  --md-purple-50: #f3e5f5;
+  --md-purple-100: #e1bee7;
+  --md-purple-200: #ce93d8;
+  --md-purple-300: #ba68c8;
+  --md-purple-400: #ab47bc;
+  --md-purple-500: #9c27b0;
+  --md-purple-600: #8e24aa;
+  --md-purple-700: #7b1fa2;
+  --md-purple-800: #6a1b9a;
+  --md-purple-900: #4a148c;
+  --md-purple-A100: #ea80fc;
+  --md-purple-A200: #e040fb;
+  --md-purple-A400: #d500f9;
+  --md-purple-A700: #aa00ff;
+
+  --md-deep-purple-50: #ede7f6;
+  --md-deep-purple-100: #d1c4e9;
+  --md-deep-purple-200: #b39ddb;
+  --md-deep-purple-300: #9575cd;
+  --md-deep-purple-400: #7e57c2;
+  --md-deep-purple-500: #673ab7;
+  --md-deep-purple-600: #5e35b1;
+  --md-deep-purple-700: #512da8;
+  --md-deep-purple-800: #4527a0;
+  --md-deep-purple-900: #311b92;
+  --md-deep-purple-A100: #b388ff;
+  --md-deep-purple-A200: #7c4dff;
+  --md-deep-purple-A400: #651fff;
+  --md-deep-purple-A700: #6200ea;
+
+  --md-indigo-50: #e8eaf6;
+  --md-indigo-100: #c5cae9;
+  --md-indigo-200: #9fa8da;
+  --md-indigo-300: #7986cb;
+  --md-indigo-400: #5c6bc0;
+  --md-indigo-500: #3f51b5;
+  --md-indigo-600: #3949ab;
+  --md-indigo-700: #303f9f;
+  --md-indigo-800: #283593;
+  --md-indigo-900: #1a237e;
+  --md-indigo-A100: #8c9eff;
+  --md-indigo-A200: #536dfe;
+  --md-indigo-A400: #3d5afe;
+  --md-indigo-A700: #304ffe;
+
+  --md-blue-50: #e3f2fd;
+  --md-blue-100: #bbdefb;
+  --md-blue-200: #90caf9;
+  --md-blue-300: #64b5f6;
+  --md-blue-400: #42a5f5;
+  --md-blue-500: #2196f3;
+  --md-blue-600: #1e88e5;
+  --md-blue-700: #1976d2;
+  --md-blue-800: #1565c0;
+  --md-blue-900: #0d47a1;
+  --md-blue-A100: #82b1ff;
+  --md-blue-A200: #448aff;
+  --md-blue-A400: #2979ff;
+  --md-blue-A700: #2962ff;
+
+  --md-light-blue-50: #e1f5fe;
+  --md-light-blue-100: #b3e5fc;
+  --md-light-blue-200: #81d4fa;
+  --md-light-blue-300: #4fc3f7;
+  --md-light-blue-400: #29b6f6;
+  --md-light-blue-500: #03a9f4;
+  --md-light-blue-600: #039be5;
+  --md-light-blue-700: #0288d1;
+  --md-light-blue-800: #0277bd;
+  --md-light-blue-900: #01579b;
+  --md-light-blue-A100: #80d8ff;
+  --md-light-blue-A200: #40c4ff;
+  --md-light-blue-A400: #00b0ff;
+  --md-light-blue-A700: #0091ea;
+
+  --md-cyan-50: #e0f7fa;
+  --md-cyan-100: #b2ebf2;
+  --md-cyan-200: #80deea;
+  --md-cyan-300: #4dd0e1;
+  --md-cyan-400: #26c6da;
+  --md-cyan-500: #00bcd4;
+  --md-cyan-600: #00acc1;
+  --md-cyan-700: #0097a7;
+  --md-cyan-800: #00838f;
+  --md-cyan-900: #006064;
+  --md-cyan-A100: #84ffff;
+  --md-cyan-A200: #18ffff;
+  --md-cyan-A400: #00e5ff;
+  --md-cyan-A700: #00b8d4;
+
+  --md-teal-50: #e0f2f1;
+  --md-teal-100: #b2dfdb;
+  --md-teal-200: #80cbc4;
+  --md-teal-300: #4db6ac;
+  --md-teal-400: #26a69a;
+  --md-teal-500: #009688;
+  --md-teal-600: #00897b;
+  --md-teal-700: #00796b;
+  --md-teal-800: #00695c;
+  --md-teal-900: #004d40;
+  --md-teal-A100: #a7ffeb;
+  --md-teal-A200: #64ffda;
+  --md-teal-A400: #1de9b6;
+  --md-teal-A700: #00bfa5;
+
+  --md-green-50: #e8f5e9;
+  --md-green-100: #c8e6c9;
+  --md-green-200: #a5d6a7;
+  --md-green-300: #81c784;
+  --md-green-400: #66bb6a;
+  --md-green-500: #4caf50;
+  --md-green-600: #43a047;
+  --md-green-700: #388e3c;
+  --md-green-800: #2e7d32;
+  --md-green-900: #1b5e20;
+  --md-green-A100: #b9f6ca;
+  --md-green-A200: #69f0ae;
+  --md-green-A400: #00e676;
+  --md-green-A700: #00c853;
+
+  --md-light-green-50: #f1f8e9;
+  --md-light-green-100: #dcedc8;
+  --md-light-green-200: #c5e1a5;
+  --md-light-green-300: #aed581;
+  --md-light-green-400: #9ccc65;
+  --md-light-green-500: #8bc34a;
+  --md-light-green-600: #7cb342;
+  --md-light-green-700: #689f38;
+  --md-light-green-800: #558b2f;
+  --md-light-green-900: #33691e;
+  --md-light-green-A100: #ccff90;
+  --md-light-green-A200: #b2ff59;
+  --md-light-green-A400: #76ff03;
+  --md-light-green-A700: #64dd17;
+
+  --md-lime-50: #f9fbe7;
+  --md-lime-100: #f0f4c3;
+  --md-lime-200: #e6ee9c;
+  --md-lime-300: #dce775;
+  --md-lime-400: #d4e157;
+  --md-lime-500: #cddc39;
+  --md-lime-600: #c0ca33;
+  --md-lime-700: #afb42b;
+  --md-lime-800: #9e9d24;
+  --md-lime-900: #827717;
+  --md-lime-A100: #f4ff81;
+  --md-lime-A200: #eeff41;
+  --md-lime-A400: #c6ff00;
+  --md-lime-A700: #aeea00;
+
+  --md-yellow-50: #fffde7;
+  --md-yellow-100: #fff9c4;
+  --md-yellow-200: #fff59d;
+  --md-yellow-300: #fff176;
+  --md-yellow-400: #ffee58;
+  --md-yellow-500: #ffeb3b;
+  --md-yellow-600: #fdd835;
+  --md-yellow-700: #fbc02d;
+  --md-yellow-800: #f9a825;
+  --md-yellow-900: #f57f17;
+  --md-yellow-A100: #ffff8d;
+  --md-yellow-A200: #ffff00;
+  --md-yellow-A400: #ffea00;
+  --md-yellow-A700: #ffd600;
+
+  --md-amber-50: #fff8e1;
+  --md-amber-100: #ffecb3;
+  --md-amber-200: #ffe082;
+  --md-amber-300: #ffd54f;
+  --md-amber-400: #ffca28;
+  --md-amber-500: #ffc107;
+  --md-amber-600: #ffb300;
+  --md-amber-700: #ffa000;
+  --md-amber-800: #ff8f00;
+  --md-amber-900: #ff6f00;
+  --md-amber-A100: #ffe57f;
+  --md-amber-A200: #ffd740;
+  --md-amber-A400: #ffc400;
+  --md-amber-A700: #ffab00;
+
+  --md-orange-50: #fff3e0;
+  --md-orange-100: #ffe0b2;
+  --md-orange-200: #ffcc80;
+  --md-orange-300: #ffb74d;
+  --md-orange-400: #ffa726;
+  --md-orange-500: #ff9800;
+  --md-orange-600: #fb8c00;
+  --md-orange-700: #f57c00;
+  --md-orange-800: #ef6c00;
+  --md-orange-900: #e65100;
+  --md-orange-A100: #ffd180;
+  --md-orange-A200: #ffab40;
+  --md-orange-A400: #ff9100;
+  --md-orange-A700: #ff6d00;
+
+  --md-deep-orange-50: #fbe9e7;
+  --md-deep-orange-100: #ffccbc;
+  --md-deep-orange-200: #ffab91;
+  --md-deep-orange-300: #ff8a65;
+  --md-deep-orange-400: #ff7043;
+  --md-deep-orange-500: #ff5722;
+  --md-deep-orange-600: #f4511e;
+  --md-deep-orange-700: #e64a19;
+  --md-deep-orange-800: #d84315;
+  --md-deep-orange-900: #bf360c;
+  --md-deep-orange-A100: #ff9e80;
+  --md-deep-orange-A200: #ff6e40;
+  --md-deep-orange-A400: #ff3d00;
+  --md-deep-orange-A700: #dd2c00;
+
+  --md-brown-50: #efebe9;
+  --md-brown-100: #d7ccc8;
+  --md-brown-200: #bcaaa4;
+  --md-brown-300: #a1887f;
+  --md-brown-400: #8d6e63;
+  --md-brown-500: #795548;
+  --md-brown-600: #6d4c41;
+  --md-brown-700: #5d4037;
+  --md-brown-800: #4e342e;
+  --md-brown-900: #3e2723;
+
+  --md-grey-50: #fafafa;
+  --md-grey-100: #f5f5f5;
+  --md-grey-200: #eeeeee;
+  --md-grey-300: #e0e0e0;
+  --md-grey-400: #bdbdbd;
+  --md-grey-500: #9e9e9e;
+  --md-grey-600: #757575;
+  --md-grey-700: #616161;
+  --md-grey-800: #424242;
+  --md-grey-900: #212121;
+
+  --md-blue-grey-50: #eceff1;
+  --md-blue-grey-100: #cfd8dc;
+  --md-blue-grey-200: #b0bec5;
+  --md-blue-grey-300: #90a4ae;
+  --md-blue-grey-400: #78909c;
+  --md-blue-grey-500: #607d8b;
+  --md-blue-grey-600: #546e7a;
+  --md-blue-grey-700: #455a64;
+  --md-blue-grey-800: #37474f;
+  --md-blue-grey-900: #263238;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2017, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-Spinner {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--jp-layout-color0);
+  outline: none;
+}
+
+.jp-SpinnerContent {
+  font-size: 10px;
+  margin: 50px auto;
+  text-indent: -9999em;
+  width: 3em;
+  height: 3em;
+  border-radius: 50%;
+  background: var(--jp-brand-color3);
+  background: linear-gradient(
+    to right,
+    #f37626 10%,
+    rgba(255, 255, 255, 0) 42%
+  );
+  position: relative;
+  animation: load3 1s infinite linear, fadeIn 1s;
+}
+
+.jp-SpinnerContent:before {
+  width: 50%;
+  height: 50%;
+  background: #f37626;
+  border-radius: 100% 0 0 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  content: '';
+}
+
+.jp-SpinnerContent:after {
+  background: var(--jp-layout-color0);
+  width: 75%;
+  height: 75%;
+  border-radius: 50%;
+  content: '';
+  margin: auto;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes load3 {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2017, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+button.jp-mod-styled {
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color0);
+  border: none;
+  box-sizing: border-box;
+  text-align: center;
+  line-height: 32px;
+  height: 32px;
+  padding: 0px 12px;
+  letter-spacing: 0.8px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+input.jp-mod-styled {
+  background: var(--jp-input-background);
+  height: 28px;
+  box-sizing: border-box;
+  border: var(--jp-border-width) solid var(--jp-border-color1);
+  padding-left: 7px;
+  padding-right: 7px;
+  font-size: var(--jp-ui-font-size2);
+  color: var(--jp-ui-font-color0);
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+input.jp-mod-styled:focus {
+  border: var(--jp-border-width) solid var(--md-blue-500);
+  box-shadow: inset 0 0 4px var(--md-blue-300);
+}
+
+.jp-select-wrapper {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  padding: 1px;
+  background-color: var(--jp-layout-color1);
+  height: 28px;
+  box-sizing: border-box;
+  margin-bottom: 12px;
+}
+
+.jp-select-wrapper.jp-mod-focused select.jp-mod-styled {
+  border: var(--jp-border-width) solid var(--jp-input-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
+  background-color: var(--jp-input-active-background);
+}
+
+select.jp-mod-styled:hover {
+  background-color: var(--jp-layout-color1);
+  cursor: pointer;
+  color: var(--jp-ui-font-color0);
+  background-color: var(--jp-input-hover-background);
+  box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
+}
+
+select.jp-mod-styled {
+  flex: 1 1 auto;
+  height: 32px;
+  width: 100%;
+  font-size: var(--jp-ui-font-size2);
+  background: var(--jp-input-background);
+  color: var(--jp-ui-font-color0);
+  padding: 0 25px 0 8px;
+  border: var(--jp-border-width) solid var(--jp-input-border-color);
+  border-radius: 0px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+:root {
+  --jp-private-toolbar-height: calc(
+    28px + var(--jp-border-width)
+  ); /* leave 28px for content */
+}
+
+.jp-Toolbar {
+  color: var(--jp-ui-font-color1);
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: row;
+  border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  background: var(--jp-toolbar-background);
+  min-height: var(--jp-toolbar-micro-height);
+  padding: 2px;
+  z-index: 1;
+}
+
+/* Toolbar items */
+
+.jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-spacer {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.jp-Toolbar-item.jp-Toolbar-kernelStatus {
+  display: inline-block;
+  width: 32px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px;
+}
+
+.jp-Toolbar > .jp-Toolbar-item {
+  flex: 0 0 auto;
+  display: flex;
+  padding-left: 1px;
+  padding-right: 1px;
+  font-size: var(--jp-ui-font-size1);
+  line-height: var(--jp-private-toolbar-height);
+  height: 100%;
+}
+
+/* Toolbar buttons */
+
+/* This is the div we use to wrap the react component into a Widget */
+div.jp-ToolbarButton {
+  color: transparent;
+  border: none;
+  box-sizing: border-box;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 0px;
+  margin: 0px;
+}
+
+button.jp-ToolbarButtonComponent {
+  background: var(--jp-layout-color1);
+  border: none;
+  box-sizing: border-box;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 0px 6px;
+  margin: 0px;
+  height: 24px;
+  border-radius: var(--jp-border-radius);
+  display: flex;
+  align-items: center;
+  text-align: center;
+  font-size: 14px;
+  min-width: unset;
+  min-height: unset;
+}
+
+button.jp-ToolbarButtonComponent:disabled {
+  opacity: 0.4;
+}
+
+button.jp-ToolbarButtonComponent span {
+  padding: 0px;
+  flex: 0 0 auto;
+}
+
+button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
+  font-size: var(--jp-ui-font-size1);
+  line-height: 100%;
+  padding-left: 2px;
+  color: var(--jp-ui-font-color1);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2017, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+
+/* <DEPRECATED> */ body.p-mod-override-cursor *, /* </DEPRECATED> */
+body.lm-mod-override-cursor * {
+  cursor: inherit !important;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-JSONEditor {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.jp-JSONEditor-host {
+  flex: 1 1 auto;
+  border: var(--jp-border-width) solid var(--jp-input-border-color);
+  border-radius: 0px;
+  background: var(--jp-layout-color0);
+  min-height: 50px;
+  padding: 1px;
+}
+
+.jp-JSONEditor.jp-mod-error .jp-JSONEditor-host {
+  border-color: red;
+  outline-color: red;
+}
+
+.jp-JSONEditor-header {
+  display: flex;
+  flex: 1 0 auto;
+  padding: 0 0 0 12px;
+}
+
+.jp-JSONEditor-header label {
+  flex: 0 0 auto;
+}
+
+.jp-JSONEditor-commitButton {
+  height: 16px;
+  width: 16px;
+  background-size: 18px;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.jp-JSONEditor-host.jp-mod-focused {
+  background-color: var(--jp-input-active-background);
+  border: 1px solid var(--jp-input-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
+}
+
+.jp-Editor.jp-mod-dropTarget {
+  border: var(--jp-border-width) solid var(--jp-input-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* BASICS */
+
+.CodeMirror {
+  /* Set height, width, borders, and global font properties here */
+  font-family: monospace;
+  height: 300px;
+  color: black;
+  direction: ltr;
+}
+
+/* PADDING */
+
+.CodeMirror-lines {
+  padding: 4px 0; /* Vertical padding around content */
+}
+.CodeMirror pre.CodeMirror-line,
+.CodeMirror pre.CodeMirror-line-like {
+  padding: 0 4px; /* Horizontal padding of content */
+}
+
+.CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+  background-color: white; /* The little square between H and V scrollbars */
+}
+
+/* GUTTER */
+
+.CodeMirror-gutters {
+  border-right: 1px solid #ddd;
+  background-color: #f7f7f7;
+  white-space: nowrap;
+}
+.CodeMirror-linenumbers {}
+.CodeMirror-linenumber {
+  padding: 0 3px 0 5px;
+  min-width: 20px;
+  text-align: right;
+  color: #999;
+  white-space: nowrap;
+}
+
+.CodeMirror-guttermarker { color: black; }
+.CodeMirror-guttermarker-subtle { color: #999; }
+
+/* CURSOR */
+
+.CodeMirror-cursor {
+  border-left: 1px solid black;
+  border-right: none;
+  width: 0;
+}
+/* Shown when moving in bi-directional text */
+.CodeMirror div.CodeMirror-secondarycursor {
+  border-left: 1px solid silver;
+}
+.cm-fat-cursor .CodeMirror-cursor {
+  width: auto;
+  border: 0 !important;
+  background: #7e7;
+}
+.cm-fat-cursor div.CodeMirror-cursors {
+  z-index: 1;
+}
+.cm-fat-cursor-mark {
+  background-color: rgba(20, 255, 20, 0.5);
+  -webkit-animation: blink 1.06s steps(1) infinite;
+  -moz-animation: blink 1.06s steps(1) infinite;
+  animation: blink 1.06s steps(1) infinite;
+}
+.cm-animate-fat-cursor {
+  width: auto;
+  border: 0;
+  -webkit-animation: blink 1.06s steps(1) infinite;
+  -moz-animation: blink 1.06s steps(1) infinite;
+  animation: blink 1.06s steps(1) infinite;
+  background-color: #7e7;
+}
+@-moz-keyframes blink {
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
+}
+@-webkit-keyframes blink {
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
+}
+@keyframes blink {
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
+}
+
+/* Can style cursor different in overwrite (non-insert) mode */
+.CodeMirror-overwrite .CodeMirror-cursor {}
+
+.cm-tab { display: inline-block; text-decoration: inherit; }
+
+.CodeMirror-rulers {
+  position: absolute;
+  left: 0; right: 0; top: -50px; bottom: 0;
+  overflow: hidden;
+}
+.CodeMirror-ruler {
+  border-left: 1px solid #ccc;
+  top: 0; bottom: 0;
+  position: absolute;
+}
+
+/* DEFAULT THEME */
+
+.cm-s-default .cm-header {color: blue;}
+.cm-s-default .cm-quote {color: #090;}
+.cm-negative {color: #d44;}
+.cm-positive {color: #292;}
+.cm-header, .cm-strong {font-weight: bold;}
+.cm-em {font-style: italic;}
+.cm-link {text-decoration: underline;}
+.cm-strikethrough {text-decoration: line-through;}
+
+.cm-s-default .cm-keyword {color: #708;}
+.cm-s-default .cm-atom {color: #219;}
+.cm-s-default .cm-number {color: #164;}
+.cm-s-default .cm-def {color: #00f;}
+.cm-s-default .cm-variable,
+.cm-s-default .cm-punctuation,
+.cm-s-default .cm-property,
+.cm-s-default .cm-operator {}
+.cm-s-default .cm-variable-2 {color: #05a;}
+.cm-s-default .cm-variable-3, .cm-s-default .cm-type {color: #085;}
+.cm-s-default .cm-comment {color: #a50;}
+.cm-s-default .cm-string {color: #a11;}
+.cm-s-default .cm-string-2 {color: #f50;}
+.cm-s-default .cm-meta {color: #555;}
+.cm-s-default .cm-qualifier {color: #555;}
+.cm-s-default .cm-builtin {color: #30a;}
+.cm-s-default .cm-bracket {color: #997;}
+.cm-s-default .cm-tag {color: #170;}
+.cm-s-default .cm-attribute {color: #00c;}
+.cm-s-default .cm-hr {color: #999;}
+.cm-s-default .cm-link {color: #00c;}
+
+.cm-s-default .cm-error {color: #f00;}
+.cm-invalidchar {color: #f00;}
+
+.CodeMirror-composing { border-bottom: 2px solid; }
+
+/* Default styles for common addons */
+
+div.CodeMirror span.CodeMirror-matchingbracket {color: #0b0;}
+div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
+.CodeMirror-matchingtag { background: rgba(255, 150, 0, .3); }
+.CodeMirror-activeline-background {background: #e8f2ff;}
+
+/* STOP */
+
+/* The rest of this file contains styles related to the mechanics of
+   the editor. You probably shouldn't touch them. */
+
+.CodeMirror {
+  position: relative;
+  overflow: hidden;
+  background: white;
+}
+
+.CodeMirror-scroll {
+  overflow: scroll !important; /* Things will break if this is overridden */
+  /* 30px is the magic margin used to hide the element's real scrollbars */
+  /* See overflow: hidden in .CodeMirror */
+  margin-bottom: -30px; margin-right: -30px;
+  padding-bottom: 30px;
+  height: 100%;
+  outline: none; /* Prevent dragging from highlighting the element */
+  position: relative;
+}
+.CodeMirror-sizer {
+  position: relative;
+  border-right: 30px solid transparent;
+}
+
+/* The fake, visible scrollbars. Used to force redraw during scrolling
+   before actual scrolling happens, thus preventing shaking and
+   flickering artifacts. */
+.CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+  position: absolute;
+  z-index: 6;
+  display: none;
+}
+.CodeMirror-vscrollbar {
+  right: 0; top: 0;
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+.CodeMirror-hscrollbar {
+  bottom: 0; left: 0;
+  overflow-y: hidden;
+  overflow-x: scroll;
+}
+.CodeMirror-scrollbar-filler {
+  right: 0; bottom: 0;
+}
+.CodeMirror-gutter-filler {
+  left: 0; bottom: 0;
+}
+
+.CodeMirror-gutters {
+  position: absolute; left: 0; top: 0;
+  min-height: 100%;
+  z-index: 3;
+}
+.CodeMirror-gutter {
+  white-space: normal;
+  height: 100%;
+  display: inline-block;
+  vertical-align: top;
+  margin-bottom: -30px;
+}
+.CodeMirror-gutter-wrapper {
+  position: absolute;
+  z-index: 4;
+  background: none !important;
+  border: none !important;
+}
+.CodeMirror-gutter-background {
+  position: absolute;
+  top: 0; bottom: 0;
+  z-index: 4;
+}
+.CodeMirror-gutter-elt {
+  position: absolute;
+  cursor: default;
+  z-index: 4;
+}
+.CodeMirror-gutter-wrapper ::selection { background-color: transparent }
+.CodeMirror-gutter-wrapper ::-moz-selection { background-color: transparent }
+
+.CodeMirror-lines {
+  cursor: text;
+  min-height: 1px; /* prevents collapsing before first draw */
+}
+.CodeMirror pre.CodeMirror-line,
+.CodeMirror pre.CodeMirror-line-like {
+  /* Reset some styles that the rest of the page might have set */
+  -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
+  border-width: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: inherit;
+  margin: 0;
+  white-space: pre;
+  word-wrap: normal;
+  line-height: inherit;
+  color: inherit;
+  z-index: 2;
+  position: relative;
+  overflow: visible;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-font-variant-ligatures: contextual;
+  font-variant-ligatures: contextual;
+}
+.CodeMirror-wrap pre.CodeMirror-line,
+.CodeMirror-wrap pre.CodeMirror-line-like {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: normal;
+}
+
+.CodeMirror-linebackground {
+  position: absolute;
+  left: 0; right: 0; top: 0; bottom: 0;
+  z-index: 0;
+}
+
+.CodeMirror-linewidget {
+  position: relative;
+  z-index: 2;
+  padding: 0.1px; /* Force widget margins to stay inside of the container */
+}
+
+.CodeMirror-widget {}
+
+.CodeMirror-rtl pre { direction: rtl; }
+
+.CodeMirror-code {
+  outline: none;
+}
+
+/* Force content-box sizing for the elements where we expect it */
+.CodeMirror-scroll,
+.CodeMirror-sizer,
+.CodeMirror-gutter,
+.CodeMirror-gutters,
+.CodeMirror-linenumber {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+}
+
+.CodeMirror-measure {
+  position: absolute;
+  width: 100%;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.CodeMirror-cursor {
+  position: absolute;
+  pointer-events: none;
+}
+.CodeMirror-measure pre { position: static; }
+
+div.CodeMirror-cursors {
+  visibility: hidden;
+  position: relative;
+  z-index: 3;
+}
+div.CodeMirror-dragcursors {
+  visibility: visible;
+}
+
+.CodeMirror-focused div.CodeMirror-cursors {
+  visibility: visible;
+}
+
+.CodeMirror-selected { background: #d9d9d9; }
+.CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
+.CodeMirror-crosshair { cursor: crosshair; }
+.CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #d7d4f0; }
+.CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #d7d4f0; }
+
+.cm-searching {
+  background-color: #ffa;
+  background-color: rgba(255, 255, 0, .4);
+}
+
+/* Used to force a border model for a node */
+.cm-force-border { padding-right: .1px; }
+
+@media print {
+  /* Hide the cursor when printing */
+  .CodeMirror div.CodeMirror-cursors {
+    visibility: hidden;
+  }
+}
+
+/* See issue #2901 */
+.cm-tab-wrap-hack:after { content: ''; }
+
+/* Help users use markselection to safely style text background */
+span.CodeMirror-selectedtext { background: none; }
+
+.CodeMirror-dialog {
+  position: absolute;
+  left: 0; right: 0;
+  background: inherit;
+  z-index: 15;
+  padding: .1em .8em;
+  overflow: hidden;
+  color: inherit;
+}
+
+.CodeMirror-dialog-top {
+  border-bottom: 1px solid #eee;
+  top: 0;
+}
+
+.CodeMirror-dialog-bottom {
+  border-top: 1px solid #eee;
+  bottom: 0;
+}
+
+.CodeMirror-dialog input {
+  border: none;
+  outline: none;
+  background: transparent;
+  width: 20em;
+  color: inherit;
+  font-family: monospace;
+}
+
+.CodeMirror-dialog button {
+  font-size: 70%;
+}
+
+.CodeMirror-foldmarker {
+  color: blue;
+  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
+  font-family: arial;
+  line-height: .3;
+  cursor: pointer;
+}
+.CodeMirror-foldgutter {
+  width: .7em;
+}
+.CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded {
+  cursor: pointer;
+}
+.CodeMirror-foldgutter-open:after {
+  content: "\25BE";
+}
+.CodeMirror-foldgutter-folded:after {
+  content: "\25B8";
+}
+
+/*
+  Name:       material
+  Author:     Mattia Astorino (http://github.com/equinusocio)
+  Website:    https://material-theme.site/
+*/
+
+.cm-s-material.CodeMirror {
+  background-color: #263238;
+  color: #EEFFFF;
+}
+
+.cm-s-material .CodeMirror-gutters {
+  background: #263238;
+  color: #546E7A;
+  border: none;
+}
+
+.cm-s-material .CodeMirror-guttermarker,
+.cm-s-material .CodeMirror-guttermarker-subtle,
+.cm-s-material .CodeMirror-linenumber {
+  color: #546E7A;
+}
+
+.cm-s-material .CodeMirror-cursor {
+  border-left: 1px solid #FFCC00;
+}
+
+.cm-s-material div.CodeMirror-selected {
+  background: rgba(128, 203, 196, 0.2);
+}
+
+.cm-s-material.CodeMirror-focused div.CodeMirror-selected {
+  background: rgba(128, 203, 196, 0.2);
+}
+
+.cm-s-material .CodeMirror-line::selection,
+.cm-s-material .CodeMirror-line>span::selection,
+.cm-s-material .CodeMirror-line>span>span::selection {
+  background: rgba(128, 203, 196, 0.2);
+}
+
+.cm-s-material .CodeMirror-line::-moz-selection,
+.cm-s-material .CodeMirror-line>span::-moz-selection,
+.cm-s-material .CodeMirror-line>span>span::-moz-selection {
+  background: rgba(128, 203, 196, 0.2);
+}
+
+.cm-s-material .CodeMirror-activeline-background {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.cm-s-material .cm-keyword {
+  color: #C792EA;
+}
+
+.cm-s-material .cm-operator {
+  color: #89DDFF;
+}
+
+.cm-s-material .cm-variable-2 {
+  color: #EEFFFF;
+}
+
+.cm-s-material .cm-variable-3,
+.cm-s-material .cm-type {
+  color: #f07178;
+}
+
+.cm-s-material .cm-builtin {
+  color: #FFCB6B;
+}
+
+.cm-s-material .cm-atom {
+  color: #F78C6C;
+}
+
+.cm-s-material .cm-number {
+  color: #FF5370;
+}
+
+.cm-s-material .cm-def {
+  color: #82AAFF;
+}
+
+.cm-s-material .cm-string {
+  color: #C3E88D;
+}
+
+.cm-s-material .cm-string-2 {
+  color: #f07178;
+}
+
+.cm-s-material .cm-comment {
+  color: #546E7A;
+}
+
+.cm-s-material .cm-variable {
+  color: #f07178;
+}
+
+.cm-s-material .cm-tag {
+  color: #FF5370;
+}
+
+.cm-s-material .cm-meta {
+  color: #FFCB6B;
+}
+
+.cm-s-material .cm-attribute {
+  color: #C792EA;
+}
+
+.cm-s-material .cm-property {
+  color: #C792EA;
+}
+
+.cm-s-material .cm-qualifier {
+  color: #DECB6B;
+}
+
+.cm-s-material .cm-variable-3,
+.cm-s-material .cm-type {
+  color: #DECB6B;
+}
+
+
+.cm-s-material .cm-error {
+  color: rgba(255, 255, 255, 1.0);
+  background-color: #FF5370;
+}
+
+.cm-s-material .CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
+}
+/**
+ * "
+ *  Using Zenburn color palette from the Emacs Zenburn Theme
+ *  https://github.com/bbatsov/zenburn-emacs/blob/master/zenburn-theme.el
+ *
+ *  Also using parts of https://github.com/xavi/coderay-lighttable-theme
+ * "
+ * From: https://github.com/wisenomad/zenburn-lighttable-theme/blob/master/zenburn.css
+ */
+
+.cm-s-zenburn .CodeMirror-gutters { background: #3f3f3f !important; }
+.cm-s-zenburn .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: #999; }
+.cm-s-zenburn .CodeMirror-cursor { border-left: 1px solid white; }
+.cm-s-zenburn { background-color: #3f3f3f; color: #dcdccc; }
+.cm-s-zenburn span.cm-builtin { color: #dcdccc; font-weight: bold; }
+.cm-s-zenburn span.cm-comment { color: #7f9f7f; }
+.cm-s-zenburn span.cm-keyword { color: #f0dfaf; font-weight: bold; }
+.cm-s-zenburn span.cm-atom { color: #bfebbf; }
+.cm-s-zenburn span.cm-def { color: #dcdccc; }
+.cm-s-zenburn span.cm-variable { color: #dfaf8f; }
+.cm-s-zenburn span.cm-variable-2 { color: #dcdccc; }
+.cm-s-zenburn span.cm-string { color: #cc9393; }
+.cm-s-zenburn span.cm-string-2 { color: #cc9393; }
+.cm-s-zenburn span.cm-number { color: #dcdccc; }
+.cm-s-zenburn span.cm-tag { color: #93e0e3; }
+.cm-s-zenburn span.cm-property { color: #dfaf8f; }
+.cm-s-zenburn span.cm-attribute { color: #dfaf8f; }
+.cm-s-zenburn span.cm-qualifier { color: #7cb8bb; }
+.cm-s-zenburn span.cm-meta { color: #f0dfaf; }
+.cm-s-zenburn span.cm-header { color: #f0efd0; }
+.cm-s-zenburn span.cm-operator { color: #f0efd0; }
+.cm-s-zenburn span.CodeMirror-matchingbracket { box-sizing: border-box; background: transparent; border-bottom: 1px solid; }
+.cm-s-zenburn span.CodeMirror-nonmatchingbracket { border-bottom: 1px solid; background: none; }
+.cm-s-zenburn .CodeMirror-activeline { background: #000000; }
+.cm-s-zenburn .CodeMirror-activeline-background { background: #000000; }
+.cm-s-zenburn div.CodeMirror-selected { background: #545454; }
+.cm-s-zenburn .CodeMirror-focused div.CodeMirror-selected { background: #4f4f4f; }
+
+.cm-s-abcdef.CodeMirror { background: #0f0f0f; color: #defdef; }
+.cm-s-abcdef div.CodeMirror-selected { background: #515151; }
+.cm-s-abcdef .CodeMirror-line::selection, .cm-s-abcdef .CodeMirror-line > span::selection, .cm-s-abcdef .CodeMirror-line > span > span::selection { background: rgba(56, 56, 56, 0.99); }
+.cm-s-abcdef .CodeMirror-line::-moz-selection, .cm-s-abcdef .CodeMirror-line > span::-moz-selection, .cm-s-abcdef .CodeMirror-line > span > span::-moz-selection { background: rgba(56, 56, 56, 0.99); }
+.cm-s-abcdef .CodeMirror-gutters { background: #555; border-right: 2px solid #314151; }
+.cm-s-abcdef .CodeMirror-guttermarker { color: #222; }
+.cm-s-abcdef .CodeMirror-guttermarker-subtle { color: azure; }
+.cm-s-abcdef .CodeMirror-linenumber { color: #FFFFFF; }
+.cm-s-abcdef .CodeMirror-cursor { border-left: 1px solid #00FF00; }
+
+.cm-s-abcdef span.cm-keyword { color: darkgoldenrod; font-weight: bold; }
+.cm-s-abcdef span.cm-atom { color: #77F; }
+.cm-s-abcdef span.cm-number { color: violet; }
+.cm-s-abcdef span.cm-def { color: #fffabc; }
+.cm-s-abcdef span.cm-variable { color: #abcdef; }
+.cm-s-abcdef span.cm-variable-2 { color: #cacbcc; }
+.cm-s-abcdef span.cm-variable-3, .cm-s-abcdef span.cm-type { color: #def; }
+.cm-s-abcdef span.cm-property { color: #fedcba; }
+.cm-s-abcdef span.cm-operator { color: #ff0; }
+.cm-s-abcdef span.cm-comment { color: #7a7b7c; font-style: italic;}
+.cm-s-abcdef span.cm-string { color: #2b4; }
+.cm-s-abcdef span.cm-meta { color: #C9F; }
+.cm-s-abcdef span.cm-qualifier { color: #FFF700; }
+.cm-s-abcdef span.cm-builtin { color: #30aabc; }
+.cm-s-abcdef span.cm-bracket { color: #8a8a8a; }
+.cm-s-abcdef span.cm-tag { color: #FFDD44; }
+.cm-s-abcdef span.cm-attribute { color: #DDFF00; }
+.cm-s-abcdef span.cm-error { color: #FF0000; }
+.cm-s-abcdef span.cm-header { color: aquamarine; font-weight: bold; }
+.cm-s-abcdef span.cm-link { color: blueviolet; }
+
+.cm-s-abcdef .CodeMirror-activeline-background { background: #314151; }
+
+/*
+
+    Name:       Base16 Default Light
+    Author:     Chris Kempson (http://chriskempson.com)
+
+    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
+    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+
+*/
+
+.cm-s-base16-light.CodeMirror { background: #f5f5f5; color: #202020; }
+.cm-s-base16-light div.CodeMirror-selected { background: #e0e0e0; }
+.cm-s-base16-light .CodeMirror-line::selection, .cm-s-base16-light .CodeMirror-line > span::selection, .cm-s-base16-light .CodeMirror-line > span > span::selection { background: #e0e0e0; }
+.cm-s-base16-light .CodeMirror-line::-moz-selection, .cm-s-base16-light .CodeMirror-line > span::-moz-selection, .cm-s-base16-light .CodeMirror-line > span > span::-moz-selection { background: #e0e0e0; }
+.cm-s-base16-light .CodeMirror-gutters { background: #f5f5f5; border-right: 0px; }
+.cm-s-base16-light .CodeMirror-guttermarker { color: #ac4142; }
+.cm-s-base16-light .CodeMirror-guttermarker-subtle { color: #b0b0b0; }
+.cm-s-base16-light .CodeMirror-linenumber { color: #b0b0b0; }
+.cm-s-base16-light .CodeMirror-cursor { border-left: 1px solid #505050; }
+
+.cm-s-base16-light span.cm-comment { color: #8f5536; }
+.cm-s-base16-light span.cm-atom { color: #aa759f; }
+.cm-s-base16-light span.cm-number { color: #aa759f; }
+
+.cm-s-base16-light span.cm-property, .cm-s-base16-light span.cm-attribute { color: #90a959; }
+.cm-s-base16-light span.cm-keyword { color: #ac4142; }
+.cm-s-base16-light span.cm-string { color: #f4bf75; }
+
+.cm-s-base16-light span.cm-variable { color: #90a959; }
+.cm-s-base16-light span.cm-variable-2 { color: #6a9fb5; }
+.cm-s-base16-light span.cm-def { color: #d28445; }
+.cm-s-base16-light span.cm-bracket { color: #202020; }
+.cm-s-base16-light span.cm-tag { color: #ac4142; }
+.cm-s-base16-light span.cm-link { color: #aa759f; }
+.cm-s-base16-light span.cm-error { background: #ac4142; color: #505050; }
+
+.cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC; }
+.cm-s-base16-light .CodeMirror-matchingbracket { color: #f5f5f5 !important; background-color: #6A9FB5 !important}
+
+/*
+
+    Name:       Base16 Default Dark
+    Author:     Chris Kempson (http://chriskempson.com)
+
+    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
+    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+
+*/
+
+.cm-s-base16-dark.CodeMirror { background: #151515; color: #e0e0e0; }
+.cm-s-base16-dark div.CodeMirror-selected { background: #303030; }
+.cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
+.cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
+.cm-s-base16-dark .CodeMirror-gutters { background: #151515; border-right: 0px; }
+.cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
+.cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
+.cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
+.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0; }
+
+.cm-s-base16-dark span.cm-comment { color: #8f5536; }
+.cm-s-base16-dark span.cm-atom { color: #aa759f; }
+.cm-s-base16-dark span.cm-number { color: #aa759f; }
+
+.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute { color: #90a959; }
+.cm-s-base16-dark span.cm-keyword { color: #ac4142; }
+.cm-s-base16-dark span.cm-string { color: #f4bf75; }
+
+.cm-s-base16-dark span.cm-variable { color: #90a959; }
+.cm-s-base16-dark span.cm-variable-2 { color: #6a9fb5; }
+.cm-s-base16-dark span.cm-def { color: #d28445; }
+.cm-s-base16-dark span.cm-bracket { color: #e0e0e0; }
+.cm-s-base16-dark span.cm-tag { color: #ac4142; }
+.cm-s-base16-dark span.cm-link { color: #aa759f; }
+.cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
+
+.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
+.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+
+/*
+
+    Name:       dracula
+    Author:     Michael Kaminsky (http://github.com/mkaminsky11)
+
+    Original dracula color scheme by Zeno Rocha (https://github.com/zenorocha/dracula-theme)
+
+*/
+
+
+.cm-s-dracula.CodeMirror, .cm-s-dracula .CodeMirror-gutters {
+  background-color: #282a36 !important;
+  color: #f8f8f2 !important;
+  border: none;
+}
+.cm-s-dracula .CodeMirror-gutters { color: #282a36; }
+.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
+.cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
+.cm-s-dracula .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula span.cm-comment { color: #6272a4; }
+.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 { color: #f1fa8c; }
+.cm-s-dracula span.cm-number { color: #bd93f9; }
+.cm-s-dracula span.cm-variable { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-2 { color: white; }
+.cm-s-dracula span.cm-def { color: #50fa7b; }
+.cm-s-dracula span.cm-operator { color: #ff79c6; }
+.cm-s-dracula span.cm-keyword { color: #ff79c6; }
+.cm-s-dracula span.cm-atom { color: #bd93f9; }
+.cm-s-dracula span.cm-meta { color: #f8f8f2; }
+.cm-s-dracula span.cm-tag { color: #ff79c6; }
+.cm-s-dracula span.cm-attribute { color: #50fa7b; }
+.cm-s-dracula span.cm-qualifier { color: #50fa7b; }
+.cm-s-dracula span.cm-property { color: #66d9ef; }
+.cm-s-dracula span.cm-builtin { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-3, .cm-s-dracula span.cm-type { color: #ffb86c; }
+
+.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
+.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+
+/*
+
+    Name:       Hopscotch
+    Author:     Jan T. Sott
+
+    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
+    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+
+*/
+
+.cm-s-hopscotch.CodeMirror {background: #322931; color: #d5d3d5;}
+.cm-s-hopscotch div.CodeMirror-selected {background: #433b42 !important;}
+.cm-s-hopscotch .CodeMirror-gutters {background: #322931; border-right: 0px;}
+.cm-s-hopscotch .CodeMirror-linenumber {color: #797379;}
+.cm-s-hopscotch .CodeMirror-cursor {border-left: 1px solid #989498 !important;}
+
+.cm-s-hopscotch span.cm-comment {color: #b33508;}
+.cm-s-hopscotch span.cm-atom {color: #c85e7c;}
+.cm-s-hopscotch span.cm-number {color: #c85e7c;}
+
+.cm-s-hopscotch span.cm-property, .cm-s-hopscotch span.cm-attribute {color: #8fc13e;}
+.cm-s-hopscotch span.cm-keyword {color: #dd464c;}
+.cm-s-hopscotch span.cm-string {color: #fdcc59;}
+
+.cm-s-hopscotch span.cm-variable {color: #8fc13e;}
+.cm-s-hopscotch span.cm-variable-2 {color: #1290bf;}
+.cm-s-hopscotch span.cm-def {color: #fd8b19;}
+.cm-s-hopscotch span.cm-error {background: #dd464c; color: #989498;}
+.cm-s-hopscotch span.cm-bracket {color: #d5d3d5;}
+.cm-s-hopscotch span.cm-tag {color: #dd464c;}
+.cm-s-hopscotch span.cm-link {color: #c85e7c;}
+
+.cm-s-hopscotch .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-hopscotch .CodeMirror-activeline-background { background: #302020; }
+
+/****************************************************************/
+/*   Based on mbonaci's Brackets mbo theme                      */
+/*   https://github.com/mbonaci/global/blob/master/Mbo.tmTheme  */
+/*   Create your own: http://tmtheme-editor.herokuapp.com       */
+/****************************************************************/
+
+.cm-s-mbo.CodeMirror { background: #2c2c2c; color: #ffffec; }
+.cm-s-mbo div.CodeMirror-selected { background: #716C62; }
+.cm-s-mbo .CodeMirror-line::selection, .cm-s-mbo .CodeMirror-line > span::selection, .cm-s-mbo .CodeMirror-line > span > span::selection { background: rgba(113, 108, 98, .99); }
+.cm-s-mbo .CodeMirror-line::-moz-selection, .cm-s-mbo .CodeMirror-line > span::-moz-selection, .cm-s-mbo .CodeMirror-line > span > span::-moz-selection { background: rgba(113, 108, 98, .99); }
+.cm-s-mbo .CodeMirror-gutters { background: #4e4e4e; border-right: 0px; }
+.cm-s-mbo .CodeMirror-guttermarker { color: white; }
+.cm-s-mbo .CodeMirror-guttermarker-subtle { color: grey; }
+.cm-s-mbo .CodeMirror-linenumber { color: #dadada; }
+.cm-s-mbo .CodeMirror-cursor { border-left: 1px solid #ffffec; }
+
+.cm-s-mbo span.cm-comment { color: #95958a; }
+.cm-s-mbo span.cm-atom { color: #00a8c6; }
+.cm-s-mbo span.cm-number { color: #00a8c6; }
+
+.cm-s-mbo span.cm-property, .cm-s-mbo span.cm-attribute { color: #9ddfe9; }
+.cm-s-mbo span.cm-keyword { color: #ffb928; }
+.cm-s-mbo span.cm-string { color: #ffcf6c; }
+.cm-s-mbo span.cm-string.cm-property { color: #ffffec; }
+
+.cm-s-mbo span.cm-variable { color: #ffffec; }
+.cm-s-mbo span.cm-variable-2 { color: #00a8c6; }
+.cm-s-mbo span.cm-def { color: #ffffec; }
+.cm-s-mbo span.cm-bracket { color: #fffffc; font-weight: bold; }
+.cm-s-mbo span.cm-tag { color: #9ddfe9; }
+.cm-s-mbo span.cm-link { color: #f54b07; }
+.cm-s-mbo span.cm-error { border-bottom: #636363; color: #ffffec; }
+.cm-s-mbo span.cm-qualifier { color: #ffffec; }
+
+.cm-s-mbo .CodeMirror-activeline-background { background: #494b41; }
+.cm-s-mbo .CodeMirror-matchingbracket { color: #ffb928 !important; }
+.cm-s-mbo .CodeMirror-matchingtag { background: rgba(255, 255, 255, .37); }
+
+/*
+  MDN-LIKE Theme - Mozilla
+  Ported to CodeMirror by Peter Kroon <plakroon@gmail.com>
+  Report bugs/issues here: https://github.com/codemirror/CodeMirror/issues
+  GitHub: @peterkroon
+
+  The mdn-like theme is inspired on the displayed code examples at: https://developer.mozilla.org/en-US/docs/Web/CSS/animation
+
+*/
+.cm-s-mdn-like.CodeMirror { color: #999; background-color: #fff; }
+.cm-s-mdn-like div.CodeMirror-selected { background: #cfc; }
+.cm-s-mdn-like .CodeMirror-line::selection, .cm-s-mdn-like .CodeMirror-line > span::selection, .cm-s-mdn-like .CodeMirror-line > span > span::selection { background: #cfc; }
+.cm-s-mdn-like .CodeMirror-line::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span > span::-moz-selection { background: #cfc; }
+
+.cm-s-mdn-like .CodeMirror-gutters { background: #f8f8f8; border-left: 6px solid rgba(0,83,159,0.65); color: #333; }
+.cm-s-mdn-like .CodeMirror-linenumber { color: #aaa; padding-left: 8px; }
+.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
+
+.cm-s-mdn-like .cm-keyword { color: #6262FF; }
+.cm-s-mdn-like .cm-atom { color: #F90; }
+.cm-s-mdn-like .cm-number { color:  #ca7841; }
+.cm-s-mdn-like .cm-def { color: #8DA6CE; }
+.cm-s-mdn-like span.cm-variable-2, .cm-s-mdn-like span.cm-tag { color: #690; }
+.cm-s-mdn-like span.cm-variable-3, .cm-s-mdn-like span.cm-def, .cm-s-mdn-like span.cm-type { color: #07a; }
+
+.cm-s-mdn-like .cm-variable { color: #07a; }
+.cm-s-mdn-like .cm-property { color: #905; }
+.cm-s-mdn-like .cm-qualifier { color: #690; }
+
+.cm-s-mdn-like .cm-operator { color: #cda869; }
+.cm-s-mdn-like .cm-comment { color:#777; font-weight:normal; }
+.cm-s-mdn-like .cm-string { color:#07a; font-style:italic; }
+.cm-s-mdn-like .cm-string-2 { color:#bd6b18; } /*?*/
+.cm-s-mdn-like .cm-meta { color: #000; } /*?*/
+.cm-s-mdn-like .cm-builtin { color: #9B7536; } /*?*/
+.cm-s-mdn-like .cm-tag { color: #997643; }
+.cm-s-mdn-like .cm-attribute { color: #d6bb6d; } /*?*/
+.cm-s-mdn-like .cm-header { color: #FF6400; }
+.cm-s-mdn-like .cm-hr { color: #AEAEAE; }
+.cm-s-mdn-like .cm-link { color:#ad9361; font-style:italic; text-decoration:none; }
+.cm-s-mdn-like .cm-error { border-bottom: 1px solid red; }
+
+div.cm-s-mdn-like .CodeMirror-activeline-background { background: #efefff; }
+div.cm-s-mdn-like span.CodeMirror-matchingbracket { outline:1px solid grey; color: inherit; }
+
+.cm-s-mdn-like.CodeMirror { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFcAAAAyCAYAAAAp8UeFAAAHvklEQVR42s2b63bcNgyEQZCSHCdt2vd/0tWF7I+Q6XgMXiTtuvU5Pl57ZQKkKHzEAOtF5KeIJBGJ8uvL599FRFREZhFx8DeXv8trn68RuGaC8TRfo3SNp9dlDDHedyLyTUTeRWStXKPZrjtpZxaRw5hPqozRs1N8/enzIiQRWcCgy4MUA0f+XWliDhyL8Lfyvx7ei/Ae3iQFHyw7U/59pQVIMEEPEz0G7XiwdRjzSfC3UTtz9vchIntxvry5iMgfIhJoEflOz2CQr3F5h/HfeFe+GTdLaKcu9L8LTeQb/R/7GgbsfKedyNdoHsN31uRPWrfZ5wsj/NzzRQHuToIdU3ahwnsKPxXCjJITuOsi7XLc7SG/v5GdALs7wf8JjTFiB5+QvTEfRyGOfX3Lrx8wxyQi3sNq46O7QahQiCsRFgqddjBouVEHOKDgXAQHD9gJCr5sMKkEdjwsarG/ww3BMHBU7OBjXnzdyY7SfCxf5/z6ATccrwlKuwC/jhznnPF4CgVzhhVf4xp2EixcBActO75iZ8/fM9zAs2OMzKdslgXWJ9XG8PQoOAMA5fGcsvORgv0doBXyHrCwfLJAOwo71QLNkb8n2Pl6EWiR7OCibtkPaz4Kc/0NNAze2gju3zOwekALDaCFPI5vjPFmgGY5AZqyGEvH1x7QfIb8YtxMnA/b+QQ0aQDAwc6JMFg8CbQZ4qoYEEHbRwNojuK3EHwd7VALSgq+MNDKzfT58T8qdpADrgW0GmgcAS1lhzztJmkAzcPNOQbsWEALBDSlMKUG0Eq4CLAQWvEVQ9WU57gZJwZtgPO3r9oBTQ9WO8TjqXINx8R0EYpiZEUWOF3FxkbJkgU9B2f41YBrIj5ZfsQa0M5kTgiAAqM3ShXLgu8XMqcrQBvJ0CL5pnTsfMB13oB8athpAq2XOQmcGmoACCLydx7nToa23ATaSIY2ichfOdPTGxlasXMLaL0MLZAOwAKIM+y8CmicobGdCcbbK9DzN+yYGVoNNI5iUKTMyYOjPse4A8SM1MmcXgU0toOq1yO/v8FOxlASyc7TgeYaAMBJHcY1CcCwGI/TK4AmDbDyKYBBtFUkRwto8gygiQEaByFgJ00BH2M8JWwQS1nafDXQCidWyOI8AcjDCSjCLk8ngObuAm3JAHAdubAmOaK06V8MNEsKPJOhobSprwQa6gD7DclRQdqcwL4zxqgBrQcabUiBLclRDKAlWp+etPkBaNMA0AKlrHwTdEByZAA4GM+SNluSY6wAzcMNewxmgig5Ks0nkrSpBvSaQHMdKTBAnLojOdYyGpQ254602ZILPdTD1hdlggdIm74jbTp8vDwF5ZYUeLWGJpWsh6XNyXgcYwVoJQTEhhTYkxzZjiU5npU2TaB979TQehlaAVq4kaGpiPwwwLkYUuBbQwocyQTv1tA0+1UFWoJF3iv1oq+qoSk8EQdJmwHkziIF7oOZk14EGitibAdjLYYK78H5vZOhtWpoI0ATGHs0Q8OMb4Ey+2bU2UYztCtA0wFAs7TplGLRVQCcqaFdGSPCeTI1QNIC52iWNzof6Uib7xjEp07mNNoUYmVosVItHrHzRlLgBn9LFyRHaQCtVUMbtTNhoXWiTOO9k/V8BdAc1Oq0ArSQs6/5SU0hckNy9NnXqQY0PGYo5dWJ7nINaN6o958FWin27aBaWRka1r5myvLOAm0j30eBJqCxHLReVclxhxOEN2JfDWjxBtAC7MIH1fVaGdoOp4qJYDgKtKPSFNID2gSnGldrCqkFZ+5UeQXQBIRrSwocbdZYQT/2LwRahBPBXoHrB8nxaGROST62DKUbQOMMzZIC9abkuELfQzQALWTnDNAm8KHWFOJgJ5+SHIvTPcmx1xQyZRhNL5Qci689aXMEaN/uNIWkEwDAvFpOZmgsBaaGnbs1NPa1Jm32gBZAIh1pCtG7TSH4aE0y1uVY4uqoFPisGlpP2rSA5qTecWn5agK6BzSpgAyD+wFaqhnYoSZ1Vwr8CmlTQbrcO3ZaX0NAEyMbYaAlyquFoLKK3SPby9CeVUPThrSJmkCAE0CrKUQadi4DrdSlWhmah0YL9z9vClH59YGbHx1J8VZTyAjQepJjmXwAKTDQI3omc3p1U4gDUf6RfcdYfrUp5ClAi2J3Ba6UOXGo+K+bQrjjssitG2SJzshaLwMtXgRagUNpYYoVkMSBLM+9GGiJZMvduG6DRZ4qc04DMPtQQxOjEtACmhO7K1AbNbQDEggZyJwscFpAGwENhoBeUwh3bWolhe8BTYVKxQEWrSUn/uhcM5KhvUu/+eQu0Lzhi+VrK0PrZZNDQKs9cpYUuFYgMVpD4/NxenJTiMCNqdUEUf1qZWjppLT5qSkkUZbCwkbZMSuVnu80hfSkzRbQeqCZSAh6huR4VtoM2gHAlLf72smuWgE+VV7XpE25Ab2WFDgyhnSuKbs4GuGzCjR+tIoUuMFg3kgcWKLTwRqanJQ2W00hAsenfaApRC42hbCvK1SlE0HtE9BGgneJO+ELamitD1YjjOYnNYVcraGhtKkW0EqVVeDx733I2NH581k1NNxNLG0i0IJ8/NjVaOZ0tYZ2Vtr0Xv7tPV3hkWp9EFkgS/J0vosngTaSoaG06WHi+xObQkaAdlbanP8B2+2l0f90LmUAAAAASUVORK5CYII=); }
+
+/*
+
+    Name:       seti
+    Author:     Michael Kaminsky (http://github.com/mkaminsky11)
+
+    Original seti color scheme by Jesse Weed (https://github.com/jesseweed/seti-syntax)
+
+*/
+
+
+.cm-s-seti.CodeMirror {
+  background-color: #151718 !important;
+  color: #CFD2D1 !important;
+  border: none;
+}
+.cm-s-seti .CodeMirror-gutters {
+  color: #404b53;
+  background-color: #0E1112;
+  border: none;
+}
+.cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
+.cm-s-seti .CodeMirror-linenumber { color: #6D8A88; }
+.cm-s-seti.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-seti .CodeMirror-line::-moz-selection, .cm-s-seti .CodeMirror-line > span::-moz-selection, .cm-s-seti .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-seti span.cm-comment { color: #41535b; }
+.cm-s-seti span.cm-string, .cm-s-seti span.cm-string-2 { color: #55b5db; }
+.cm-s-seti span.cm-number { color: #cd3f45; }
+.cm-s-seti span.cm-variable { color: #55b5db; }
+.cm-s-seti span.cm-variable-2 { color: #a074c4; }
+.cm-s-seti span.cm-def { color: #55b5db; }
+.cm-s-seti span.cm-keyword { color: #ff79c6; }
+.cm-s-seti span.cm-operator { color: #9fca56; }
+.cm-s-seti span.cm-keyword { color: #e6cd69; }
+.cm-s-seti span.cm-atom { color: #cd3f45; }
+.cm-s-seti span.cm-meta { color: #55b5db; }
+.cm-s-seti span.cm-tag { color: #55b5db; }
+.cm-s-seti span.cm-attribute { color: #9fca56; }
+.cm-s-seti span.cm-qualifier { color: #9fca56; }
+.cm-s-seti span.cm-property { color: #a074c4; }
+.cm-s-seti span.cm-variable-3, .cm-s-seti span.cm-type { color: #9fca56; }
+.cm-s-seti span.cm-builtin { color: #9fca56; }
+.cm-s-seti .CodeMirror-activeline-background { background: #101213; }
+.cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+
+/*
+Solarized theme for code-mirror
+http://ethanschoonover.com/solarized
+*/
+
+/*
+Solarized color palette
+http://ethanschoonover.com/solarized/img/solarized-palette.png
+*/
+
+.solarized.base03 { color: #002b36; }
+.solarized.base02 { color: #073642; }
+.solarized.base01 { color: #586e75; }
+.solarized.base00 { color: #657b83; }
+.solarized.base0 { color: #839496; }
+.solarized.base1 { color: #93a1a1; }
+.solarized.base2 { color: #eee8d5; }
+.solarized.base3  { color: #fdf6e3; }
+.solarized.solar-yellow  { color: #b58900; }
+.solarized.solar-orange  { color: #cb4b16; }
+.solarized.solar-red { color: #dc322f; }
+.solarized.solar-magenta { color: #d33682; }
+.solarized.solar-violet  { color: #6c71c4; }
+.solarized.solar-blue { color: #268bd2; }
+.solarized.solar-cyan { color: #2aa198; }
+.solarized.solar-green { color: #859900; }
+
+/* Color scheme for code-mirror */
+
+.cm-s-solarized {
+  line-height: 1.45em;
+  color-profile: sRGB;
+  rendering-intent: auto;
+}
+.cm-s-solarized.cm-s-dark {
+  color: #839496;
+  background-color: #002b36;
+  text-shadow: #002b36 0 1px;
+}
+.cm-s-solarized.cm-s-light {
+  background-color: #fdf6e3;
+  color: #657b83;
+  text-shadow: #eee8d5 0 1px;
+}
+
+.cm-s-solarized .CodeMirror-widget {
+  text-shadow: none;
+}
+
+.cm-s-solarized .cm-header { color: #586e75; }
+.cm-s-solarized .cm-quote { color: #93a1a1; }
+
+.cm-s-solarized .cm-keyword { color: #cb4b16; }
+.cm-s-solarized .cm-atom { color: #d33682; }
+.cm-s-solarized .cm-number { color: #d33682; }
+.cm-s-solarized .cm-def { color: #2aa198; }
+
+.cm-s-solarized .cm-variable { color: #839496; }
+.cm-s-solarized .cm-variable-2 { color: #b58900; }
+.cm-s-solarized .cm-variable-3, .cm-s-solarized .cm-type { color: #6c71c4; }
+
+.cm-s-solarized .cm-property { color: #2aa198; }
+.cm-s-solarized .cm-operator { color: #6c71c4; }
+
+.cm-s-solarized .cm-comment { color: #586e75; font-style:italic; }
+
+.cm-s-solarized .cm-string { color: #859900; }
+.cm-s-solarized .cm-string-2 { color: #b58900; }
+
+.cm-s-solarized .cm-meta { color: #859900; }
+.cm-s-solarized .cm-qualifier { color: #b58900; }
+.cm-s-solarized .cm-builtin { color: #d33682; }
+.cm-s-solarized .cm-bracket { color: #cb4b16; }
+.cm-s-solarized .CodeMirror-matchingbracket { color: #859900; }
+.cm-s-solarized .CodeMirror-nonmatchingbracket { color: #dc322f; }
+.cm-s-solarized .cm-tag { color: #93a1a1; }
+.cm-s-solarized .cm-attribute { color: #2aa198; }
+.cm-s-solarized .cm-hr {
+  color: transparent;
+  border-top: 1px solid #586e75;
+  display: block;
+}
+.cm-s-solarized .cm-link { color: #93a1a1; cursor: pointer; }
+.cm-s-solarized .cm-special { color: #6c71c4; }
+.cm-s-solarized .cm-em {
+  color: #999;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+.cm-s-solarized .cm-error,
+.cm-s-solarized .cm-invalidchar {
+  color: #586e75;
+  border-bottom: 1px dotted #dc322f;
+}
+
+.cm-s-solarized.cm-s-dark div.CodeMirror-selected { background: #073642; }
+.cm-s-solarized.cm-s-dark.CodeMirror ::selection { background: rgba(7, 54, 66, 0.99); }
+.cm-s-solarized.cm-s-dark .CodeMirror-line::-moz-selection, .cm-s-dark .CodeMirror-line > span::-moz-selection, .cm-s-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(7, 54, 66, 0.99); }
+
+.cm-s-solarized.cm-s-light div.CodeMirror-selected { background: #eee8d5; }
+.cm-s-solarized.cm-s-light .CodeMirror-line::selection, .cm-s-light .CodeMirror-line > span::selection, .cm-s-light .CodeMirror-line > span > span::selection { background: #eee8d5; }
+.cm-s-solarized.cm-s-light .CodeMirror-line::-moz-selection, .cm-s-ligh .CodeMirror-line > span::-moz-selection, .cm-s-ligh .CodeMirror-line > span > span::-moz-selection { background: #eee8d5; }
+
+/* Editor styling */
+
+
+
+/* Little shadow on the view-port of the buffer view */
+.cm-s-solarized.CodeMirror {
+  -moz-box-shadow: inset 7px 0 12px -6px #000;
+  -webkit-box-shadow: inset 7px 0 12px -6px #000;
+  box-shadow: inset 7px 0 12px -6px #000;
+}
+
+/* Remove gutter border */
+.cm-s-solarized .CodeMirror-gutters {
+  border-right: 0;
+}
+
+/* Gutter colors and line number styling based of color scheme (dark / light) */
+
+/* Dark */
+.cm-s-solarized.cm-s-dark .CodeMirror-gutters {
+  background-color: #073642;
+}
+
+.cm-s-solarized.cm-s-dark .CodeMirror-linenumber {
+  color: #586e75;
+  text-shadow: #021014 0 -1px;
+}
+
+/* Light */
+.cm-s-solarized.cm-s-light .CodeMirror-gutters {
+  background-color: #eee8d5;
+}
+
+.cm-s-solarized.cm-s-light .CodeMirror-linenumber {
+  color: #839496;
+}
+
+/* Common */
+.cm-s-solarized .CodeMirror-linenumber {
+  padding: 0 5px;
+}
+.cm-s-solarized .CodeMirror-guttermarker-subtle { color: #586e75; }
+.cm-s-solarized.cm-s-dark .CodeMirror-guttermarker { color: #ddd; }
+.cm-s-solarized.cm-s-light .CodeMirror-guttermarker { color: #cb4b16; }
+
+.cm-s-solarized .CodeMirror-gutter .CodeMirror-gutter-text {
+  color: #586e75;
+}
+
+/* Cursor */
+.cm-s-solarized .CodeMirror-cursor { border-left: 1px solid #819090; }
+
+/* Fat cursor */
+.cm-s-solarized.cm-s-light.cm-fat-cursor .CodeMirror-cursor { background: #77ee77; }
+.cm-s-solarized.cm-s-light .cm-animate-fat-cursor { background-color: #77ee77; }
+.cm-s-solarized.cm-s-dark.cm-fat-cursor .CodeMirror-cursor { background: #586e75; }
+.cm-s-solarized.cm-s-dark .cm-animate-fat-cursor { background-color: #586e75; }
+
+/* Active line */
+.cm-s-solarized.cm-s-dark .CodeMirror-activeline-background {
+  background: rgba(255, 255, 255, 0.06);
+}
+.cm-s-solarized.cm-s-light .CodeMirror-activeline-background {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.cm-s-the-matrix.CodeMirror { background: #000000; color: #00FF00; }
+.cm-s-the-matrix div.CodeMirror-selected { background: #2D2D2D; }
+.cm-s-the-matrix .CodeMirror-line::selection, .cm-s-the-matrix .CodeMirror-line > span::selection, .cm-s-the-matrix .CodeMirror-line > span > span::selection { background: rgba(45, 45, 45, 0.99); }
+.cm-s-the-matrix .CodeMirror-line::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span > span::-moz-selection { background: rgba(45, 45, 45, 0.99); }
+.cm-s-the-matrix .CodeMirror-gutters { background: #060; border-right: 2px solid #00FF00; }
+.cm-s-the-matrix .CodeMirror-guttermarker { color: #0f0; }
+.cm-s-the-matrix .CodeMirror-guttermarker-subtle { color: white; }
+.cm-s-the-matrix .CodeMirror-linenumber { color: #FFFFFF; }
+.cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00; }
+
+.cm-s-the-matrix span.cm-keyword { color: #008803; font-weight: bold; }
+.cm-s-the-matrix span.cm-atom { color: #3FF; }
+.cm-s-the-matrix span.cm-number { color: #FFB94F; }
+.cm-s-the-matrix span.cm-def { color: #99C; }
+.cm-s-the-matrix span.cm-variable { color: #F6C; }
+.cm-s-the-matrix span.cm-variable-2 { color: #C6F; }
+.cm-s-the-matrix span.cm-variable-3, .cm-s-the-matrix span.cm-type { color: #96F; }
+.cm-s-the-matrix span.cm-property { color: #62FFA0; }
+.cm-s-the-matrix span.cm-operator { color: #999; }
+.cm-s-the-matrix span.cm-comment { color: #CCCCCC; }
+.cm-s-the-matrix span.cm-string { color: #39C; }
+.cm-s-the-matrix span.cm-meta { color: #C9F; }
+.cm-s-the-matrix span.cm-qualifier { color: #FFF700; }
+.cm-s-the-matrix span.cm-builtin { color: #30a; }
+.cm-s-the-matrix span.cm-bracket { color: #cc7; }
+.cm-s-the-matrix span.cm-tag { color: #FFBD40; }
+.cm-s-the-matrix span.cm-attribute { color: #FFF700; }
+.cm-s-the-matrix span.cm-error { color: #FF0000; }
+
+.cm-s-the-matrix .CodeMirror-activeline-background { background: #040; }
+
+/*
+Copyright (C) 2011 by MarkLogic Corporation
+Author: Mike Brevoort <mike@brevoort.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+.cm-s-xq-light span.cm-keyword { line-height: 1em; font-weight: bold; color: #5A5CAD; }
+.cm-s-xq-light span.cm-atom { color: #6C8CD5; }
+.cm-s-xq-light span.cm-number { color: #164; }
+.cm-s-xq-light span.cm-def { text-decoration:underline; }
+.cm-s-xq-light span.cm-variable { color: black; }
+.cm-s-xq-light span.cm-variable-2 { color:black; }
+.cm-s-xq-light span.cm-variable-3, .cm-s-xq-light span.cm-type { color: black; }
+.cm-s-xq-light span.cm-property {}
+.cm-s-xq-light span.cm-operator {}
+.cm-s-xq-light span.cm-comment { color: #0080FF; font-style: italic; }
+.cm-s-xq-light span.cm-string { color: red; }
+.cm-s-xq-light span.cm-meta { color: yellow; }
+.cm-s-xq-light span.cm-qualifier { color: grey; }
+.cm-s-xq-light span.cm-builtin { color: #7EA656; }
+.cm-s-xq-light span.cm-bracket { color: #cc7; }
+.cm-s-xq-light span.cm-tag { color: #3F7F7F; }
+.cm-s-xq-light span.cm-attribute { color: #7F007F; }
+.cm-s-xq-light span.cm-error { color: #f00; }
+
+.cm-s-xq-light .CodeMirror-activeline-background { background: #e8f2ff; }
+.cm-s-xq-light .CodeMirror-matchingbracket { outline:1px solid grey;color:black !important;background:yellow; }
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.CodeMirror {
+  line-height: var(--jp-code-line-height);
+  font-size: var(--jp-code-font-size);
+  font-family: var(--jp-code-font-family);
+  border: 0;
+  border-radius: 0;
+  height: auto;
+  /* Changed to auto to autogrow */
+}
+
+.CodeMirror pre {
+  padding: 0 var(--jp-code-padding);
+}
+
+.jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-dialog {
+  background-color: var(--jp-layout-color0);
+  color: var(--jp-content-font-color1);
+}
+
+/* This causes https://github.com/jupyter/jupyterlab/issues/522 */
+/* May not cause it not because we changed it! */
+.CodeMirror-lines {
+  padding: var(--jp-code-padding) 0;
+}
+
+.CodeMirror-linenumber {
+  padding: 0 8px;
+}
+
+.jp-CodeMirrorEditor-static {
+  margin: var(--jp-code-padding);
+}
+
+.jp-CodeMirrorEditor,
+.jp-CodeMirrorEditor-static {
+  cursor: text;
+}
+
+.jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
+  border-left: var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color);
+}
+
+/* When zoomed out 67% and 33% on a screen of 1440 width x 900 height */
+@media screen and (min-width: 2138px) and (max-width: 4319px) {
+  .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
+    border-left: var(--jp-code-cursor-width1) solid
+      var(--jp-editor-cursor-color);
+  }
+}
+
+/* When zoomed out less than 33% */
+@media screen and (min-width: 4320px) {
+  .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
+    border-left: var(--jp-code-cursor-width2) solid
+      var(--jp-editor-cursor-color);
+  }
+}
+
+.CodeMirror.jp-mod-readOnly .CodeMirror-cursor {
+  display: none;
+}
+
+.CodeMirror-gutters {
+  border-right: 1px solid var(--jp-border-color2);
+  background-color: var(--jp-layout-color0);
+}
+
+.jp-CollaboratorCursor {
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: none;
+  border-bottom: 3px solid;
+  background-clip: content-box;
+  margin-left: -5px;
+  margin-right: -5px;
+}
+
+.CodeMirror-selectedtext.cm-searching {
+  background-color: var(--jp-search-selected-match-background-color) !important;
+  color: var(--jp-search-selected-match-color) !important;
+}
+
+.cm-searching {
+  background-color: var(
+    --jp-search-unselected-match-background-color
+  ) !important;
+  color: var(--jp-search-unselected-match-color) !important;
+}
+
+.CodeMirror-focused .CodeMirror-selected {
+  background-color: var(--jp-editor-selected-focused-background);
+}
+
+.CodeMirror-selected {
+  background-color: var(--jp-editor-selected-background);
+}
+
+.jp-CollaboratorCursor-hover {
+  position: absolute;
+  z-index: 1;
+  transform: translateX(-50%);
+  color: white;
+  border-radius: 3px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  text-align: center;
+  font-size: var(--jp-ui-font-size1);
+  white-space: nowrap;
+}
+
+.jp-CodeMirror-ruler {
+  border-left: 1px dashed var(--jp-border-color2);
+}
+
+/**
+ * Here is our jupyter theme for CodeMirror syntax highlighting
+ * This is used in our marked.js syntax highlighting and CodeMirror itself
+ * The string "jupyter" is set in ../codemirror/widget.DEFAULT_CODEMIRROR_THEME
+ * This came from the classic notebook, which came form highlight.js/GitHub
+ */
+
+/**
+ * CodeMirror themes are handling the background/color in this way. This works
+ * fine for CodeMirror editors outside the notebook, but the notebook styles
+ * these things differently.
+ */
+.CodeMirror.cm-s-jupyter {
+  background: var(--jp-layout-color0);
+  color: var(--jp-content-font-color1);
+}
+
+/* In the notebook, we want this styling to be handled by its container */
+.jp-CodeConsole .CodeMirror.cm-s-jupyter,
+.jp-Notebook .CodeMirror.cm-s-jupyter {
+  background: transparent;
+}
+
+.cm-s-jupyter .CodeMirror-cursor {
+  border-left: var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color);
+}
+.cm-s-jupyter span.cm-keyword {
+  color: var(--jp-mirror-editor-keyword-color);
+  font-weight: bold;
+}
+.cm-s-jupyter span.cm-atom {
+  color: var(--jp-mirror-editor-atom-color);
+}
+.cm-s-jupyter span.cm-number {
+  color: var(--jp-mirror-editor-number-color);
+}
+.cm-s-jupyter span.cm-def {
+  color: var(--jp-mirror-editor-def-color);
+}
+.cm-s-jupyter span.cm-variable {
+  color: var(--jp-mirror-editor-variable-color);
+}
+.cm-s-jupyter span.cm-variable-2 {
+  color: var(--jp-mirror-editor-variable-2-color);
+}
+.cm-s-jupyter span.cm-variable-3 {
+  color: var(--jp-mirror-editor-variable-3-color);
+}
+.cm-s-jupyter span.cm-punctuation {
+  color: var(--jp-mirror-editor-punctuation-color);
+}
+.cm-s-jupyter span.cm-property {
+  color: var(--jp-mirror-editor-property-color);
+}
+.cm-s-jupyter span.cm-operator {
+  color: var(--jp-mirror-editor-operator-color);
+  font-weight: bold;
+}
+.cm-s-jupyter span.cm-comment {
+  color: var(--jp-mirror-editor-comment-color);
+  font-style: italic;
+}
+.cm-s-jupyter span.cm-string {
+  color: var(--jp-mirror-editor-string-color);
+}
+.cm-s-jupyter span.cm-string-2 {
+  color: var(--jp-mirror-editor-string-2-color);
+}
+.cm-s-jupyter span.cm-meta {
+  color: var(--jp-mirror-editor-meta-color);
+}
+.cm-s-jupyter span.cm-qualifier {
+  color: var(--jp-mirror-editor-qualifier-color);
+}
+.cm-s-jupyter span.cm-builtin {
+  color: var(--jp-mirror-editor-builtin-color);
+}
+.cm-s-jupyter span.cm-bracket {
+  color: var(--jp-mirror-editor-bracket-color);
+}
+.cm-s-jupyter span.cm-tag {
+  color: var(--jp-mirror-editor-tag-color);
+}
+.cm-s-jupyter span.cm-attribute {
+  color: var(--jp-mirror-editor-attribute-color);
+}
+.cm-s-jupyter span.cm-header {
+  color: var(--jp-mirror-editor-header-color);
+}
+.cm-s-jupyter span.cm-quote {
+  color: var(--jp-mirror-editor-quote-color);
+}
+.cm-s-jupyter span.cm-link {
+  color: var(--jp-mirror-editor-link-color);
+}
+.cm-s-jupyter span.cm-error {
+  color: var(--jp-mirror-editor-error-color);
+}
+.cm-s-jupyter span.cm-hr {
+  color: #999;
+}
+
+.cm-s-jupyter span.cm-tab {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
+  background-position: right;
+  background-repeat: no-repeat;
+}
+
+.cm-s-jupyter .CodeMirror-activeline-background,
+.cm-s-jupyter .CodeMirror-gutter {
+  background-color: var(--jp-layout-color2);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| RenderedText
+|----------------------------------------------------------------------------*/
+
+.jp-RenderedText {
+  text-align: left;
+  padding-left: var(--jp-code-padding);
+  line-height: var(--jp-code-line-height);
+  font-family: var(--jp-code-font-family);
+}
+
+.jp-RenderedText pre,
+.jp-RenderedJavaScript pre,
+.jp-RenderedHTMLCommon pre {
+  color: var(--jp-content-font-color1);
+  font-size: var(--jp-code-font-size);
+  border: none;
+  margin: 0px;
+  padding: 0px;
+  line-height: normal;
+}
+
+.jp-RenderedText pre a:link {
+  text-decoration: none;
+  color: var(--jp-content-link-color);
+}
+.jp-RenderedText pre a:hover {
+  text-decoration: underline;
+  color: var(--jp-content-link-color);
+}
+.jp-RenderedText pre a:visited {
+  text-decoration: none;
+  color: var(--jp-content-link-color);
+}
+
+/* console foregrounds and backgrounds */
+.jp-RenderedText pre .ansi-black-fg {
+  color: #3e424d;
+}
+.jp-RenderedText pre .ansi-red-fg {
+  color: #e75c58;
+}
+.jp-RenderedText pre .ansi-green-fg {
+  color: #00a250;
+}
+.jp-RenderedText pre .ansi-yellow-fg {
+  color: #ddb62b;
+}
+.jp-RenderedText pre .ansi-blue-fg {
+  color: #208ffb;
+}
+.jp-RenderedText pre .ansi-magenta-fg {
+  color: #d160c4;
+}
+.jp-RenderedText pre .ansi-cyan-fg {
+  color: #60c6c8;
+}
+.jp-RenderedText pre .ansi-white-fg {
+  color: #c5c1b4;
+}
+
+.jp-RenderedText pre .ansi-black-bg {
+  background-color: #3e424d;
+}
+.jp-RenderedText pre .ansi-red-bg {
+  background-color: #e75c58;
+}
+.jp-RenderedText pre .ansi-green-bg {
+  background-color: #00a250;
+}
+.jp-RenderedText pre .ansi-yellow-bg {
+  background-color: #ddb62b;
+}
+.jp-RenderedText pre .ansi-blue-bg {
+  background-color: #208ffb;
+}
+.jp-RenderedText pre .ansi-magenta-bg {
+  background-color: #d160c4;
+}
+.jp-RenderedText pre .ansi-cyan-bg {
+  background-color: #60c6c8;
+}
+.jp-RenderedText pre .ansi-white-bg {
+  background-color: #c5c1b4;
+}
+
+.jp-RenderedText pre .ansi-black-intense-fg {
+  color: #282c36;
+}
+.jp-RenderedText pre .ansi-red-intense-fg {
+  color: #b22b31;
+}
+.jp-RenderedText pre .ansi-green-intense-fg {
+  color: #007427;
+}
+.jp-RenderedText pre .ansi-yellow-intense-fg {
+  color: #b27d12;
+}
+.jp-RenderedText pre .ansi-blue-intense-fg {
+  color: #0065ca;
+}
+.jp-RenderedText pre .ansi-magenta-intense-fg {
+  color: #a03196;
+}
+.jp-RenderedText pre .ansi-cyan-intense-fg {
+  color: #258f8f;
+}
+.jp-RenderedText pre .ansi-white-intense-fg {
+  color: #a1a6b2;
+}
+
+.jp-RenderedText pre .ansi-black-intense-bg {
+  background-color: #282c36;
+}
+.jp-RenderedText pre .ansi-red-intense-bg {
+  background-color: #b22b31;
+}
+.jp-RenderedText pre .ansi-green-intense-bg {
+  background-color: #007427;
+}
+.jp-RenderedText pre .ansi-yellow-intense-bg {
+  background-color: #b27d12;
+}
+.jp-RenderedText pre .ansi-blue-intense-bg {
+  background-color: #0065ca;
+}
+.jp-RenderedText pre .ansi-magenta-intense-bg {
+  background-color: #a03196;
+}
+.jp-RenderedText pre .ansi-cyan-intense-bg {
+  background-color: #258f8f;
+}
+.jp-RenderedText pre .ansi-white-intense-bg {
+  background-color: #a1a6b2;
+}
+
+.jp-RenderedText pre .ansi-default-inverse-fg {
+  color: var(--jp-ui-inverse-font-color0);
+}
+.jp-RenderedText pre .ansi-default-inverse-bg {
+  background-color: var(--jp-inverse-layout-color0);
+}
+
+.jp-RenderedText pre .ansi-bold {
+  font-weight: bold;
+}
+.jp-RenderedText pre .ansi-underline {
+  text-decoration: underline;
+}
+
+.jp-RenderedText[data-mime-type='application/vnd.jupyter.stderr'] {
+  background: var(--jp-rendermime-error-background);
+  padding-top: var(--jp-code-padding);
+}
+
+/*-----------------------------------------------------------------------------
+| RenderedLatex
+|----------------------------------------------------------------------------*/
+
+.jp-RenderedLatex {
+  color: var(--jp-content-font-color1);
+  font-size: var(--jp-content-font-size1);
+  line-height: var(--jp-content-line-height);
+}
+
+/* Left-justify outputs.*/
+.jp-OutputArea-output.jp-RenderedLatex {
+  padding: var(--jp-code-padding);
+  text-align: left;
+}
+
+/*-----------------------------------------------------------------------------
+| RenderedHTML
+|----------------------------------------------------------------------------*/
+
+.jp-RenderedHTMLCommon {
+  color: var(--jp-content-font-color1);
+  font-family: var(--jp-content-font-family);
+  font-size: var(--jp-content-font-size1);
+  line-height: var(--jp-content-line-height);
+  /* Give a bit more R padding on Markdown text to keep line lengths reasonable */
+  padding-right: 20px;
+}
+
+.jp-RenderedHTMLCommon em {
+  font-style: italic;
+}
+
+.jp-RenderedHTMLCommon strong {
+  font-weight: bold;
+}
+
+.jp-RenderedHTMLCommon u {
+  text-decoration: underline;
+}
+
+.jp-RenderedHTMLCommon a:link {
+  text-decoration: none;
+  color: var(--jp-content-link-color);
+}
+
+.jp-RenderedHTMLCommon a:hover {
+  text-decoration: underline;
+  color: var(--jp-content-link-color);
+}
+
+.jp-RenderedHTMLCommon a:visited {
+  text-decoration: none;
+  color: var(--jp-content-link-color);
+}
+
+/* Headings */
+
+.jp-RenderedHTMLCommon h1,
+.jp-RenderedHTMLCommon h2,
+.jp-RenderedHTMLCommon h3,
+.jp-RenderedHTMLCommon h4,
+.jp-RenderedHTMLCommon h5,
+.jp-RenderedHTMLCommon h6 {
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: var(--jp-content-heading-font-weight);
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0
+    var(--jp-content-heading-margin-bottom) 0;
+}
+
+.jp-RenderedHTMLCommon h1:first-child,
+.jp-RenderedHTMLCommon h2:first-child,
+.jp-RenderedHTMLCommon h3:first-child,
+.jp-RenderedHTMLCommon h4:first-child,
+.jp-RenderedHTMLCommon h5:first-child,
+.jp-RenderedHTMLCommon h6:first-child {
+  margin-top: calc(0.5 * var(--jp-content-heading-margin-top));
+}
+
+.jp-RenderedHTMLCommon h1:last-child,
+.jp-RenderedHTMLCommon h2:last-child,
+.jp-RenderedHTMLCommon h3:last-child,
+.jp-RenderedHTMLCommon h4:last-child,
+.jp-RenderedHTMLCommon h5:last-child,
+.jp-RenderedHTMLCommon h6:last-child {
+  margin-bottom: calc(0.5 * var(--jp-content-heading-margin-bottom));
+}
+
+.jp-RenderedHTMLCommon h1 {
+  font-size: var(--jp-content-font-size5);
+}
+
+.jp-RenderedHTMLCommon h2 {
+  font-size: var(--jp-content-font-size4);
+}
+
+.jp-RenderedHTMLCommon h3 {
+  font-size: var(--jp-content-font-size3);
+}
+
+.jp-RenderedHTMLCommon h4 {
+  font-size: var(--jp-content-font-size2);
+}
+
+.jp-RenderedHTMLCommon h5 {
+  font-size: var(--jp-content-font-size1);
+}
+
+.jp-RenderedHTMLCommon h6 {
+  font-size: var(--jp-content-font-size0);
+}
+
+/* Lists */
+
+.jp-RenderedHTMLCommon ul:not(.list-inline),
+.jp-RenderedHTMLCommon ol:not(.list-inline) {
+  padding-left: 2em;
+}
+
+.jp-RenderedHTMLCommon ul {
+  list-style: disc;
+}
+
+.jp-RenderedHTMLCommon ul ul {
+  list-style: square;
+}
+
+.jp-RenderedHTMLCommon ul ul ul {
+  list-style: circle;
+}
+
+.jp-RenderedHTMLCommon ol {
+  list-style: decimal;
+}
+
+.jp-RenderedHTMLCommon ol ol {
+  list-style: upper-alpha;
+}
+
+.jp-RenderedHTMLCommon ol ol ol {
+  list-style: lower-alpha;
+}
+
+.jp-RenderedHTMLCommon ol ol ol ol {
+  list-style: lower-roman;
+}
+
+.jp-RenderedHTMLCommon ol ol ol ol ol {
+  list-style: decimal;
+}
+
+.jp-RenderedHTMLCommon ol,
+.jp-RenderedHTMLCommon ul {
+  margin-bottom: 1em;
+}
+
+.jp-RenderedHTMLCommon ul ul,
+.jp-RenderedHTMLCommon ul ol,
+.jp-RenderedHTMLCommon ol ul,
+.jp-RenderedHTMLCommon ol ol {
+  margin-bottom: 0em;
+}
+
+.jp-RenderedHTMLCommon hr {
+  color: var(--jp-border-color2);
+  background-color: var(--jp-border-color1);
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.jp-RenderedHTMLCommon > pre {
+  margin: 1.5em 2em;
+}
+
+.jp-RenderedHTMLCommon pre,
+.jp-RenderedHTMLCommon code {
+  border: 0;
+  background-color: var(--jp-layout-color0);
+  color: var(--jp-content-font-color1);
+  font-family: var(--jp-code-font-family);
+  font-size: inherit;
+  line-height: var(--jp-code-line-height);
+  padding: 0;
+  white-space: pre-wrap;
+}
+
+.jp-RenderedHTMLCommon :not(pre) > code {
+  background-color: var(--jp-layout-color2);
+  padding: 1px 5px;
+}
+
+/* Tables */
+
+.jp-RenderedHTMLCommon table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  border: none;
+  color: var(--jp-ui-font-color1);
+  font-size: 12px;
+  table-layout: fixed;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.jp-RenderedHTMLCommon thead {
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  vertical-align: bottom;
+}
+
+.jp-RenderedHTMLCommon td,
+.jp-RenderedHTMLCommon th,
+.jp-RenderedHTMLCommon tr {
+  vertical-align: middle;
+  padding: 0.5em 0.5em;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
+  border: none;
+}
+
+.jp-RenderedMarkdown.jp-RenderedHTMLCommon td,
+.jp-RenderedMarkdown.jp-RenderedHTMLCommon th {
+  max-width: none;
+}
+
+:not(.jp-RenderedMarkdown).jp-RenderedHTMLCommon td,
+:not(.jp-RenderedMarkdown).jp-RenderedHTMLCommon th,
+:not(.jp-RenderedMarkdown).jp-RenderedHTMLCommon tr {
+  text-align: right;
+}
+
+.jp-RenderedHTMLCommon th {
+  font-weight: bold;
+}
+
+.jp-RenderedHTMLCommon tbody tr:nth-child(odd) {
+  background: var(--jp-layout-color0);
+}
+
+.jp-RenderedHTMLCommon tbody tr:nth-child(even) {
+  background: var(--jp-rendermime-table-row-background);
+}
+
+.jp-RenderedHTMLCommon tbody tr:hover {
+  background: var(--jp-rendermime-table-row-hover-background);
+}
+
+.jp-RenderedHTMLCommon table {
+  margin-bottom: 1em;
+}
+
+.jp-RenderedHTMLCommon p {
+  text-align: left;
+  margin: 0px;
+}
+
+.jp-RenderedHTMLCommon p {
+  margin-bottom: 1em;
+}
+
+.jp-RenderedHTMLCommon img {
+  -moz-force-broken-image-icon: 1;
+}
+
+/* Restrict to direct children as other images could be nested in other content. */
+.jp-RenderedHTMLCommon > img {
+  display: block;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 1em;
+}
+
+/* Change color behind transparent images if they need it... */
+[data-jp-theme-light='false'] .jp-RenderedImage img.jp-needs-light-background {
+  background-color: var(--jp-inverse-layout-color1);
+}
+[data-jp-theme-light='true'] .jp-RenderedImage img.jp-needs-dark-background {
+  background-color: var(--jp-inverse-layout-color1);
+}
+/* ...or leave it untouched if they don't */
+[data-jp-theme-light='false'] .jp-RenderedImage img.jp-needs-dark-background {
+}
+[data-jp-theme-light='true'] .jp-RenderedImage img.jp-needs-light-background {
+}
+
+.jp-RenderedHTMLCommon img,
+.jp-RenderedImage img,
+.jp-RenderedHTMLCommon svg,
+.jp-RenderedSVG svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.jp-RenderedHTMLCommon img.jp-mod-unconfined,
+.jp-RenderedImage img.jp-mod-unconfined,
+.jp-RenderedHTMLCommon svg.jp-mod-unconfined,
+.jp-RenderedSVG svg.jp-mod-unconfined {
+  max-width: none;
+}
+
+.jp-RenderedHTMLCommon .alert {
+  padding: var(--jp-notebook-padding);
+  border: var(--jp-border-width) solid transparent;
+  border-radius: var(--jp-border-radius);
+  margin-bottom: 1em;
+}
+
+.jp-RenderedHTMLCommon .alert-info {
+  color: var(--jp-info-color0);
+  background-color: var(--jp-info-color3);
+  border-color: var(--jp-info-color2);
+}
+.jp-RenderedHTMLCommon .alert-info hr {
+  border-color: var(--jp-info-color3);
+}
+.jp-RenderedHTMLCommon .alert-info > p:last-child,
+.jp-RenderedHTMLCommon .alert-info > ul:last-child {
+  margin-bottom: 0;
+}
+
+.jp-RenderedHTMLCommon .alert-warning {
+  color: var(--jp-warn-color0);
+  background-color: var(--jp-warn-color3);
+  border-color: var(--jp-warn-color2);
+}
+.jp-RenderedHTMLCommon .alert-warning hr {
+  border-color: var(--jp-warn-color3);
+}
+.jp-RenderedHTMLCommon .alert-warning > p:last-child,
+.jp-RenderedHTMLCommon .alert-warning > ul:last-child {
+  margin-bottom: 0;
+}
+
+.jp-RenderedHTMLCommon .alert-success {
+  color: var(--jp-success-color0);
+  background-color: var(--jp-success-color3);
+  border-color: var(--jp-success-color2);
+}
+.jp-RenderedHTMLCommon .alert-success hr {
+  border-color: var(--jp-success-color3);
+}
+.jp-RenderedHTMLCommon .alert-success > p:last-child,
+.jp-RenderedHTMLCommon .alert-success > ul:last-child {
+  margin-bottom: 0;
+}
+
+.jp-RenderedHTMLCommon .alert-danger {
+  color: var(--jp-error-color0);
+  background-color: var(--jp-error-color3);
+  border-color: var(--jp-error-color2);
+}
+.jp-RenderedHTMLCommon .alert-danger hr {
+  border-color: var(--jp-error-color3);
+}
+.jp-RenderedHTMLCommon .alert-danger > p:last-child,
+.jp-RenderedHTMLCommon .alert-danger > ul:last-child {
+  margin-bottom: 0;
+}
+
+.jp-RenderedHTMLCommon blockquote {
+  margin: 1em 2em;
+  padding: 0 1em;
+  border-left: 5px solid var(--jp-border-color2);
+}
+
+a.jp-InternalAnchorLink {
+  visibility: hidden;
+  margin-left: 8px;
+  color: var(--md-blue-800);
+}
+
+h1:hover .jp-InternalAnchorLink,
+h2:hover .jp-InternalAnchorLink,
+h3:hover .jp-InternalAnchorLink,
+h4:hover .jp-InternalAnchorLink,
+h5:hover .jp-InternalAnchorLink,
+h6:hover .jp-InternalAnchorLink {
+  visibility: visible;
+}
+
+.jp-RenderedHTMLCommon kbd {
+  background-color: var(--jp-rendermime-table-row-background);
+  border: 1px solid var(--jp-border-color0);
+  border-bottom-color: var(--jp-border-color2);
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+  display: inline-block;
+  font-size: 0.8em;
+  line-height: 1em;
+  padding: 0.2em 0.5em;
+}
+
+/* Most direct children of .jp-RenderedHTMLCommon have a margin-bottom of 1.0.
+ * At the bottom of cells this is a bit too much as there is also spacing
+ * between cells. Going all the way to 0 gets too tight between markdown and
+ * code cells.
+ */
+.jp-RenderedHTMLCommon > *:last-child {
+  margin-bottom: 0.5em;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-MimeDocument {
+  outline: none;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Variables
+|----------------------------------------------------------------------------*/
+
+:root {
+  --jp-private-filebrowser-button-height: 28px;
+  --jp-private-filebrowser-button-width: 48px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-FileBrowser {
+  display: flex;
+  flex-direction: column;
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color1);
+  /* This is needed so that all font sizing of children done in ems is
+   * relative to this base size */
+  font-size: var(--jp-ui-font-size1);
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar {
+  border-bottom: none;
+  height: auto;
+  margin: var(--jp-toolbar-header-margin);
+  box-shadow: none;
+}
+
+.jp-BreadCrumbs {
+  flex: 0 0 auto;
+  margin: 4px 12px;
+}
+
+.jp-BreadCrumbs-item {
+  margin: 0px 2px;
+  padding: 0px 2px;
+  border-radius: var(--jp-border-radius);
+  cursor: pointer;
+}
+
+.jp-BreadCrumbs-item:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.jp-BreadCrumbs-item:first-child {
+  margin-left: 0px;
+}
+
+.jp-BreadCrumbs-item.jp-mod-dropTarget {
+  background-color: var(--jp-brand-color2);
+  opacity: 0.7;
+}
+
+/*-----------------------------------------------------------------------------
+| Buttons
+|----------------------------------------------------------------------------*/
+
+.jp-FileBrowser-toolbar.jp-Toolbar {
+  padding: 0px;
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar {
+  justify-content: space-evenly;
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item {
+  flex: 1;
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar .jp-ToolbarButtonComponent {
+  width: 100%;
+}
+
+/*-----------------------------------------------------------------------------
+| DirListing
+|----------------------------------------------------------------------------*/
+
+.jp-DirListing {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  outline: 0;
+}
+
+.jp-DirListing-header {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+  border-top: var(--jp-border-width) solid var(--jp-border-color2);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  z-index: 2;
+}
+
+.jp-DirListing-headerItem {
+  padding: 4px 12px 2px 12px;
+  font-weight: 500;
+}
+
+.jp-DirListing-headerItem:hover {
+  background: var(--jp-layout-color2);
+}
+
+.jp-DirListing-headerItem.jp-id-name {
+  flex: 1 0 84px;
+}
+
+.jp-DirListing-headerItem.jp-id-modified {
+  flex: 0 0 112px;
+  border-left: var(--jp-border-width) solid var(--jp-border-color2);
+  text-align: right;
+}
+
+.jp-DirListing-narrow .jp-id-modified,
+.jp-DirListing-narrow .jp-DirListing-itemModified {
+  display: none;
+}
+
+.jp-DirListing-headerItem.jp-mod-selected {
+  font-weight: 600;
+}
+
+/* increase specificity to override bundled default */
+.jp-DirListing-content {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  overflow: auto;
+  background-color: var(--jp-layout-color1);
+}
+
+/* Style the directory listing content when a user drops a file to upload */
+.jp-DirListing.jp-mod-native-drop .jp-DirListing-content {
+  outline: 5px dashed rgba(128, 128, 128, 0.5);
+  outline-offset: -10px;
+  cursor: copy;
+}
+
+.jp-DirListing-item {
+  display: flex;
+  flex-direction: row;
+  padding: 4px 12px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.jp-DirListing-item.jp-mod-selected {
+  color: white;
+  background: var(--jp-brand-color1);
+}
+
+.jp-DirListing-item.jp-mod-dropTarget {
+  background: var(--jp-brand-color3);
+}
+
+.jp-DirListing-item:hover:not(.jp-mod-selected) {
+  background: var(--jp-layout-color2);
+}
+
+.jp-DirListing-itemIcon {
+  flex: 0 0 20px;
+  margin-right: 4px;
+}
+
+.jp-DirListing-itemText {
+  flex: 1 0 64px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  user-select: none;
+}
+
+.jp-DirListing-itemModified {
+  flex: 0 0 125px;
+  text-align: right;
+}
+
+.jp-DirListing-editor {
+  flex: 1 0 64px;
+  outline: none;
+  border: none;
+}
+
+.jp-DirListing-item.jp-mod-running .jp-DirListing-itemIcon:before {
+  color: limegreen;
+  content: '\25CF';
+  font-size: 8px;
+  position: absolute;
+  left: -8px;
+}
+
+.jp-DirListing-item.lm-mod-drag-image,
+.jp-DirListing-item.jp-mod-selected.lm-mod-drag-image {
+  font-size: var(--jp-ui-font-size1);
+  padding-left: 4px;
+  margin-left: 4px;
+  width: 160px;
+  background-color: var(--jp-ui-inverse-font-color2);
+  box-shadow: var(--jp-elevation-z2);
+  border-radius: 0px;
+  color: var(--jp-ui-font-color1);
+  transform: translateX(-40%) translateY(-58%);
+}
+
+.jp-DirListing-deadSpace {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  overflow: auto;
+  background-color: var(--jp-layout-color1);
+}
+
+.jp-Document {
+  min-width: 120px;
+  min-height: 120px;
+  outline: none;
+}
+
+.jp-FileDialog.jp-mod-conflict input {
+  color: red;
+}
+
+.jp-FileDialog .jp-new-name-title {
+  margin-top: 12px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Private CSS variables
+|----------------------------------------------------------------------------*/
+
+:root {
+}
+
+/*-----------------------------------------------------------------------------
+| Main OutputArea
+| OutputArea has a list of Outputs
+|----------------------------------------------------------------------------*/
+
+.jp-OutputArea {
+  overflow-y: auto;
+}
+
+.jp-OutputArea-child {
+  display: flex;
+  flex-direction: row;
+}
+
+.jp-OutputPrompt {
+  flex: 0 0 var(--jp-cell-prompt-width);
+  color: var(--jp-cell-outprompt-font-color);
+  font-family: var(--jp-cell-prompt-font-family);
+  padding: var(--jp-code-padding);
+  letter-spacing: var(--jp-cell-prompt-letter-spacing);
+  line-height: var(--jp-code-line-height);
+  font-size: var(--jp-code-font-size);
+  border: var(--jp-border-width) solid transparent;
+  opacity: var(--jp-cell-prompt-opacity);
+  /* Right align prompt text, don't wrap to handle large prompt numbers */
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Disable text selection */
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.jp-OutputArea-output {
+  height: auto;
+  overflow: auto;
+  user-select: text;
+  -moz-user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
+}
+
+.jp-OutputArea-child .jp-OutputArea-output {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+/**
+ * Isolated output.
+ */
+.jp-OutputArea-output.jp-mod-isolated {
+  width: 100%;
+  display: block;
+}
+
+/*
+When drag events occur, `p-mod-override-cursor` is added to the body.
+Because iframes steal all cursor events, the following two rules are necessary
+to suppress pointer events while resize drags are occurring. There may be a
+better solution to this problem.
+*/
+body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated {
+  position: relative;
+}
+
+body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: transparent;
+}
+
+/* pre */
+
+.jp-OutputArea-output pre {
+  border: none;
+  margin: 0px;
+  padding: 0px;
+  overflow-x: auto;
+  overflow-y: auto;
+  word-break: break-all;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+/* tables */
+
+.jp-OutputArea-output.jp-RenderedHTMLCommon table {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* description lists */
+
+.jp-OutputArea-output dl,
+.jp-OutputArea-output dt,
+.jp-OutputArea-output dd {
+  display: block;
+}
+
+.jp-OutputArea-output dl {
+  width: 100%;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+}
+
+.jp-OutputArea-output dt {
+  font-weight: bold;
+  float: left;
+  width: 20%;
+  padding: 0;
+  margin: 0;
+}
+
+.jp-OutputArea-output dd {
+  float: left;
+  width: 80%;
+  padding: 0;
+  margin: 0;
+}
+
+/* Hide the gutter in case of
+ *  - nested output areas (e.g. in the case of output widgets)
+ *  - mirrored output areas
+ */
+.jp-OutputArea .jp-OutputArea .jp-OutputArea-prompt {
+  display: none;
+}
+
+/*-----------------------------------------------------------------------------
+| executeResult is added to any Output-result for the display of the object
+| returned by a cell
+|----------------------------------------------------------------------------*/
+
+.jp-OutputArea-output.jp-OutputArea-executeResult {
+  margin-left: 0px;
+  flex: 1 1 auto;
+}
+
+.jp-OutputArea-executeResult.jp-RenderedText {
+  padding-top: var(--jp-code-padding);
+}
+
+/*-----------------------------------------------------------------------------
+| The Stdin output
+|----------------------------------------------------------------------------*/
+
+.jp-OutputArea-stdin {
+  line-height: var(--jp-code-line-height);
+  padding-top: var(--jp-code-padding);
+  display: flex;
+}
+
+.jp-Stdin-prompt {
+  color: var(--jp-content-font-color0);
+  padding-right: var(--jp-code-padding);
+  vertical-align: baseline;
+  flex: 0 0 auto;
+}
+
+.jp-Stdin-input {
+  font-family: var(--jp-code-font-family);
+  font-size: inherit;
+  color: inherit;
+  background-color: inherit;
+  width: 42%;
+  min-width: 200px;
+  /* make sure input baseline aligns with prompt */
+  vertical-align: baseline;
+  /* padding + margin = 0.5em between prompt and cursor */
+  padding: 0em 0.25em;
+  margin: 0em 0.25em;
+  flex: 0 0 70%;
+}
+
+.jp-Stdin-input:focus {
+  box-shadow: none;
+}
+
+/*-----------------------------------------------------------------------------
+| Output Area View
+|----------------------------------------------------------------------------*/
+
+.jp-LinkedOutputView .jp-OutputArea {
+  height: 100%;
+  display: block;
+}
+
+.jp-LinkedOutputView .jp-OutputArea-output:only-child {
+  height: 100%;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-Collapser {
+  flex: 0 0 var(--jp-cell-collapser-width);
+  padding: 0px;
+  margin: 0px;
+  border: none;
+  outline: none;
+  background: transparent;
+  border-radius: var(--jp-border-radius);
+  opacity: 1;
+}
+
+.jp-Collapser-child {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  /* height: 100% doesn't work because the height of its parent is computed from content */
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Header/Footer
+|----------------------------------------------------------------------------*/
+
+/* Hidden by zero height by default */
+.jp-CellHeader,
+.jp-CellFooter {
+  height: 0px;
+  width: 100%;
+  padding: 0px;
+  margin: 0px;
+  border: none;
+  outline: none;
+  background: transparent;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Input
+|----------------------------------------------------------------------------*/
+
+/* All input areas */
+.jp-InputArea {
+  display: flex;
+  flex-direction: row;
+}
+
+.jp-InputArea-editor {
+  flex: 1 1 auto;
+}
+
+.jp-InputArea-editor {
+  /* This is the non-active, default styling */
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  border-radius: 0px;
+  background: var(--jp-cell-editor-background);
+}
+
+.jp-InputPrompt {
+  flex: 0 0 var(--jp-cell-prompt-width);
+  color: var(--jp-cell-inprompt-font-color);
+  font-family: var(--jp-cell-prompt-font-family);
+  padding: var(--jp-code-padding);
+  letter-spacing: var(--jp-cell-prompt-letter-spacing);
+  opacity: var(--jp-cell-prompt-opacity);
+  line-height: var(--jp-code-line-height);
+  font-size: var(--jp-code-font-size);
+  border: var(--jp-border-width) solid transparent;
+  opacity: var(--jp-cell-prompt-opacity);
+  /* Right align prompt text, don't wrap to handle large prompt numbers */
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Disable text selection */
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Placeholder
+|----------------------------------------------------------------------------*/
+
+.jp-Placeholder {
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
+}
+
+.jp-Placeholder-prompt {
+  box-sizing: border-box;
+}
+
+.jp-Placeholder-content {
+  flex: 1 1 auto;
+  border: none;
+  background: transparent;
+  height: 20px;
+  box-sizing: border-box;
+}
+
+.jp-Placeholder-content .jp-MoreHorizIcon {
+  width: 32px;
+  height: 16px;
+  border: 1px solid transparent;
+  border-radius: var(--jp-border-radius);
+}
+
+.jp-Placeholder-content .jp-MoreHorizIcon:hover {
+  border: 1px solid var(--jp-border-color1);
+  box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.25);
+  background-color: var(--jp-layout-color0);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Private CSS variables
+|----------------------------------------------------------------------------*/
+
+:root {
+  --jp-private-cell-scrolling-output-offset: 5px;
+}
+
+/*-----------------------------------------------------------------------------
+| Cell
+|----------------------------------------------------------------------------*/
+
+.jp-Cell {
+  padding: var(--jp-cell-padding);
+  margin: 0px;
+  border: none;
+  outline: none;
+  background: transparent;
+}
+
+/*-----------------------------------------------------------------------------
+| Common input/output
+|----------------------------------------------------------------------------*/
+
+.jp-Cell-inputWrapper,
+.jp-Cell-outputWrapper {
+  display: flex;
+  flex-direction: row;
+  padding: 0px;
+  margin: 0px;
+  /* Added to reveal the box-shadow on the input and output collapsers. */
+  overflow: visible;
+}
+
+/* Only input/output areas inside cells */
+.jp-Cell-inputArea,
+.jp-Cell-outputArea {
+  flex: 1 1 auto;
+}
+
+/*-----------------------------------------------------------------------------
+| Collapser
+|----------------------------------------------------------------------------*/
+
+/* Make the output collapser disappear when there is not output, but do so
+ * in a manner that leaves it in the layout and preserves its width.
+ */
+.jp-Cell.jp-mod-noOutputs .jp-Cell-outputCollapser {
+  border: none !important;
+  background: transparent !important;
+}
+
+.jp-Cell:not(.jp-mod-noOutputs) .jp-Cell-outputCollapser {
+  min-height: var(--jp-cell-collapser-min-height);
+}
+
+/*-----------------------------------------------------------------------------
+| Output
+|----------------------------------------------------------------------------*/
+
+/* Put a space between input and output when there IS output */
+.jp-Cell:not(.jp-mod-noOutputs) .jp-Cell-outputWrapper {
+  margin-top: 5px;
+}
+
+/* Text output with the Out[] prompt needs a top padding to match the
+ * alignment of the Out[] prompt itself.
+ */
+.jp-OutputArea-executeResult .jp-RenderedText.jp-OutputArea-output {
+  padding-top: var(--jp-code-padding);
+}
+
+.jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
+  overflow-y: auto;
+  max-height: 200px;
+  box-shadow: inset 0 0 6px 2px rgba(0, 0, 0, 0.3);
+  margin-left: var(--jp-private-cell-scrolling-output-offset);
+}
+
+.jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {
+  flex: 0 0
+    calc(
+      var(--jp-cell-prompt-width) -
+        var(--jp-private-cell-scrolling-output-offset)
+    );
+}
+
+/*-----------------------------------------------------------------------------
+| CodeCell
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| MarkdownCell
+|----------------------------------------------------------------------------*/
+
+.jp-MarkdownOutput {
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: var(--jp-code-padding);
+}
+
+.jp-MarkdownOutput.jp-RenderedHTMLCommon {
+  overflow: auto;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Variables
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+
+/*-----------------------------------------------------------------------------
+| Styles
+|----------------------------------------------------------------------------*/
+
+.jp-NotebookPanel-toolbar {
+  padding: 2px;
+}
+
+.jp-Toolbar-item.jp-Notebook-toolbarCellType .jp-select-wrapper.jp-mod-focused {
+  border: none;
+  box-shadow: none;
+}
+
+.jp-Notebook-toolbarCellTypeDropdown select {
+  height: 24px;
+  font-size: var(--jp-ui-font-size1);
+  line-height: 14px;
+  border-radius: 0;
+  display: block;
+}
+
+.jp-Notebook-toolbarCellTypeDropdown span {
+  top: 5px !important;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Private CSS variables
+|----------------------------------------------------------------------------*/
+
+:root {
+  --jp-private-notebook-dragImage-width: 304px;
+  --jp-private-notebook-dragImage-height: 36px;
+  --jp-private-notebook-selected-color: var(--md-blue-400);
+  --jp-private-notebook-active-color: var(--md-green-400);
+}
+
+/*-----------------------------------------------------------------------------
+| Imports
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Notebook
+|----------------------------------------------------------------------------*/
+
+.jp-NotebookPanel {
+  display: block;
+  height: 100%;
+}
+
+.jp-NotebookPanel.jp-Document {
+  min-width: 240px;
+  min-height: 120px;
+}
+
+.jp-Notebook {
+  padding: var(--jp-notebook-padding);
+  outline: none;
+  overflow: auto;
+  background: var(--jp-layout-color0);
+}
+
+.jp-Notebook.jp-mod-scrollPastEnd::after {
+  display: block;
+  content: '';
+  min-height: var(--jp-notebook-scroll-padding);
+}
+
+.jp-Notebook .jp-Cell {
+  overflow: visible;
+}
+
+.jp-Notebook .jp-Cell .jp-InputPrompt {
+  cursor: move;
+}
+
+/*-----------------------------------------------------------------------------
+| Notebook state related styling
+|
+| The notebook and cells each have states, here are the possibilities:
+|
+| - Notebook
+|   - Command
+|   - Edit
+| - Cell
+|   - None
+|   - Active (only one can be active)
+|   - Selected (the cells actions are applied to)
+|   - Multiselected (when multiple selected, the cursor)
+|   - No outputs
+|----------------------------------------------------------------------------*/
+
+/* Command or edit modes */
+
+.jp-Notebook .jp-Cell:not(.jp-mod-active) .jp-InputPrompt {
+  opacity: var(--jp-cell-prompt-not-active-opacity);
+  color: var(--jp-cell-prompt-not-active-font-color);
+}
+
+.jp-Notebook .jp-Cell:not(.jp-mod-active) .jp-OutputPrompt {
+  opacity: var(--jp-cell-prompt-not-active-opacity);
+  color: var(--jp-cell-prompt-not-active-font-color);
+}
+
+/* cell is active */
+.jp-Notebook .jp-Cell.jp-mod-active .jp-Collapser {
+  background: var(--jp-brand-color1);
+}
+
+/* collapser is hovered */
+.jp-Notebook .jp-Cell .jp-Collapser:hover {
+  box-shadow: var(--jp-elevation-z2);
+  background: var(--jp-brand-color1);
+  opacity: var(--jp-cell-collapser-not-active-hover-opacity);
+}
+
+/* cell is active and collapser is hovered */
+.jp-Notebook .jp-Cell.jp-mod-active .jp-Collapser:hover {
+  background: var(--jp-brand-color0);
+  opacity: 1;
+}
+
+/* Command mode */
+
+.jp-Notebook.jp-mod-commandMode .jp-Cell.jp-mod-selected {
+  background: var(--jp-notebook-multiselected-color);
+}
+
+.jp-Notebook.jp-mod-commandMode
+  .jp-Cell.jp-mod-active.jp-mod-selected:not(.jp-mod-multiSelected) {
+  background: transparent;
+}
+
+/* Edit mode */
+
+.jp-Notebook.jp-mod-editMode .jp-Cell.jp-mod-active .jp-InputArea-editor {
+  border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
+  background-color: var(--jp-cell-editor-active-background);
+}
+
+/*-----------------------------------------------------------------------------
+| Notebook drag and drop
+|----------------------------------------------------------------------------*/
+
+.jp-Notebook-cell.jp-mod-dropSource {
+  opacity: 0.5;
+}
+
+.jp-Notebook-cell.jp-mod-dropTarget,
+.jp-Notebook.jp-mod-commandMode
+  .jp-Notebook-cell.jp-mod-active.jp-mod-selected.jp-mod-dropTarget {
+  border-top-color: var(--jp-private-notebook-selected-color);
+  border-top-style: solid;
+  border-top-width: 2px;
+}
+
+.jp-dragImage {
+  display: flex;
+  flex-direction: row;
+  width: var(--jp-private-notebook-dragImage-width);
+  height: var(--jp-private-notebook-dragImage-height);
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  background: var(--jp-cell-editor-background);
+  overflow: visible;
+}
+
+.jp-dragImage-singlePrompt {
+  box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.12);
+}
+
+.jp-dragImage .jp-dragImage-content {
+  flex: 1 1 auto;
+  z-index: 2;
+  font-size: var(--jp-code-font-size);
+  font-family: var(--jp-code-font-family);
+  line-height: var(--jp-code-line-height);
+  padding: var(--jp-code-padding);
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  background: var(--jp-cell-editor-background-color);
+  color: var(--jp-content-font-color3);
+  text-align: left;
+  margin: 4px 4px 4px 0px;
+}
+
+.jp-dragImage .jp-dragImage-prompt {
+  flex: 0 0 auto;
+  min-width: 36px;
+  color: var(--jp-cell-inprompt-font-color);
+  padding: var(--jp-code-padding);
+  padding-left: 12px;
+  font-family: var(--jp-cell-prompt-font-family);
+  letter-spacing: var(--jp-cell-prompt-letter-spacing);
+  line-height: 1.9;
+  font-size: var(--jp-code-font-size);
+  border: var(--jp-border-width) solid transparent;
+}
+
+.jp-dragImage-multipleBack {
+  z-index: -1;
+  position: absolute;
+  height: 32px;
+  width: 300px;
+  top: 8px;
+  left: 8px;
+  background: var(--jp-layout-color2);
+  border: var(--jp-border-width) solid var(--jp-input-border-color);
+  box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.12);
+}
+
+/*-----------------------------------------------------------------------------
+| Cell toolbar
+|----------------------------------------------------------------------------*/
+
+.jp-NotebookTools {
+  display: block;
+  min-width: var(--jp-sidebar-min-width);
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color1);
+  /* This is needed so that all font sizing of children done in ems is
+    * relative to this base size */
+  font-size: var(--jp-ui-font-size1);
+  overflow: auto;
+}
+
+.jp-NotebookTools-tool {
+  padding: 0px 12px 0 12px;
+}
+
+.jp-ActiveCellTool {
+  padding: 12px;
+  background-color: var(--jp-layout-color1);
+  border-top: none !important;
+}
+
+.jp-ActiveCellTool .jp-InputArea-prompt {
+  flex: 0 0 auto;
+  padding-left: 0px;
+}
+
+.jp-ActiveCellTool .jp-InputArea-editor {
+  flex: 1 1 auto;
+  background: var(--jp-cell-editor-background);
+  border-color: var(--jp-cell-editor-border-color);
+}
+
+.jp-ActiveCellTool .jp-InputArea-editor .CodeMirror {
+  background: transparent;
+}
+
+.jp-MetadataEditorTool {
+  flex-direction: column;
+  padding: 12px 0px 12px 0px;
+}
+
+.jp-RankedPanel > :not(:first-child) {
+  margin-top: 12px;
+}
+
+.jp-KeySelector select.jp-mod-styled {
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color0);
+  border: var(--jp-border-width) solid var(--jp-border-color1);
+}
+
+.jp-KeySelector label,
+.jp-MetadataEditorTool label {
+  line-height: 1.4;
+}
+
+/*-----------------------------------------------------------------------------
+| Presentation Mode (.jp-mod-presentationMode)
+|----------------------------------------------------------------------------*/
+
+.jp-mod-presentationMode .jp-Notebook {
+  --jp-content-font-size1: var(--jp-content-presentation-font-size1);
+  --jp-code-font-size: var(--jp-code-presentation-font-size);
+}
+
+.jp-mod-presentationMode .jp-Notebook .jp-Cell .jp-InputPrompt,
+.jp-mod-presentationMode .jp-Notebook .jp-Cell .jp-OutputPrompt {
+  flex: 0 0 110px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+

--- a/share/jupyter/nbconvert/templates/presto/static/index.css
+++ b/share/jupyter/nbconvert/templates/presto/static/index.css
@@ -183,8 +183,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-Widget, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Widget, /* </DEPRECATED> */
 .lm-Widget {
   box-sizing: border-box;
   position: relative;
@@ -192,8 +192,8 @@
   cursor: default;
 }
 
-
-/* <DEPRECATED> */ .p-Widget.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Widget.p-mod-hidden, /* </DEPRECATED> */
 .lm-Widget.lm-mod-hidden {
   display: none !important;
 }
@@ -207,8 +207,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-CommandPalette, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette, /* </DEPRECATED> */
 .lm-CommandPalette {
   display: flex;
   flex-direction: column;
@@ -218,14 +218,14 @@
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-search, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-search, /* </DEPRECATED> */
 .lm-CommandPalette-search {
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-content, /* </DEPRECATED> */
 .lm-CommandPalette-content {
   flex: 1 1 auto;
   margin: 0;
@@ -235,42 +235,42 @@
   list-style-type: none;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-header, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-header, /* </DEPRECATED> */
 .lm-CommandPalette-header {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-item, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-item, /* </DEPRECATED> */
 .lm-CommandPalette-item {
   display: flex;
   flex-direction: row;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemIcon, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemIcon, /* </DEPRECATED> */
 .lm-CommandPalette-itemIcon {
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemContent, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemContent, /* </DEPRECATED> */
 .lm-CommandPalette-itemContent {
   flex: 1 1 auto;
   overflow: hidden;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemShortcut, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemShortcut, /* </DEPRECATED> */
 .lm-CommandPalette-itemShortcut {
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemLabel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemLabel, /* </DEPRECATED> */
 .lm-CommandPalette-itemLabel {
   overflow: hidden;
   white-space: nowrap;
@@ -286,38 +286,38 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-DockPanel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel, /* </DEPRECATED> */
 .lm-DockPanel {
   z-index: 0;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-widget, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-widget, /* </DEPRECATED> */
 .lm-DockPanel-widget {
   z-index: 0;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-tabBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-tabBar, /* </DEPRECATED> */
 .lm-DockPanel-tabBar {
   z-index: 1;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-handle, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-handle, /* </DEPRECATED> */
 .lm-DockPanel-handle {
   z-index: 2;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-handle.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-handle.p-mod-hidden, /* </DEPRECATED> */
 .lm-DockPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-handle:after, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-handle:after, /* </DEPRECATED> */
 .lm-DockPanel-handle:after {
   position: absolute;
   top: 0;
@@ -327,7 +327,6 @@
   content: '';
 }
 
-
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='horizontal'],
 /* </DEPRECATED> */
@@ -335,14 +334,12 @@
   cursor: ew-resize;
 }
 
-
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='vertical'],
 /* </DEPRECATED> */
 .lm-DockPanel-handle[data-orientation='vertical'] {
   cursor: ns-resize;
 }
-
 
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='horizontal']:after,
@@ -353,7 +350,6 @@
   transform: translateX(-50%);
 }
 
-
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='vertical']:after,
 /* </DEPRECATED> */
@@ -363,16 +359,16 @@
   transform: translateY(-50%);
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-overlay, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-overlay, /* </DEPRECATED> */
 .lm-DockPanel-overlay {
   z-index: 3;
   box-sizing: border-box;
   pointer-events: none;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-overlay.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-overlay.p-mod-hidden, /* </DEPRECATED> */
 .lm-DockPanel-overlay.lm-mod-hidden {
   display: none !important;
 }
@@ -386,8 +382,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-Menu, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu, /* </DEPRECATED> */
 .lm-Menu {
   z-index: 10000;
   position: absolute;
@@ -401,8 +397,8 @@
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-content, /* </DEPRECATED> */
 .lm-Menu-content {
   margin: 0;
   padding: 0;
@@ -410,12 +406,11 @@
   list-style-type: none;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-item, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-item, /* </DEPRECATED> */
 .lm-Menu-item {
   display: table-row;
 }
-
 
 /* <DEPRECATED> */
 .p-Menu-item.p-mod-hidden,
@@ -425,7 +420,6 @@
 .lm-Menu-item.lm-mod-collapsed {
   display: none !important;
 }
-
 
 /* <DEPRECATED> */
 .p-Menu-itemIcon,
@@ -437,15 +431,15 @@
   text-align: center;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-itemLabel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-itemLabel, /* </DEPRECATED> */
 .lm-Menu-itemLabel {
   display: table-cell;
   text-align: left;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-itemShortcut, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-itemShortcut, /* </DEPRECATED> */
 .lm-Menu-itemShortcut {
   display: table-cell;
   text-align: right;
@@ -460,8 +454,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-MenuBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-MenuBar, /* </DEPRECATED> */
 .lm-MenuBar {
   outline: none;
   -webkit-user-select: none;
@@ -470,8 +464,8 @@
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-MenuBar-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-MenuBar-content, /* </DEPRECATED> */
 .lm-MenuBar-content {
   margin: 0;
   padding: 0;
@@ -480,12 +474,11 @@
   list-style-type: none;
 }
 
-
-/* <DEPRECATED> */ .p--MenuBar-item, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p--MenuBar-item, /* </DEPRECATED> */
 .lm-MenuBar-item {
   box-sizing: border-box;
 }
-
 
 /* <DEPRECATED> */
 .p-MenuBar-itemIcon,
@@ -505,8 +498,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-ScrollBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar, /* </DEPRECATED> */
 .lm-ScrollBar {
   display: flex;
   -webkit-user-select: none;
@@ -515,14 +508,12 @@
   user-select: none;
 }
 
-
 /* <DEPRECATED> */
 .p-ScrollBar[data-orientation='horizontal'],
 /* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
-
 
 /* <DEPRECATED> */
 .p-ScrollBar[data-orientation='vertical'],
@@ -531,15 +522,15 @@
   flex-direction: column;
 }
 
-
-/* <DEPRECATED> */ .p-ScrollBar-button, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar-button, /* </DEPRECATED> */
 .lm-ScrollBar-button {
   box-sizing: border-box;
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-ScrollBar-track, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar-track, /* </DEPRECATED> */
 .lm-ScrollBar-track {
   box-sizing: border-box;
   position: relative;
@@ -547,8 +538,8 @@
   flex: 1 1 auto;
 }
 
-
-/* <DEPRECATED> */ .p-ScrollBar-thumb, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar-thumb, /* </DEPRECATED> */
 .lm-ScrollBar-thumb {
   box-sizing: border-box;
   position: absolute;
@@ -563,26 +554,26 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-SplitPanel-child, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-child, /* </DEPRECATED> */
 .lm-SplitPanel-child {
   z-index: 0;
 }
 
-
-/* <DEPRECATED> */ .p-SplitPanel-handle, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-handle, /* </DEPRECATED> */
 .lm-SplitPanel-handle {
   z-index: 1;
 }
 
-
-/* <DEPRECATED> */ .p-SplitPanel-handle.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-handle.p-mod-hidden, /* </DEPRECATED> */
 .lm-SplitPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
-
-/* <DEPRECATED> */ .p-SplitPanel-handle:after, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-handle:after, /* </DEPRECATED> */
 .lm-SplitPanel-handle:after {
   position: absolute;
   top: 0;
@@ -592,7 +583,6 @@
   content: '';
 }
 
-
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle,
 /* </DEPRECATED> */
@@ -600,14 +590,12 @@
   cursor: ew-resize;
 }
 
-
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle,
 /* </DEPRECATED> */
 .lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle {
   cursor: ns-resize;
 }
-
 
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle:after,
@@ -617,7 +605,6 @@
   min-width: 8px;
   transform: translateX(-50%);
 }
-
 
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle:after,
@@ -637,8 +624,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-TabBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar, /* </DEPRECATED> */
 .lm-TabBar {
   display: flex;
   -webkit-user-select: none;
@@ -647,20 +634,20 @@
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar[data-orientation='horizontal'], /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='horizontal'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar[data-orientation='vertical'], /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='vertical'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='vertical'] {
   flex-direction: column;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-content, /* </DEPRECATED> */
 .lm-TabBar-content {
   margin: 0;
   padding: 0;
@@ -669,14 +656,12 @@
   list-style-type: none;
 }
 
-
 /* <DEPRECATED> */
 .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content,
 /* </DEPRECATED> */
 .lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-content {
   flex-direction: row;
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar[data-orientation='vertical'] > .p-TabBar-content,
@@ -685,15 +670,14 @@
   flex-direction: column;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-tab, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar-tab {
   display: flex;
   flex-direction: row;
   box-sizing: border-box;
   overflow: hidden;
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar-tabIcon,
@@ -704,26 +688,25 @@
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-tabLabel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-tabLabel, /* </DEPRECATED> */
 .lm-TabBar-tabLabel {
   flex: 1 1 auto;
   overflow: hidden;
   white-space: nowrap;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-hidden {
   display: none !important;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar.p-mod-dragging .p-TabBar-tab, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging .p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab {
   position: relative;
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar.p-mod-dragging[data-orientation='horizontal'] .p-TabBar-tab,
@@ -733,7 +716,6 @@
   transition: left 150ms ease;
 }
 
-
 /* <DEPRECATED> */
 .p-TabBar.p-mod-dragging[data-orientation='vertical'] .p-TabBar-tab,
 /* </DEPRECATED> */
@@ -741,7 +723,6 @@
   top: 0;
   transition: top 150ms ease;
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging
@@ -759,14 +740,14 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-TabPanel-tabBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabPanel-tabBar, /* </DEPRECATED> */
 .lm-TabPanel-tabBar {
   z-index: 1;
 }
 
-
-/* <DEPRECATED> */ .p-TabPanel-stackedPanel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabPanel-stackedPanel, /* </DEPRECATED> */
 .lm-TabPanel-stackedPanel {
   z-index: 0;
 }
@@ -787,7925 +768,11792 @@ Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
 Licensed under the Apache License, Version 2.0.
 
 */
-html{
-  -webkit-box-sizing:border-box;
-          box-sizing:border-box; }
+html {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
 
 *,
 *::before,
-*::after{
-  -webkit-box-sizing:inherit;
-          box-sizing:inherit; }
+*::after {
+  -webkit-box-sizing: inherit;
+  box-sizing: inherit;
+}
 
-body{
-  text-transform:none;
-  line-height:1.28581;
-  letter-spacing:0;
-  font-size:14px;
-  font-weight:400;
-  color:#182026;
-  font-family:-apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", "Icons16", sans-serif; }
+body {
+  text-transform: none;
+  line-height: 1.28581;
+  letter-spacing: 0;
+  font-size: 14px;
+  font-weight: 400;
+  color: #182026;
+  font-family: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', 'Icons16',
+    sans-serif;
+}
 
-p{
-  margin-top:0;
-  margin-bottom:10px; }
+p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
 
-small{
-  font-size:12px; }
+small {
+  font-size: 12px;
+}
 
-strong{
-  font-weight:600; }
+strong {
+  font-weight: 600;
+}
 
-::-moz-selection{
-  background:rgba(125, 188, 255, 0.6); }
+::-moz-selection {
+  background: rgba(125, 188, 255, 0.6);
+}
 
-::selection{
-  background:rgba(125, 188, 255, 0.6); }
-.bp3-heading{
-  color:#182026;
-  font-weight:600;
-  margin:0 0 10px;
-  padding:0; }
-  .bp3-dark .bp3-heading{
-    color:#f5f8fa; }
+::selection {
+  background: rgba(125, 188, 255, 0.6);
+}
+.bp3-heading {
+  color: #182026;
+  font-weight: 600;
+  margin: 0 0 10px;
+  padding: 0;
+}
+.bp3-dark .bp3-heading {
+  color: #f5f8fa;
+}
 
-h1.bp3-heading, .bp3-running-text h1{
-  line-height:40px;
-  font-size:36px; }
+h1.bp3-heading,
+.bp3-running-text h1 {
+  line-height: 40px;
+  font-size: 36px;
+}
 
-h2.bp3-heading, .bp3-running-text h2{
-  line-height:32px;
-  font-size:28px; }
+h2.bp3-heading,
+.bp3-running-text h2 {
+  line-height: 32px;
+  font-size: 28px;
+}
 
-h3.bp3-heading, .bp3-running-text h3{
-  line-height:25px;
-  font-size:22px; }
+h3.bp3-heading,
+.bp3-running-text h3 {
+  line-height: 25px;
+  font-size: 22px;
+}
 
-h4.bp3-heading, .bp3-running-text h4{
-  line-height:21px;
-  font-size:18px; }
+h4.bp3-heading,
+.bp3-running-text h4 {
+  line-height: 21px;
+  font-size: 18px;
+}
 
-h5.bp3-heading, .bp3-running-text h5{
-  line-height:19px;
-  font-size:16px; }
+h5.bp3-heading,
+.bp3-running-text h5 {
+  line-height: 19px;
+  font-size: 16px;
+}
 
-h6.bp3-heading, .bp3-running-text h6{
-  line-height:16px;
-  font-size:14px; }
-.bp3-ui-text{
-  text-transform:none;
-  line-height:1.28581;
-  letter-spacing:0;
-  font-size:14px;
-  font-weight:400; }
+h6.bp3-heading,
+.bp3-running-text h6 {
+  line-height: 16px;
+  font-size: 14px;
+}
+.bp3-ui-text {
+  text-transform: none;
+  line-height: 1.28581;
+  letter-spacing: 0;
+  font-size: 14px;
+  font-weight: 400;
+}
 
-.bp3-monospace-text{
-  text-transform:none;
-  font-family:monospace; }
+.bp3-monospace-text {
+  text-transform: none;
+  font-family: monospace;
+}
 
-.bp3-text-muted{
-  color:#5c7080; }
-  .bp3-dark .bp3-text-muted{
-    color:#a7b6c2; }
+.bp3-text-muted {
+  color: #5c7080;
+}
+.bp3-dark .bp3-text-muted {
+  color: #a7b6c2;
+}
 
-.bp3-text-disabled{
-  color:rgba(92, 112, 128, 0.6); }
-  .bp3-dark .bp3-text-disabled{
-    color:rgba(167, 182, 194, 0.6); }
+.bp3-text-disabled {
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-dark .bp3-text-disabled {
+  color: rgba(167, 182, 194, 0.6);
+}
 
-.bp3-text-overflow-ellipsis{
-  overflow:hidden;
-  text-overflow:ellipsis;
-  white-space:nowrap;
-  word-wrap:normal; }
-.bp3-running-text{
-  line-height:1.5;
-  font-size:14px; }
-  .bp3-running-text h1{
-    color:#182026;
-    font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
-    .bp3-dark .bp3-running-text h1{
-      color:#f5f8fa; }
-  .bp3-running-text h2{
-    color:#182026;
-    font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
-    .bp3-dark .bp3-running-text h2{
-      color:#f5f8fa; }
-  .bp3-running-text h3{
-    color:#182026;
-    font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
-    .bp3-dark .bp3-running-text h3{
-      color:#f5f8fa; }
-  .bp3-running-text h4{
-    color:#182026;
-    font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
-    .bp3-dark .bp3-running-text h4{
-      color:#f5f8fa; }
-  .bp3-running-text h5{
-    color:#182026;
-    font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
-    .bp3-dark .bp3-running-text h5{
-      color:#f5f8fa; }
-  .bp3-running-text h6{
-    color:#182026;
-    font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
-    .bp3-dark .bp3-running-text h6{
-      color:#f5f8fa; }
-  .bp3-running-text hr{
-    margin:20px 0;
-    border:none;
-    border-bottom:1px solid rgba(16, 22, 26, 0.15); }
-    .bp3-dark .bp3-running-text hr{
-      border-color:rgba(255, 255, 255, 0.15); }
-  .bp3-running-text p{
-    margin:0 0 10px;
-    padding:0; }
+.bp3-text-overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+.bp3-running-text {
+  line-height: 1.5;
+  font-size: 14px;
+}
+.bp3-running-text h1 {
+  color: #182026;
+  font-weight: 600;
+  margin-top: 40px;
+  margin-bottom: 20px;
+}
+.bp3-dark .bp3-running-text h1 {
+  color: #f5f8fa;
+}
+.bp3-running-text h2 {
+  color: #182026;
+  font-weight: 600;
+  margin-top: 40px;
+  margin-bottom: 20px;
+}
+.bp3-dark .bp3-running-text h2 {
+  color: #f5f8fa;
+}
+.bp3-running-text h3 {
+  color: #182026;
+  font-weight: 600;
+  margin-top: 40px;
+  margin-bottom: 20px;
+}
+.bp3-dark .bp3-running-text h3 {
+  color: #f5f8fa;
+}
+.bp3-running-text h4 {
+  color: #182026;
+  font-weight: 600;
+  margin-top: 40px;
+  margin-bottom: 20px;
+}
+.bp3-dark .bp3-running-text h4 {
+  color: #f5f8fa;
+}
+.bp3-running-text h5 {
+  color: #182026;
+  font-weight: 600;
+  margin-top: 40px;
+  margin-bottom: 20px;
+}
+.bp3-dark .bp3-running-text h5 {
+  color: #f5f8fa;
+}
+.bp3-running-text h6 {
+  color: #182026;
+  font-weight: 600;
+  margin-top: 40px;
+  margin-bottom: 20px;
+}
+.bp3-dark .bp3-running-text h6 {
+  color: #f5f8fa;
+}
+.bp3-running-text hr {
+  margin: 20px 0;
+  border: none;
+  border-bottom: 1px solid rgba(16, 22, 26, 0.15);
+}
+.bp3-dark .bp3-running-text hr {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+.bp3-running-text p {
+  margin: 0 0 10px;
+  padding: 0;
+}
 
-.bp3-text-large{
-  font-size:16px; }
+.bp3-text-large {
+  font-size: 16px;
+}
 
-.bp3-text-small{
-  font-size:12px; }
-a{
-  text-decoration:none;
-  color:#106ba3; }
-  a:hover{
-    cursor:pointer;
-    text-decoration:underline;
-    color:#106ba3; }
-  a .bp3-icon, a .bp3-icon-standard, a .bp3-icon-large{
-    color:inherit; }
-  a code,
-  .bp3-dark a code{
-    color:inherit; }
-  .bp3-dark a,
-  .bp3-dark a:hover{
-    color:#48aff0; }
-    .bp3-dark a .bp3-icon, .bp3-dark a .bp3-icon-standard, .bp3-dark a .bp3-icon-large,
-    .bp3-dark a:hover .bp3-icon,
-    .bp3-dark a:hover .bp3-icon-standard,
-    .bp3-dark a:hover .bp3-icon-large{
-      color:inherit; }
-.bp3-running-text code, .bp3-code{
-  text-transform:none;
-  font-family:monospace;
-  border-radius:3px;
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
-  background:rgba(255, 255, 255, 0.7);
-  padding:2px 5px;
-  color:#5c7080;
-  font-size:smaller; }
-  .bp3-dark .bp3-running-text code, .bp3-running-text .bp3-dark code, .bp3-dark .bp3-code{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
-    color:#a7b6c2; }
-  .bp3-running-text a > code, a > .bp3-code{
-    color:#137cbd; }
-    .bp3-dark .bp3-running-text a > code, .bp3-running-text .bp3-dark a > code, .bp3-dark a > .bp3-code{
-      color:inherit; }
+.bp3-text-small {
+  font-size: 12px;
+}
+a {
+  text-decoration: none;
+  color: #106ba3;
+}
+a:hover {
+  cursor: pointer;
+  text-decoration: underline;
+  color: #106ba3;
+}
+a .bp3-icon,
+a .bp3-icon-standard,
+a .bp3-icon-large {
+  color: inherit;
+}
+a code,
+.bp3-dark a code {
+  color: inherit;
+}
+.bp3-dark a,
+.bp3-dark a:hover {
+  color: #48aff0;
+}
+.bp3-dark a .bp3-icon,
+.bp3-dark a .bp3-icon-standard,
+.bp3-dark a .bp3-icon-large,
+.bp3-dark a:hover .bp3-icon,
+.bp3-dark a:hover .bp3-icon-standard,
+.bp3-dark a:hover .bp3-icon-large {
+  color: inherit;
+}
+.bp3-running-text code,
+.bp3-code {
+  text-transform: none;
+  font-family: monospace;
+  border-radius: 3px;
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2);
+  background: rgba(255, 255, 255, 0.7);
+  padding: 2px 5px;
+  color: #5c7080;
+  font-size: smaller;
+}
+.bp3-dark .bp3-running-text code,
+.bp3-running-text .bp3-dark code,
+.bp3-dark .bp3-code {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background: rgba(16, 22, 26, 0.3);
+  color: #a7b6c2;
+}
+.bp3-running-text a > code,
+a > .bp3-code {
+  color: #137cbd;
+}
+.bp3-dark .bp3-running-text a > code,
+.bp3-running-text .bp3-dark a > code,
+.bp3-dark a > .bp3-code {
+  color: inherit;
+}
 
-.bp3-running-text pre, .bp3-code-block{
-  text-transform:none;
-  font-family:monospace;
-  display:block;
-  margin:10px 0;
-  border-radius:3px;
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
-  background:rgba(255, 255, 255, 0.7);
-  padding:13px 15px 12px;
-  line-height:1.4;
-  color:#182026;
-  font-size:13px;
-  word-break:break-all;
-  word-wrap:break-word; }
-  .bp3-dark .bp3-running-text pre, .bp3-running-text .bp3-dark pre, .bp3-dark .bp3-code-block{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
-    color:#f5f8fa; }
-  .bp3-running-text pre > code, .bp3-code-block > code{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none;
-    padding:0;
-    color:inherit;
-    font-size:inherit; }
+.bp3-running-text pre,
+.bp3-code-block {
+  text-transform: none;
+  font-family: monospace;
+  display: block;
+  margin: 10px 0;
+  border-radius: 3px;
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+  background: rgba(255, 255, 255, 0.7);
+  padding: 13px 15px 12px;
+  line-height: 1.4;
+  color: #182026;
+  font-size: 13px;
+  word-break: break-all;
+  word-wrap: break-word;
+}
+.bp3-dark .bp3-running-text pre,
+.bp3-running-text .bp3-dark pre,
+.bp3-dark .bp3-code-block {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background: rgba(16, 22, 26, 0.3);
+  color: #f5f8fa;
+}
+.bp3-running-text pre > code,
+.bp3-code-block > code {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
 
-.bp3-running-text kbd, .bp3-key{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
-  border-radius:3px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  min-width:24px;
-  height:24px;
-  padding:3px 6px;
-  vertical-align:middle;
-  line-height:24px;
-  color:#5c7080;
-  font-family:inherit;
-  font-size:12px; }
-  .bp3-running-text kbd .bp3-icon, .bp3-key .bp3-icon, .bp3-running-text kbd .bp3-icon-standard, .bp3-key .bp3-icon-standard, .bp3-running-text kbd .bp3-icon-large, .bp3-key .bp3-icon-large{
-    margin-right:5px; }
-  .bp3-dark .bp3-running-text kbd, .bp3-running-text .bp3-dark kbd, .bp3-dark .bp3-key{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:#394b59;
-    color:#a7b6c2; }
-.bp3-running-text blockquote, .bp3-blockquote{
-  margin:0 0 10px;
-  border-left:solid 4px rgba(167, 182, 194, 0.5);
-  padding:0 20px; }
-  .bp3-dark .bp3-running-text blockquote, .bp3-running-text .bp3-dark blockquote, .bp3-dark .bp3-blockquote{
-    border-color:rgba(115, 134, 148, 0.5); }
+.bp3-running-text kbd,
+.bp3-key {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  background: #ffffff;
+  min-width: 24px;
+  height: 24px;
+  padding: 3px 6px;
+  vertical-align: middle;
+  line-height: 24px;
+  color: #5c7080;
+  font-family: inherit;
+  font-size: 12px;
+}
+.bp3-running-text kbd .bp3-icon,
+.bp3-key .bp3-icon,
+.bp3-running-text kbd .bp3-icon-standard,
+.bp3-key .bp3-icon-standard,
+.bp3-running-text kbd .bp3-icon-large,
+.bp3-key .bp3-icon-large {
+  margin-right: 5px;
+}
+.bp3-dark .bp3-running-text kbd,
+.bp3-running-text .bp3-dark kbd,
+.bp3-dark .bp3-key {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+  background: #394b59;
+  color: #a7b6c2;
+}
+.bp3-running-text blockquote,
+.bp3-blockquote {
+  margin: 0 0 10px;
+  border-left: solid 4px rgba(167, 182, 194, 0.5);
+  padding: 0 20px;
+}
+.bp3-dark .bp3-running-text blockquote,
+.bp3-running-text .bp3-dark blockquote,
+.bp3-dark .bp3-blockquote {
+  border-color: rgba(115, 134, 148, 0.5);
+}
 .bp3-running-text ul,
-.bp3-running-text ol, .bp3-list{
-  margin:10px 0;
-  padding-left:30px; }
-  .bp3-running-text ul li:not(:last-child), .bp3-running-text ol li:not(:last-child), .bp3-list li:not(:last-child){
-    margin-bottom:5px; }
-  .bp3-running-text ul ol, .bp3-running-text ol ol, .bp3-list ol,
-  .bp3-running-text ul ul,
-  .bp3-running-text ol ul,
-  .bp3-list ul{
-    margin-top:5px; }
+.bp3-running-text ol,
+.bp3-list {
+  margin: 10px 0;
+  padding-left: 30px;
+}
+.bp3-running-text ul li:not(:last-child),
+.bp3-running-text ol li:not(:last-child),
+.bp3-list li:not(:last-child) {
+  margin-bottom: 5px;
+}
+.bp3-running-text ul ol,
+.bp3-running-text ol ol,
+.bp3-list ol,
+.bp3-running-text ul ul,
+.bp3-running-text ol ul,
+.bp3-list ul {
+  margin-top: 5px;
+}
 
-.bp3-list-unstyled{
-  margin:0;
-  padding:0;
-  list-style:none; }
-  .bp3-list-unstyled li{
-    padding:0; }
-.bp3-rtl{
-  text-align:right; }
+.bp3-list-unstyled {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.bp3-list-unstyled li {
+  padding: 0;
+}
+.bp3-rtl {
+  text-align: right;
+}
 
-.bp3-dark{
-  color:#f5f8fa; }
+.bp3-dark {
+  color: #f5f8fa;
+}
 
-:focus{
-  outline:rgba(19, 124, 189, 0.6) auto 2px;
-  outline-offset:2px;
-  -moz-outline-radius:6px; }
+:focus {
+  outline: rgba(19, 124, 189, 0.6) auto 2px;
+  outline-offset: 2px;
+  -moz-outline-radius: 6px;
+}
 
-.bp3-focus-disabled :focus{
-  outline:none !important; }
-  .bp3-focus-disabled :focus ~ .bp3-control-indicator{
-    outline:none !important; }
+.bp3-focus-disabled :focus {
+  outline: none !important;
+}
+.bp3-focus-disabled :focus ~ .bp3-control-indicator {
+  outline: none !important;
+}
 
-.bp3-alert{
-  max-width:400px;
-  padding:20px; }
+.bp3-alert {
+  max-width: 400px;
+  padding: 20px;
+}
 
-.bp3-alert-body{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex; }
-  .bp3-alert-body .bp3-icon{
-    margin-top:0;
-    margin-right:20px;
-    font-size:40px; }
+.bp3-alert-body {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.bp3-alert-body .bp3-icon {
+  margin-top: 0;
+  margin-right: 20px;
+  font-size: 40px;
+}
 
-.bp3-alert-footer{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:reverse;
-      -ms-flex-direction:row-reverse;
-          flex-direction:row-reverse;
-  margin-top:10px; }
-  .bp3-alert-footer .bp3-button{
-    margin-left:10px; }
-.bp3-breadcrumbs{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -ms-flex-wrap:wrap;
-      flex-wrap:wrap;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  margin:0;
-  cursor:default;
-  height:30px;
-  padding:0;
-  list-style:none; }
-  .bp3-breadcrumbs > li{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    -webkit-box-align:center;
-        -ms-flex-align:center;
-            align-items:center; }
-    .bp3-breadcrumbs > li::after{
-      display:block;
-      margin:0 5px;
-      background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.71 7.29l-4-4a1.003 1.003 0 0 0-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z' fill='%235C7080'/%3e%3c/svg%3e");
-      width:16px;
-      height:16px;
-      content:""; }
-    .bp3-breadcrumbs > li:last-of-type::after{
-      display:none; }
+.bp3-alert-footer {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+  margin-top: 10px;
+}
+.bp3-alert-footer .bp3-button {
+  margin-left: 10px;
+}
+.bp3-breadcrumbs {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 0;
+  cursor: default;
+  height: 30px;
+  padding: 0;
+  list-style: none;
+}
+.bp3-breadcrumbs > li {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+.bp3-breadcrumbs > li::after {
+  display: block;
+  margin: 0 5px;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.71 7.29l-4-4a1.003 1.003 0 0 0-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z' fill='%235C7080'/%3e%3c/svg%3e");
+  width: 16px;
+  height: 16px;
+  content: '';
+}
+.bp3-breadcrumbs > li:last-of-type::after {
+  display: none;
+}
 
 .bp3-breadcrumb,
 .bp3-breadcrumb-current,
-.bp3-breadcrumbs-collapsed{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  font-size:16px; }
+.bp3-breadcrumbs-collapsed {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 16px;
+}
 
 .bp3-breadcrumb,
-.bp3-breadcrumbs-collapsed{
-  color:#5c7080; }
+.bp3-breadcrumbs-collapsed {
+  color: #5c7080;
+}
 
-.bp3-breadcrumb:hover{
-  text-decoration:none; }
+.bp3-breadcrumb:hover {
+  text-decoration: none;
+}
 
-.bp3-breadcrumb.bp3-disabled{
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+.bp3-breadcrumb.bp3-disabled {
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
 
-.bp3-breadcrumb .bp3-icon{
-  margin-right:5px; }
+.bp3-breadcrumb .bp3-icon {
+  margin-right: 5px;
+}
 
-.bp3-breadcrumb-current{
-  color:inherit;
-  font-weight:600; }
-  .bp3-breadcrumb-current .bp3-input{
-    vertical-align:baseline;
-    font-size:inherit;
-    font-weight:inherit; }
+.bp3-breadcrumb-current {
+  color: inherit;
+  font-weight: 600;
+}
+.bp3-breadcrumb-current .bp3-input {
+  vertical-align: baseline;
+  font-size: inherit;
+  font-weight: inherit;
+}
 
-.bp3-breadcrumbs-collapsed{
-  margin-right:2px;
-  border:none;
-  border-radius:3px;
-  background:#ced9e0;
-  cursor:pointer;
-  padding:1px 5px;
-  vertical-align:text-bottom; }
-  .bp3-breadcrumbs-collapsed::before{
-    display:block;
-    background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cg fill='%235C7080'%3e%3ccircle cx='2' cy='8.03' r='2'/%3e%3ccircle cx='14' cy='8.03' r='2'/%3e%3ccircle cx='8' cy='8.03' r='2'/%3e%3c/g%3e%3c/svg%3e") center no-repeat;
-    width:16px;
-    height:16px;
-    content:""; }
-  .bp3-breadcrumbs-collapsed:hover{
-    background:#bfccd6;
-    text-decoration:none;
-    color:#182026; }
+.bp3-breadcrumbs-collapsed {
+  margin-right: 2px;
+  border: none;
+  border-radius: 3px;
+  background: #ced9e0;
+  cursor: pointer;
+  padding: 1px 5px;
+  vertical-align: text-bottom;
+}
+.bp3-breadcrumbs-collapsed::before {
+  display: block;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cg fill='%235C7080'%3e%3ccircle cx='2' cy='8.03' r='2'/%3e%3ccircle cx='14' cy='8.03' r='2'/%3e%3ccircle cx='8' cy='8.03' r='2'/%3e%3c/g%3e%3c/svg%3e")
+    center no-repeat;
+  width: 16px;
+  height: 16px;
+  content: '';
+}
+.bp3-breadcrumbs-collapsed:hover {
+  background: #bfccd6;
+  text-decoration: none;
+  color: #182026;
+}
 
 .bp3-dark .bp3-breadcrumb,
-.bp3-dark .bp3-breadcrumbs-collapsed{
-  color:#a7b6c2; }
+.bp3-dark .bp3-breadcrumbs-collapsed {
+  color: #a7b6c2;
+}
 
-.bp3-dark .bp3-breadcrumbs > li::after{
-  color:#a7b6c2; }
+.bp3-dark .bp3-breadcrumbs > li::after {
+  color: #a7b6c2;
+}
 
-.bp3-dark .bp3-breadcrumb.bp3-disabled{
-  color:rgba(167, 182, 194, 0.6); }
+.bp3-dark .bp3-breadcrumb.bp3-disabled {
+  color: rgba(167, 182, 194, 0.6);
+}
 
-.bp3-dark .bp3-breadcrumb-current{
-  color:#f5f8fa; }
+.bp3-dark .bp3-breadcrumb-current {
+  color: #f5f8fa;
+}
 
-.bp3-dark .bp3-breadcrumbs-collapsed{
-  background:rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-breadcrumbs-collapsed:hover{
-    background:rgba(16, 22, 26, 0.6);
-    color:#f5f8fa; }
-.bp3-button{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:row;
-          flex-direction:row;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
-  border:none;
-  border-radius:3px;
-  cursor:pointer;
-  padding:5px 10px;
-  vertical-align:middle;
-  text-align:left;
-  font-size:14px;
-  min-width:30px;
-  min-height:30px; }
-  .bp3-button > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-button > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-button::before,
-  .bp3-button > *{
-    margin-right:7px; }
-  .bp3-button:empty::before,
-  .bp3-button > :last-child{
-    margin-right:0; }
-  .bp3-button:empty{
-    padding:0 !important; }
-  .bp3-button:disabled, .bp3-button.bp3-disabled{
-    cursor:not-allowed; }
-  .bp3-button.bp3-fill{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    width:100%; }
-  .bp3-button.bp3-align-right,
-  .bp3-align-right .bp3-button{
-    text-align:right; }
-  .bp3-button.bp3-align-left,
-  .bp3-align-left .bp3-button{
-    text-align:left; }
-  .bp3-button:not([class*="bp3-intent-"]){
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-color:#f5f8fa;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
-    color:#182026; }
-    .bp3-button:not([class*="bp3-intent-"]):hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-      background-clip:padding-box;
-      background-color:#ebf1f5; }
-    .bp3-button:not([class*="bp3-intent-"]):active, .bp3-button:not([class*="bp3-intent-"]).bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#d8e1e8;
-      background-image:none; }
-    .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
-      outline:none;
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(206, 217, 224, 0.5);
-      background-image:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
-      .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active:hover, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active:hover{
-        background:rgba(206, 217, 224, 0.7); }
-  .bp3-button.bp3-intent-primary{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#137cbd;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-    .bp3-button.bp3-intent-primary:hover, .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
-      color:#ffffff; }
-    .bp3-button.bp3-intent-primary:hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#106ba3; }
-    .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#0e5a8a;
-      background-image:none; }
-    .bp3-button.bp3-intent-primary:disabled, .bp3-button.bp3-intent-primary.bp3-disabled{
-      border-color:transparent;
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(19, 124, 189, 0.5);
-      background-image:none;
-      color:rgba(255, 255, 255, 0.6); }
-  .bp3-button.bp3-intent-success{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#0f9960;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-    .bp3-button.bp3-intent-success:hover, .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
-      color:#ffffff; }
-    .bp3-button.bp3-intent-success:hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#0d8050; }
-    .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#0a6640;
-      background-image:none; }
-    .bp3-button.bp3-intent-success:disabled, .bp3-button.bp3-intent-success.bp3-disabled{
-      border-color:transparent;
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(15, 153, 96, 0.5);
-      background-image:none;
-      color:rgba(255, 255, 255, 0.6); }
-  .bp3-button.bp3-intent-warning{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#d9822b;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-    .bp3-button.bp3-intent-warning:hover, .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
-      color:#ffffff; }
-    .bp3-button.bp3-intent-warning:hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#bf7326; }
-    .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#a66321;
-      background-image:none; }
-    .bp3-button.bp3-intent-warning:disabled, .bp3-button.bp3-intent-warning.bp3-disabled{
-      border-color:transparent;
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(217, 130, 43, 0.5);
-      background-image:none;
-      color:rgba(255, 255, 255, 0.6); }
-  .bp3-button.bp3-intent-danger{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#db3737;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-    .bp3-button.bp3-intent-danger:hover, .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
-      color:#ffffff; }
-    .bp3-button.bp3-intent-danger:hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#c23030; }
-    .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#a82a2a;
-      background-image:none; }
-    .bp3-button.bp3-intent-danger:disabled, .bp3-button.bp3-intent-danger.bp3-disabled{
-      border-color:transparent;
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(219, 55, 55, 0.5);
-      background-image:none;
-      color:rgba(255, 255, 255, 0.6); }
-  .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
-    stroke:#ffffff; }
-  .bp3-button.bp3-large,
-  .bp3-large .bp3-button{
-    min-width:40px;
-    min-height:40px;
-    padding:5px 15px;
-    font-size:16px; }
-    .bp3-button.bp3-large::before,
-    .bp3-button.bp3-large > *,
-    .bp3-large .bp3-button::before,
-    .bp3-large .bp3-button > *{
-      margin-right:10px; }
-    .bp3-button.bp3-large:empty::before,
-    .bp3-button.bp3-large > :last-child,
-    .bp3-large .bp3-button:empty::before,
-    .bp3-large .bp3-button > :last-child{
-      margin-right:0; }
-  .bp3-button.bp3-small,
-  .bp3-small .bp3-button{
-    min-width:24px;
-    min-height:24px;
-    padding:0 7px; }
-  .bp3-button.bp3-loading{
-    position:relative; }
-    .bp3-button.bp3-loading[class*="bp3-icon-"]::before{
-      visibility:hidden; }
-    .bp3-button.bp3-loading .bp3-button-spinner{
-      position:absolute;
-      margin:0; }
-    .bp3-button.bp3-loading > :not(.bp3-button-spinner){
-      visibility:hidden; }
-  .bp3-button[class*="bp3-icon-"]::before{
-    line-height:1;
-    font-family:"Icons16", sans-serif;
-    font-size:16px;
-    font-weight:400;
-    font-style:normal;
-    -moz-osx-font-smoothing:grayscale;
-    -webkit-font-smoothing:antialiased;
-    color:#5c7080; }
-  .bp3-button .bp3-icon, .bp3-button .bp3-icon-standard, .bp3-button .bp3-icon-large{
-    color:#5c7080; }
-    .bp3-button .bp3-icon.bp3-align-right, .bp3-button .bp3-icon-standard.bp3-align-right, .bp3-button .bp3-icon-large.bp3-align-right{
-      margin-left:7px; }
-  .bp3-button .bp3-icon:first-child:last-child,
-  .bp3-button .bp3-spinner + .bp3-icon:last-child{
-    margin:0 -7px; }
-  .bp3-dark .bp3-button:not([class*="bp3-intent-"]){
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#394b59;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
-    color:#f5f8fa; }
-    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover, .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
-      color:#f5f8fa; }
-    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
-    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#202b33;
-      background-image:none; }
-    .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(57, 75, 89, 0.5);
-      background-image:none;
-      color:rgba(167, 182, 194, 0.6); }
-      .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active{
-        background:rgba(57, 75, 89, 0.7); }
-    .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-button-spinner .bp3-spinner-head{
-      background:rgba(16, 22, 26, 0.5);
-      stroke:#8a9ba8; }
-    .bp3-dark .bp3-button:not([class*="bp3-intent-"])[class*="bp3-icon-"]::before{
-      color:#a7b6c2; }
-    .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-icon, .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-icon-standard, .bp3-dark .bp3-button:not([class*="bp3-intent-"]) .bp3-icon-large{
-      color:#a7b6c2; }
-  .bp3-dark .bp3-button[class*="bp3-intent-"]{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-button[class*="bp3-intent-"]:hover{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-button[class*="bp3-intent-"]:active, .bp3-dark .bp3-button[class*="bp3-intent-"].bp3-active{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
-    .bp3-dark .bp3-button[class*="bp3-intent-"]:disabled, .bp3-dark .bp3-button[class*="bp3-intent-"].bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-image:none;
-      color:rgba(255, 255, 255, 0.3); }
-    .bp3-dark .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
-      stroke:#8a9ba8; }
-  .bp3-button:disabled::before,
-  .bp3-button:disabled .bp3-icon, .bp3-button:disabled .bp3-icon-standard, .bp3-button:disabled .bp3-icon-large, .bp3-button.bp3-disabled::before,
-  .bp3-button.bp3-disabled .bp3-icon, .bp3-button.bp3-disabled .bp3-icon-standard, .bp3-button.bp3-disabled .bp3-icon-large, .bp3-button[class*="bp3-intent-"]::before,
-  .bp3-button[class*="bp3-intent-"] .bp3-icon, .bp3-button[class*="bp3-intent-"] .bp3-icon-standard, .bp3-button[class*="bp3-intent-"] .bp3-icon-large{
-    color:inherit !important; }
-  .bp3-button.bp3-minimal{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none; }
-    .bp3-button.bp3-minimal:hover{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(167, 182, 194, 0.3);
-      text-decoration:none;
-      color:#182026; }
-    .bp3-button.bp3-minimal:active, .bp3-button.bp3-minimal.bp3-active{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(115, 134, 148, 0.3);
-      color:#182026; }
-    .bp3-button.bp3-minimal:disabled, .bp3-button.bp3-minimal:disabled:hover, .bp3-button.bp3-minimal.bp3-disabled, .bp3-button.bp3-minimal.bp3-disabled:hover{
-      background:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
-      .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
-        background:rgba(115, 134, 148, 0.3); }
-    .bp3-dark .bp3-button.bp3-minimal{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none;
-      color:inherit; }
-      .bp3-dark .bp3-button.bp3-minimal:hover, .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none; }
-      .bp3-dark .bp3-button.bp3-minimal:hover{
-        background:rgba(138, 155, 168, 0.15); }
-      .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
-        background:rgba(138, 155, 168, 0.3);
-        color:#f5f8fa; }
-      .bp3-dark .bp3-button.bp3-minimal:disabled, .bp3-dark .bp3-button.bp3-minimal:disabled:hover, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover{
-        background:none;
-        cursor:not-allowed;
-        color:rgba(167, 182, 194, 0.6); }
-        .bp3-dark .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
-          background:rgba(138, 155, 168, 0.3); }
-    .bp3-button.bp3-minimal.bp3-intent-primary{
-      color:#106ba3; }
-      .bp3-button.bp3-minimal.bp3-intent-primary:hover, .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#106ba3; }
-      .bp3-button.bp3-minimal.bp3-intent-primary:hover{
-        background:rgba(19, 124, 189, 0.15);
-        color:#106ba3; }
-      .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
-        background:rgba(19, 124, 189, 0.3);
-        color:#106ba3; }
-      .bp3-button.bp3-minimal.bp3-intent-primary:disabled, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled{
-        background:none;
-        color:rgba(16, 107, 163, 0.5); }
-        .bp3-button.bp3-minimal.bp3-intent-primary:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled.bp3-active{
-          background:rgba(19, 124, 189, 0.3); }
-      .bp3-button.bp3-minimal.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
-        stroke:#106ba3; }
-      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary{
-        color:#48aff0; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:hover{
-          background:rgba(19, 124, 189, 0.2);
-          color:#48aff0; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
-          background:rgba(19, 124, 189, 0.3);
-          color:#48aff0; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled{
-          background:none;
-          color:rgba(72, 175, 240, 0.5); }
-          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled.bp3-active{
-            background:rgba(19, 124, 189, 0.3); }
-    .bp3-button.bp3-minimal.bp3-intent-success{
-      color:#0d8050; }
-      .bp3-button.bp3-minimal.bp3-intent-success:hover, .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#0d8050; }
-      .bp3-button.bp3-minimal.bp3-intent-success:hover{
-        background:rgba(15, 153, 96, 0.15);
-        color:#0d8050; }
-      .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
-        background:rgba(15, 153, 96, 0.3);
-        color:#0d8050; }
-      .bp3-button.bp3-minimal.bp3-intent-success:disabled, .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled{
-        background:none;
-        color:rgba(13, 128, 80, 0.5); }
-        .bp3-button.bp3-minimal.bp3-intent-success:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled.bp3-active{
-          background:rgba(15, 153, 96, 0.3); }
-      .bp3-button.bp3-minimal.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
-        stroke:#0d8050; }
-      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success{
-        color:#3dcc91; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:hover{
-          background:rgba(15, 153, 96, 0.2);
-          color:#3dcc91; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
-          background:rgba(15, 153, 96, 0.3);
-          color:#3dcc91; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled{
-          background:none;
-          color:rgba(61, 204, 145, 0.5); }
-          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled.bp3-active{
-            background:rgba(15, 153, 96, 0.3); }
-    .bp3-button.bp3-minimal.bp3-intent-warning{
-      color:#bf7326; }
-      .bp3-button.bp3-minimal.bp3-intent-warning:hover, .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#bf7326; }
-      .bp3-button.bp3-minimal.bp3-intent-warning:hover{
-        background:rgba(217, 130, 43, 0.15);
-        color:#bf7326; }
-      .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
-        background:rgba(217, 130, 43, 0.3);
-        color:#bf7326; }
-      .bp3-button.bp3-minimal.bp3-intent-warning:disabled, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled{
-        background:none;
-        color:rgba(191, 115, 38, 0.5); }
-        .bp3-button.bp3-minimal.bp3-intent-warning:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled.bp3-active{
-          background:rgba(217, 130, 43, 0.3); }
-      .bp3-button.bp3-minimal.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
-        stroke:#bf7326; }
-      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning{
-        color:#ffb366; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:hover{
-          background:rgba(217, 130, 43, 0.2);
-          color:#ffb366; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
-          background:rgba(217, 130, 43, 0.3);
-          color:#ffb366; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled{
-          background:none;
-          color:rgba(255, 179, 102, 0.5); }
-          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled.bp3-active{
-            background:rgba(217, 130, 43, 0.3); }
-    .bp3-button.bp3-minimal.bp3-intent-danger{
-      color:#c23030; }
-      .bp3-button.bp3-minimal.bp3-intent-danger:hover, .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#c23030; }
-      .bp3-button.bp3-minimal.bp3-intent-danger:hover{
-        background:rgba(219, 55, 55, 0.15);
-        color:#c23030; }
-      .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
-        background:rgba(219, 55, 55, 0.3);
-        color:#c23030; }
-      .bp3-button.bp3-minimal.bp3-intent-danger:disabled, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled{
-        background:none;
-        color:rgba(194, 48, 48, 0.5); }
-        .bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active{
-          background:rgba(219, 55, 55, 0.3); }
-      .bp3-button.bp3-minimal.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
-        stroke:#c23030; }
-      .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger{
-        color:#ff7373; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:hover{
-          background:rgba(219, 55, 55, 0.2);
-          color:#ff7373; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
-          background:rgba(219, 55, 55, 0.3);
-          color:#ff7373; }
-        .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled{
-          background:none;
-          color:rgba(255, 115, 115, 0.5); }
-          .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active{
-            background:rgba(219, 55, 55, 0.3); }
+.bp3-dark .bp3-breadcrumbs-collapsed {
+  background: rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-breadcrumbs-collapsed:hover {
+  background: rgba(16, 22, 26, 0.6);
+  color: #f5f8fa;
+}
+.bp3-button {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 5px 10px;
+  vertical-align: middle;
+  text-align: left;
+  font-size: 14px;
+  min-width: 30px;
+  min-height: 30px;
+}
+.bp3-button > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-button > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-button::before,
+.bp3-button > * {
+  margin-right: 7px;
+}
+.bp3-button:empty::before,
+.bp3-button > :last-child {
+  margin-right: 0;
+}
+.bp3-button:empty {
+  padding: 0 !important;
+}
+.bp3-button:disabled,
+.bp3-button.bp3-disabled {
+  cursor: not-allowed;
+}
+.bp3-button.bp3-fill {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+.bp3-button.bp3-align-right,
+.bp3-align-right .bp3-button {
+  text-align: right;
+}
+.bp3-button.bp3-align-left,
+.bp3-align-left .bp3-button {
+  text-align: left;
+}
+.bp3-button:not([class*='bp3-intent-']) {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-color: #f5f8fa;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.8)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.8),
+    rgba(255, 255, 255, 0)
+  );
+  color: #182026;
+}
+.bp3-button:not([class*='bp3-intent-']):hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-clip: padding-box;
+  background-color: #ebf1f5;
+}
+.bp3-button:not([class*='bp3-intent-']):active,
+.bp3-button:not([class*='bp3-intent-']).bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #d8e1e8;
+  background-image: none;
+}
+.bp3-button:not([class*='bp3-intent-']):disabled,
+.bp3-button:not([class*='bp3-intent-']).bp3-disabled {
+  outline: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(206, 217, 224, 0.5);
+  background-image: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-button:not([class*='bp3-intent-']):disabled.bp3-active,
+.bp3-button:not([class*='bp3-intent-']):disabled.bp3-active:hover,
+.bp3-button:not([class*='bp3-intent-']).bp3-disabled.bp3-active,
+.bp3-button:not([class*='bp3-intent-']).bp3-disabled.bp3-active:hover {
+  background: rgba(206, 217, 224, 0.7);
+}
+.bp3-button.bp3-intent-primary {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #137cbd;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.1)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0)
+  );
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-primary:hover,
+.bp3-button.bp3-intent-primary:active,
+.bp3-button.bp3-intent-primary.bp3-active {
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-primary:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #106ba3;
+}
+.bp3-button.bp3-intent-primary:active,
+.bp3-button.bp3-intent-primary.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #0e5a8a;
+  background-image: none;
+}
+.bp3-button.bp3-intent-primary:disabled,
+.bp3-button.bp3-intent-primary.bp3-disabled {
+  border-color: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(19, 124, 189, 0.5);
+  background-image: none;
+  color: rgba(255, 255, 255, 0.6);
+}
+.bp3-button.bp3-intent-success {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #0f9960;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.1)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0)
+  );
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-success:hover,
+.bp3-button.bp3-intent-success:active,
+.bp3-button.bp3-intent-success.bp3-active {
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-success:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #0d8050;
+}
+.bp3-button.bp3-intent-success:active,
+.bp3-button.bp3-intent-success.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #0a6640;
+  background-image: none;
+}
+.bp3-button.bp3-intent-success:disabled,
+.bp3-button.bp3-intent-success.bp3-disabled {
+  border-color: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(15, 153, 96, 0.5);
+  background-image: none;
+  color: rgba(255, 255, 255, 0.6);
+}
+.bp3-button.bp3-intent-warning {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #d9822b;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.1)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0)
+  );
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-warning:hover,
+.bp3-button.bp3-intent-warning:active,
+.bp3-button.bp3-intent-warning.bp3-active {
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-warning:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #bf7326;
+}
+.bp3-button.bp3-intent-warning:active,
+.bp3-button.bp3-intent-warning.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #a66321;
+  background-image: none;
+}
+.bp3-button.bp3-intent-warning:disabled,
+.bp3-button.bp3-intent-warning.bp3-disabled {
+  border-color: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(217, 130, 43, 0.5);
+  background-image: none;
+  color: rgba(255, 255, 255, 0.6);
+}
+.bp3-button.bp3-intent-danger {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #db3737;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.1)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0)
+  );
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-danger:hover,
+.bp3-button.bp3-intent-danger:active,
+.bp3-button.bp3-intent-danger.bp3-active {
+  color: #ffffff;
+}
+.bp3-button.bp3-intent-danger:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #c23030;
+}
+.bp3-button.bp3-intent-danger:active,
+.bp3-button.bp3-intent-danger.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #a82a2a;
+  background-image: none;
+}
+.bp3-button.bp3-intent-danger:disabled,
+.bp3-button.bp3-intent-danger.bp3-disabled {
+  border-color: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(219, 55, 55, 0.5);
+  background-image: none;
+  color: rgba(255, 255, 255, 0.6);
+}
+.bp3-button[class*='bp3-intent-'] .bp3-button-spinner .bp3-spinner-head {
+  stroke: #ffffff;
+}
+.bp3-button.bp3-large,
+.bp3-large .bp3-button {
+  min-width: 40px;
+  min-height: 40px;
+  padding: 5px 15px;
+  font-size: 16px;
+}
+.bp3-button.bp3-large::before,
+.bp3-button.bp3-large > *,
+.bp3-large .bp3-button::before,
+.bp3-large .bp3-button > * {
+  margin-right: 10px;
+}
+.bp3-button.bp3-large:empty::before,
+.bp3-button.bp3-large > :last-child,
+.bp3-large .bp3-button:empty::before,
+.bp3-large .bp3-button > :last-child {
+  margin-right: 0;
+}
+.bp3-button.bp3-small,
+.bp3-small .bp3-button {
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0 7px;
+}
+.bp3-button.bp3-loading {
+  position: relative;
+}
+.bp3-button.bp3-loading[class*='bp3-icon-']::before {
+  visibility: hidden;
+}
+.bp3-button.bp3-loading .bp3-button-spinner {
+  position: absolute;
+  margin: 0;
+}
+.bp3-button.bp3-loading > :not(.bp3-button-spinner) {
+  visibility: hidden;
+}
+.bp3-button[class*='bp3-icon-']::before {
+  line-height: 1;
+  font-family: 'Icons16', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  color: #5c7080;
+}
+.bp3-button .bp3-icon,
+.bp3-button .bp3-icon-standard,
+.bp3-button .bp3-icon-large {
+  color: #5c7080;
+}
+.bp3-button .bp3-icon.bp3-align-right,
+.bp3-button .bp3-icon-standard.bp3-align-right,
+.bp3-button .bp3-icon-large.bp3-align-right {
+  margin-left: 7px;
+}
+.bp3-button .bp3-icon:first-child:last-child,
+.bp3-button .bp3-spinner + .bp3-icon:last-child {
+  margin: 0 -7px;
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-']) {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #394b59;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.05)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0)
+  );
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-']):hover,
+.bp3-dark .bp3-button:not([class*='bp3-intent-']):active,
+.bp3-dark .bp3-button:not([class*='bp3-intent-']).bp3-active {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-']):hover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #30404d;
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-']):active,
+.bp3-dark .bp3-button:not([class*='bp3-intent-']).bp3-active {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #202b33;
+  background-image: none;
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-']):disabled,
+.bp3-dark .bp3-button:not([class*='bp3-intent-']).bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(57, 75, 89, 0.5);
+  background-image: none;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-']):disabled.bp3-active,
+.bp3-dark .bp3-button:not([class*='bp3-intent-']).bp3-disabled.bp3-active {
+  background: rgba(57, 75, 89, 0.7);
+}
+.bp3-dark
+  .bp3-button:not([class*='bp3-intent-'])
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  background: rgba(16, 22, 26, 0.5);
+  stroke: #8a9ba8;
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-'])[class*='bp3-icon-']::before {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-button:not([class*='bp3-intent-']) .bp3-icon,
+.bp3-dark .bp3-button:not([class*='bp3-intent-']) .bp3-icon-standard,
+.bp3-dark .bp3-button:not([class*='bp3-intent-']) .bp3-icon-large {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-button[class*='bp3-intent-'] {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-button[class*='bp3-intent-']:hover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-button[class*='bp3-intent-']:active,
+.bp3-dark .bp3-button[class*='bp3-intent-'].bp3-active {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+}
+.bp3-dark .bp3-button[class*='bp3-intent-']:disabled,
+.bp3-dark .bp3-button[class*='bp3-intent-'].bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-image: none;
+  color: rgba(255, 255, 255, 0.3);
+}
+.bp3-dark
+  .bp3-button[class*='bp3-intent-']
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #8a9ba8;
+}
+.bp3-button:disabled::before,
+.bp3-button:disabled .bp3-icon,
+.bp3-button:disabled .bp3-icon-standard,
+.bp3-button:disabled .bp3-icon-large,
+.bp3-button.bp3-disabled::before,
+.bp3-button.bp3-disabled .bp3-icon,
+.bp3-button.bp3-disabled .bp3-icon-standard,
+.bp3-button.bp3-disabled .bp3-icon-large,
+.bp3-button[class*='bp3-intent-']::before,
+.bp3-button[class*='bp3-intent-'] .bp3-icon,
+.bp3-button[class*='bp3-intent-'] .bp3-icon-standard,
+.bp3-button[class*='bp3-intent-'] .bp3-icon-large {
+  color: inherit !important;
+}
+.bp3-button.bp3-minimal {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+}
+.bp3-button.bp3-minimal:hover {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(167, 182, 194, 0.3);
+  text-decoration: none;
+  color: #182026;
+}
+.bp3-button.bp3-minimal:active,
+.bp3-button.bp3-minimal.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(115, 134, 148, 0.3);
+  color: #182026;
+}
+.bp3-button.bp3-minimal:disabled,
+.bp3-button.bp3-minimal:disabled:hover,
+.bp3-button.bp3-minimal.bp3-disabled,
+.bp3-button.bp3-minimal.bp3-disabled:hover {
+  background: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-button.bp3-minimal:disabled.bp3-active,
+.bp3-button.bp3-minimal:disabled:hover.bp3-active,
+.bp3-button.bp3-minimal.bp3-disabled.bp3-active,
+.bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active {
+  background: rgba(115, 134, 148, 0.3);
+}
+.bp3-dark .bp3-button.bp3-minimal {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: inherit;
+}
+.bp3-dark .bp3-button.bp3-minimal:hover,
+.bp3-dark .bp3-button.bp3-minimal:active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+}
+.bp3-dark .bp3-button.bp3-minimal:hover {
+  background: rgba(138, 155, 168, 0.15);
+}
+.bp3-dark .bp3-button.bp3-minimal:active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-active {
+  background: rgba(138, 155, 168, 0.3);
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-button.bp3-minimal:disabled,
+.bp3-dark .bp3-button.bp3-minimal:disabled:hover,
+.bp3-dark .bp3-button.bp3-minimal.bp3-disabled,
+.bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover {
+  background: none;
+  cursor: not-allowed;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-button.bp3-minimal:disabled.bp3-active,
+.bp3-dark .bp3-button.bp3-minimal:disabled:hover.bp3-active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-disabled.bp3-active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active {
+  background: rgba(138, 155, 168, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-primary {
+  color: #106ba3;
+}
+.bp3-button.bp3-minimal.bp3-intent-primary:hover,
+.bp3-button.bp3-minimal.bp3-intent-primary:active,
+.bp3-button.bp3-minimal.bp3-intent-primary.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #106ba3;
+}
+.bp3-button.bp3-minimal.bp3-intent-primary:hover {
+  background: rgba(19, 124, 189, 0.15);
+  color: #106ba3;
+}
+.bp3-button.bp3-minimal.bp3-intent-primary:active,
+.bp3-button.bp3-minimal.bp3-intent-primary.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+  color: #106ba3;
+}
+.bp3-button.bp3-minimal.bp3-intent-primary:disabled,
+.bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled {
+  background: none;
+  color: rgba(16, 107, 163, 0.5);
+}
+.bp3-button.bp3-minimal.bp3-intent-primary:disabled.bp3-active,
+.bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-primary
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #106ba3;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary {
+  color: #48aff0;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:hover {
+  background: rgba(19, 124, 189, 0.2);
+  color: #48aff0;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+  color: #48aff0;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:disabled,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled {
+  background: none;
+  color: rgba(72, 175, 240, 0.5);
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary:disabled.bp3-active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-primary.bp3-disabled.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-success {
+  color: #0d8050;
+}
+.bp3-button.bp3-minimal.bp3-intent-success:hover,
+.bp3-button.bp3-minimal.bp3-intent-success:active,
+.bp3-button.bp3-minimal.bp3-intent-success.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #0d8050;
+}
+.bp3-button.bp3-minimal.bp3-intent-success:hover {
+  background: rgba(15, 153, 96, 0.15);
+  color: #0d8050;
+}
+.bp3-button.bp3-minimal.bp3-intent-success:active,
+.bp3-button.bp3-minimal.bp3-intent-success.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+  color: #0d8050;
+}
+.bp3-button.bp3-minimal.bp3-intent-success:disabled,
+.bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled {
+  background: none;
+  color: rgba(13, 128, 80, 0.5);
+}
+.bp3-button.bp3-minimal.bp3-intent-success:disabled.bp3-active,
+.bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-success
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #0d8050;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success {
+  color: #3dcc91;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:hover {
+  background: rgba(15, 153, 96, 0.2);
+  color: #3dcc91;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+  color: #3dcc91;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:disabled,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled {
+  background: none;
+  color: rgba(61, 204, 145, 0.5);
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success:disabled.bp3-active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-success.bp3-disabled.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-warning {
+  color: #bf7326;
+}
+.bp3-button.bp3-minimal.bp3-intent-warning:hover,
+.bp3-button.bp3-minimal.bp3-intent-warning:active,
+.bp3-button.bp3-minimal.bp3-intent-warning.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #bf7326;
+}
+.bp3-button.bp3-minimal.bp3-intent-warning:hover {
+  background: rgba(217, 130, 43, 0.15);
+  color: #bf7326;
+}
+.bp3-button.bp3-minimal.bp3-intent-warning:active,
+.bp3-button.bp3-minimal.bp3-intent-warning.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+  color: #bf7326;
+}
+.bp3-button.bp3-minimal.bp3-intent-warning:disabled,
+.bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled {
+  background: none;
+  color: rgba(191, 115, 38, 0.5);
+}
+.bp3-button.bp3-minimal.bp3-intent-warning:disabled.bp3-active,
+.bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-warning
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #bf7326;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning {
+  color: #ffb366;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:hover {
+  background: rgba(217, 130, 43, 0.2);
+  color: #ffb366;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+  color: #ffb366;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:disabled,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled {
+  background: none;
+  color: rgba(255, 179, 102, 0.5);
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning:disabled.bp3-active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-warning.bp3-disabled.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-danger {
+  color: #c23030;
+}
+.bp3-button.bp3-minimal.bp3-intent-danger:hover,
+.bp3-button.bp3-minimal.bp3-intent-danger:active,
+.bp3-button.bp3-minimal.bp3-intent-danger.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #c23030;
+}
+.bp3-button.bp3-minimal.bp3-intent-danger:hover {
+  background: rgba(219, 55, 55, 0.15);
+  color: #c23030;
+}
+.bp3-button.bp3-minimal.bp3-intent-danger:active,
+.bp3-button.bp3-minimal.bp3-intent-danger.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+  color: #c23030;
+}
+.bp3-button.bp3-minimal.bp3-intent-danger:disabled,
+.bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled {
+  background: none;
+  color: rgba(194, 48, 48, 0.5);
+}
+.bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active,
+.bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+}
+.bp3-button.bp3-minimal.bp3-intent-danger
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #c23030;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger {
+  color: #ff7373;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:hover {
+  background: rgba(219, 55, 55, 0.2);
+  color: #ff7373;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+  color: #ff7373;
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled {
+  background: none;
+  color: rgba(255, 115, 115, 0.5);
+}
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active,
+.bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+}
 
-a.bp3-button{
-  text-align:center;
-  text-decoration:none;
-  -webkit-transition:none;
-  transition:none; }
-  a.bp3-button, a.bp3-button:hover, a.bp3-button:active{
-    color:#182026; }
-  a.bp3-button.bp3-disabled{
-    color:rgba(92, 112, 128, 0.6); }
+a.bp3-button {
+  text-align: center;
+  text-decoration: none;
+  -webkit-transition: none;
+  transition: none;
+}
+a.bp3-button,
+a.bp3-button:hover,
+a.bp3-button:active {
+  color: #182026;
+}
+a.bp3-button.bp3-disabled {
+  color: rgba(92, 112, 128, 0.6);
+}
 
-.bp3-button-text{
-  -webkit-box-flex:0;
-      -ms-flex:0 1 auto;
-          flex:0 1 auto; }
+.bp3-button-text {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
 
-.bp3-button.bp3-align-left .bp3-button-text, .bp3-button.bp3-align-right .bp3-button-text,
+.bp3-button.bp3-align-left .bp3-button-text,
+.bp3-button.bp3-align-right .bp3-button-text,
 .bp3-button-group.bp3-align-left .bp3-button-text,
-.bp3-button-group.bp3-align-right .bp3-button-text{
-  -webkit-box-flex:1;
-      -ms-flex:1 1 auto;
-          flex:1 1 auto; }
-.bp3-button-group{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex; }
-  .bp3-button-group .bp3-button{
-    -webkit-box-flex:0;
-        -ms-flex:0 0 auto;
-            flex:0 0 auto;
-    position:relative;
-    z-index:4; }
-    .bp3-button-group .bp3-button:focus{
-      z-index:5; }
-    .bp3-button-group .bp3-button:hover{
-      z-index:6; }
-    .bp3-button-group .bp3-button:active, .bp3-button-group .bp3-button.bp3-active{
-      z-index:7; }
-    .bp3-button-group .bp3-button:disabled, .bp3-button-group .bp3-button.bp3-disabled{
-      z-index:3; }
-    .bp3-button-group .bp3-button[class*="bp3-intent-"]{
-      z-index:9; }
-      .bp3-button-group .bp3-button[class*="bp3-intent-"]:focus{
-        z-index:10; }
-      .bp3-button-group .bp3-button[class*="bp3-intent-"]:hover{
-        z-index:11; }
-      .bp3-button-group .bp3-button[class*="bp3-intent-"]:active, .bp3-button-group .bp3-button[class*="bp3-intent-"].bp3-active{
-        z-index:12; }
-      .bp3-button-group .bp3-button[class*="bp3-intent-"]:disabled, .bp3-button-group .bp3-button[class*="bp3-intent-"].bp3-disabled{
-        z-index:8; }
-  .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:first-child) .bp3-button,
-  .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:first-child){
-    border-top-left-radius:0;
-    border-bottom-left-radius:0; }
-  .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
-  .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child){
-    margin-right:-1px;
-    border-top-right-radius:0;
-    border-bottom-right-radius:0; }
-  .bp3-button-group.bp3-minimal .bp3-button{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none; }
-    .bp3-button-group.bp3-minimal .bp3-button:hover{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(167, 182, 194, 0.3);
-      text-decoration:none;
-      color:#182026; }
-    .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(115, 134, 148, 0.3);
-      color:#182026; }
-    .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
-      background:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
-      .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
-        background:rgba(115, 134, 148, 0.3); }
-    .bp3-dark .bp3-button-group.bp3-minimal .bp3-button{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none;
-      color:inherit; }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none; }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover{
-        background:rgba(138, 155, 168, 0.15); }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
-        background:rgba(138, 155, 168, 0.3);
-        color:#f5f8fa; }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
-        background:none;
-        cursor:not-allowed;
-        color:rgba(167, 182, 194, 0.6); }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
-          background:rgba(138, 155, 168, 0.3); }
-    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary{
-      color:#106ba3; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#106ba3; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover{
-        background:rgba(19, 124, 189, 0.15);
-        color:#106ba3; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
-        background:rgba(19, 124, 189, 0.3);
-        color:#106ba3; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled{
-        background:none;
-        color:rgba(16, 107, 163, 0.5); }
-        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled.bp3-active{
-          background:rgba(19, 124, 189, 0.3); }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
-        stroke:#106ba3; }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary{
-        color:#48aff0; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover{
-          background:rgba(19, 124, 189, 0.2);
-          color:#48aff0; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
-          background:rgba(19, 124, 189, 0.3);
-          color:#48aff0; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled{
-          background:none;
-          color:rgba(72, 175, 240, 0.5); }
-          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled.bp3-active{
-            background:rgba(19, 124, 189, 0.3); }
-    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success{
-      color:#0d8050; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#0d8050; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover{
-        background:rgba(15, 153, 96, 0.15);
-        color:#0d8050; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
-        background:rgba(15, 153, 96, 0.3);
-        color:#0d8050; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled{
-        background:none;
-        color:rgba(13, 128, 80, 0.5); }
-        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled.bp3-active{
-          background:rgba(15, 153, 96, 0.3); }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
-        stroke:#0d8050; }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success{
-        color:#3dcc91; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover{
-          background:rgba(15, 153, 96, 0.2);
-          color:#3dcc91; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
-          background:rgba(15, 153, 96, 0.3);
-          color:#3dcc91; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled{
-          background:none;
-          color:rgba(61, 204, 145, 0.5); }
-          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled.bp3-active{
-            background:rgba(15, 153, 96, 0.3); }
-    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning{
-      color:#bf7326; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#bf7326; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover{
-        background:rgba(217, 130, 43, 0.15);
-        color:#bf7326; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
-        background:rgba(217, 130, 43, 0.3);
-        color:#bf7326; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled{
-        background:none;
-        color:rgba(191, 115, 38, 0.5); }
-        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled.bp3-active{
-          background:rgba(217, 130, 43, 0.3); }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
-        stroke:#bf7326; }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning{
-        color:#ffb366; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover{
-          background:rgba(217, 130, 43, 0.2);
-          color:#ffb366; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
-          background:rgba(217, 130, 43, 0.3);
-          color:#ffb366; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled{
-          background:none;
-          color:rgba(255, 179, 102, 0.5); }
-          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled.bp3-active{
-            background:rgba(217, 130, 43, 0.3); }
-    .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger{
-      color:#c23030; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none;
-        color:#c23030; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover{
-        background:rgba(219, 55, 55, 0.15);
-        color:#c23030; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
-        background:rgba(219, 55, 55, 0.3);
-        color:#c23030; }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled{
-        background:none;
-        color:rgba(194, 48, 48, 0.5); }
-        .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled.bp3-active{
-          background:rgba(219, 55, 55, 0.3); }
-      .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
-        stroke:#c23030; }
-      .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger{
-        color:#ff7373; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover{
-          background:rgba(219, 55, 55, 0.2);
-          color:#ff7373; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
-          background:rgba(219, 55, 55, 0.3);
-          color:#ff7373; }
-        .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled{
-          background:none;
-          color:rgba(255, 115, 115, 0.5); }
-          .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled.bp3-active{
-            background:rgba(219, 55, 55, 0.3); }
-  .bp3-button-group .bp3-popover-wrapper,
-  .bp3-button-group .bp3-popover-target{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto; }
-  .bp3-button-group.bp3-fill{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    width:100%; }
-  .bp3-button-group .bp3-button.bp3-fill,
-  .bp3-button-group.bp3-fill .bp3-button:not(.bp3-fixed){
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto; }
-  .bp3-button-group.bp3-vertical{
-    -webkit-box-orient:vertical;
-    -webkit-box-direction:normal;
-        -ms-flex-direction:column;
-            flex-direction:column;
-    -webkit-box-align:stretch;
-        -ms-flex-align:stretch;
-            align-items:stretch;
-    vertical-align:top; }
-    .bp3-button-group.bp3-vertical.bp3-fill{
-      width:unset;
-      height:100%; }
-    .bp3-button-group.bp3-vertical .bp3-button{
-      margin-right:0 !important;
-      width:100%; }
-    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-popover-wrapper:first-child .bp3-button,
-    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:first-child{
-      border-radius:3px 3px 0 0; }
-    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-popover-wrapper:last-child .bp3-button,
-    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:last-child{
-      border-radius:0 0 3px 3px; }
-    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
-    .bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:not(:last-child){
-      margin-bottom:-1px; }
-  .bp3-button-group.bp3-align-left .bp3-button{
-    text-align:left; }
-  .bp3-dark .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
-  .bp3-dark .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child){
-    margin-right:1px; }
-  .bp3-dark .bp3-button-group.bp3-vertical > .bp3-popover-wrapper:not(:last-child) .bp3-button,
-  .bp3-dark .bp3-button-group.bp3-vertical > .bp3-button:not(:last-child){
-    margin-bottom:1px; }
-.bp3-callout{
-  line-height:1.5;
-  font-size:14px;
-  position:relative;
-  border-radius:3px;
-  background-color:rgba(138, 155, 168, 0.15);
-  width:100%;
-  padding:10px 12px 9px; }
-  .bp3-callout[class*="bp3-icon-"]{
-    padding-left:40px; }
-    .bp3-callout[class*="bp3-icon-"]::before{
-      line-height:1;
-      font-family:"Icons20", sans-serif;
-      font-size:20px;
-      font-weight:400;
-      font-style:normal;
-      -moz-osx-font-smoothing:grayscale;
-      -webkit-font-smoothing:antialiased;
-      position:absolute;
-      top:10px;
-      left:10px;
-      color:#5c7080; }
-  .bp3-callout.bp3-callout-icon{
-    padding-left:40px; }
-    .bp3-callout.bp3-callout-icon > .bp3-icon:first-child{
-      position:absolute;
-      top:10px;
-      left:10px;
-      color:#5c7080; }
-  .bp3-callout .bp3-heading{
-    margin-top:0;
-    margin-bottom:5px;
-    line-height:20px; }
-    .bp3-callout .bp3-heading:last-child{
-      margin-bottom:0; }
-  .bp3-dark .bp3-callout{
-    background-color:rgba(138, 155, 168, 0.2); }
-    .bp3-dark .bp3-callout[class*="bp3-icon-"]::before{
-      color:#a7b6c2; }
-  .bp3-callout.bp3-intent-primary{
-    background-color:rgba(19, 124, 189, 0.15); }
-    .bp3-callout.bp3-intent-primary[class*="bp3-icon-"]::before,
-    .bp3-callout.bp3-intent-primary > .bp3-icon:first-child,
-    .bp3-callout.bp3-intent-primary .bp3-heading{
-      color:#106ba3; }
-    .bp3-dark .bp3-callout.bp3-intent-primary{
-      background-color:rgba(19, 124, 189, 0.25); }
-      .bp3-dark .bp3-callout.bp3-intent-primary[class*="bp3-icon-"]::before,
-      .bp3-dark .bp3-callout.bp3-intent-primary > .bp3-icon:first-child,
-      .bp3-dark .bp3-callout.bp3-intent-primary .bp3-heading{
-        color:#48aff0; }
-  .bp3-callout.bp3-intent-success{
-    background-color:rgba(15, 153, 96, 0.15); }
-    .bp3-callout.bp3-intent-success[class*="bp3-icon-"]::before,
-    .bp3-callout.bp3-intent-success > .bp3-icon:first-child,
-    .bp3-callout.bp3-intent-success .bp3-heading{
-      color:#0d8050; }
-    .bp3-dark .bp3-callout.bp3-intent-success{
-      background-color:rgba(15, 153, 96, 0.25); }
-      .bp3-dark .bp3-callout.bp3-intent-success[class*="bp3-icon-"]::before,
-      .bp3-dark .bp3-callout.bp3-intent-success > .bp3-icon:first-child,
-      .bp3-dark .bp3-callout.bp3-intent-success .bp3-heading{
-        color:#3dcc91; }
-  .bp3-callout.bp3-intent-warning{
-    background-color:rgba(217, 130, 43, 0.15); }
-    .bp3-callout.bp3-intent-warning[class*="bp3-icon-"]::before,
-    .bp3-callout.bp3-intent-warning > .bp3-icon:first-child,
-    .bp3-callout.bp3-intent-warning .bp3-heading{
-      color:#bf7326; }
-    .bp3-dark .bp3-callout.bp3-intent-warning{
-      background-color:rgba(217, 130, 43, 0.25); }
-      .bp3-dark .bp3-callout.bp3-intent-warning[class*="bp3-icon-"]::before,
-      .bp3-dark .bp3-callout.bp3-intent-warning > .bp3-icon:first-child,
-      .bp3-dark .bp3-callout.bp3-intent-warning .bp3-heading{
-        color:#ffb366; }
-  .bp3-callout.bp3-intent-danger{
-    background-color:rgba(219, 55, 55, 0.15); }
-    .bp3-callout.bp3-intent-danger[class*="bp3-icon-"]::before,
-    .bp3-callout.bp3-intent-danger > .bp3-icon:first-child,
-    .bp3-callout.bp3-intent-danger .bp3-heading{
-      color:#c23030; }
-    .bp3-dark .bp3-callout.bp3-intent-danger{
-      background-color:rgba(219, 55, 55, 0.25); }
-      .bp3-dark .bp3-callout.bp3-intent-danger[class*="bp3-icon-"]::before,
-      .bp3-dark .bp3-callout.bp3-intent-danger > .bp3-icon:first-child,
-      .bp3-dark .bp3-callout.bp3-intent-danger .bp3-heading{
-        color:#ff7373; }
-  .bp3-running-text .bp3-callout{
-    margin:20px 0; }
-.bp3-card{
-  border-radius:3px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-  background-color:#ffffff;
-  padding:20px;
-  -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-  .bp3-card.bp3-dark,
-  .bp3-dark .bp3-card{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-    background-color:#30404d; }
+.bp3-button-group.bp3-align-right .bp3-button-text {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+.bp3-button-group {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+.bp3-button-group .bp3-button {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  position: relative;
+  z-index: 4;
+}
+.bp3-button-group .bp3-button:focus {
+  z-index: 5;
+}
+.bp3-button-group .bp3-button:hover {
+  z-index: 6;
+}
+.bp3-button-group .bp3-button:active,
+.bp3-button-group .bp3-button.bp3-active {
+  z-index: 7;
+}
+.bp3-button-group .bp3-button:disabled,
+.bp3-button-group .bp3-button.bp3-disabled {
+  z-index: 3;
+}
+.bp3-button-group .bp3-button[class*='bp3-intent-'] {
+  z-index: 9;
+}
+.bp3-button-group .bp3-button[class*='bp3-intent-']:focus {
+  z-index: 10;
+}
+.bp3-button-group .bp3-button[class*='bp3-intent-']:hover {
+  z-index: 11;
+}
+.bp3-button-group .bp3-button[class*='bp3-intent-']:active,
+.bp3-button-group .bp3-button[class*='bp3-intent-'].bp3-active {
+  z-index: 12;
+}
+.bp3-button-group .bp3-button[class*='bp3-intent-']:disabled,
+.bp3-button-group .bp3-button[class*='bp3-intent-'].bp3-disabled {
+  z-index: 8;
+}
+.bp3-button-group:not(.bp3-minimal)
+  > .bp3-popover-wrapper:not(:first-child)
+  .bp3-button,
+.bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.bp3-button-group:not(.bp3-minimal)
+  > .bp3-popover-wrapper:not(:last-child)
+  .bp3-button,
+.bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child) {
+  margin-right: -1px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.bp3-button-group.bp3-minimal .bp3-button {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+}
+.bp3-button-group.bp3-minimal .bp3-button:hover {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(167, 182, 194, 0.3);
+  text-decoration: none;
+  color: #182026;
+}
+.bp3-button-group.bp3-minimal .bp3-button:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(115, 134, 148, 0.3);
+  color: #182026;
+}
+.bp3-button-group.bp3-minimal .bp3-button:disabled,
+.bp3-button-group.bp3-minimal .bp3-button:disabled:hover,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-disabled,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover {
+  background: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active,
+.bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active {
+  background: rgba(115, 134, 148, 0.3);
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: inherit;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover {
+  background: rgba(138, 155, 168, 0.15);
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active {
+  background: rgba(138, 155, 168, 0.3);
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover {
+  background: none;
+  cursor: not-allowed;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active,
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-disabled:hover.bp3-active {
+  background: rgba(138, 155, 168, 0.3);
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary {
+  color: #106ba3;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #106ba3;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover {
+  background: rgba(19, 124, 189, 0.15);
+  color: #106ba3;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+  color: #106ba3;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-disabled {
+  background: none;
+  color: rgba(16, 107, 163, 0.5);
+}
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-primary:disabled.bp3-active,
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-primary.bp3-disabled.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+}
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-primary
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #106ba3;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary {
+  color: #48aff0;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover {
+  background: rgba(19, 124, 189, 0.2);
+  color: #48aff0;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-primary.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+  color: #48aff0;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:disabled,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-primary.bp3-disabled {
+  background: none;
+  color: rgba(72, 175, 240, 0.5);
+}
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-primary:disabled.bp3-active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-primary.bp3-disabled.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success {
+  color: #0d8050;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #0d8050;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover {
+  background: rgba(15, 153, 96, 0.15);
+  color: #0d8050;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+  color: #0d8050;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-disabled {
+  background: none;
+  color: rgba(13, 128, 80, 0.5);
+}
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-success:disabled.bp3-active,
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-success.bp3-disabled.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+}
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-success
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #0d8050;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success {
+  color: #3dcc91;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover {
+  background: rgba(15, 153, 96, 0.2);
+  color: #3dcc91;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-success.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+  color: #3dcc91;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:disabled,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-success.bp3-disabled {
+  background: none;
+  color: rgba(61, 204, 145, 0.5);
+}
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-success:disabled.bp3-active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-success.bp3-disabled.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning {
+  color: #bf7326;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #bf7326;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover {
+  background: rgba(217, 130, 43, 0.15);
+  color: #bf7326;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+  color: #bf7326;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-disabled {
+  background: none;
+  color: rgba(191, 115, 38, 0.5);
+}
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-warning:disabled.bp3-active,
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-warning.bp3-disabled.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+}
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-warning
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #bf7326;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning {
+  color: #ffb366;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover {
+  background: rgba(217, 130, 43, 0.2);
+  color: #ffb366;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-warning.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+  color: #ffb366;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:disabled,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-warning.bp3-disabled {
+  background: none;
+  color: rgba(255, 179, 102, 0.5);
+}
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-warning:disabled.bp3-active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-warning.bp3-disabled.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger {
+  color: #c23030;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #c23030;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover {
+  background: rgba(219, 55, 55, 0.15);
+  color: #c23030;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+  color: #c23030;
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled,
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-disabled {
+  background: none;
+  color: rgba(194, 48, 48, 0.5);
+}
+.bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled.bp3-active,
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-danger.bp3-disabled.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+}
+.bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-danger
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #c23030;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger {
+  color: #ff7373;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover {
+  background: rgba(219, 55, 55, 0.2);
+  color: #ff7373;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-danger.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+  color: #ff7373;
+}
+.bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:disabled,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-danger.bp3-disabled {
+  background: none;
+  color: rgba(255, 115, 115, 0.5);
+}
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-danger:disabled.bp3-active,
+.bp3-dark
+  .bp3-button-group.bp3-minimal
+  .bp3-button.bp3-intent-danger.bp3-disabled.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+}
+.bp3-button-group .bp3-popover-wrapper,
+.bp3-button-group .bp3-popover-target {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+.bp3-button-group.bp3-fill {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+.bp3-button-group .bp3-button.bp3-fill,
+.bp3-button-group.bp3-fill .bp3-button:not(.bp3-fixed) {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+.bp3-button-group.bp3-vertical {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  vertical-align: top;
+}
+.bp3-button-group.bp3-vertical.bp3-fill {
+  width: unset;
+  height: 100%;
+}
+.bp3-button-group.bp3-vertical .bp3-button {
+  margin-right: 0 !important;
+  width: 100%;
+}
+.bp3-button-group.bp3-vertical:not(.bp3-minimal)
+  > .bp3-popover-wrapper:first-child
+  .bp3-button,
+.bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:first-child {
+  border-radius: 3px 3px 0 0;
+}
+.bp3-button-group.bp3-vertical:not(.bp3-minimal)
+  > .bp3-popover-wrapper:last-child
+  .bp3-button,
+.bp3-button-group.bp3-vertical:not(.bp3-minimal) > .bp3-button:last-child {
+  border-radius: 0 0 3px 3px;
+}
+.bp3-button-group.bp3-vertical:not(.bp3-minimal)
+  > .bp3-popover-wrapper:not(:last-child)
+  .bp3-button,
+.bp3-button-group.bp3-vertical:not(.bp3-minimal)
+  > .bp3-button:not(:last-child) {
+  margin-bottom: -1px;
+}
+.bp3-button-group.bp3-align-left .bp3-button {
+  text-align: left;
+}
+.bp3-dark
+  .bp3-button-group:not(.bp3-minimal)
+  > .bp3-popover-wrapper:not(:last-child)
+  .bp3-button,
+.bp3-dark .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child) {
+  margin-right: 1px;
+}
+.bp3-dark
+  .bp3-button-group.bp3-vertical
+  > .bp3-popover-wrapper:not(:last-child)
+  .bp3-button,
+.bp3-dark .bp3-button-group.bp3-vertical > .bp3-button:not(:last-child) {
+  margin-bottom: 1px;
+}
+.bp3-callout {
+  line-height: 1.5;
+  font-size: 14px;
+  position: relative;
+  border-radius: 3px;
+  background-color: rgba(138, 155, 168, 0.15);
+  width: 100%;
+  padding: 10px 12px 9px;
+}
+.bp3-callout[class*='bp3-icon-'] {
+  padding-left: 40px;
+}
+.bp3-callout[class*='bp3-icon-']::before {
+  line-height: 1;
+  font-family: 'Icons20', sans-serif;
+  font-size: 20px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  color: #5c7080;
+}
+.bp3-callout.bp3-callout-icon {
+  padding-left: 40px;
+}
+.bp3-callout.bp3-callout-icon > .bp3-icon:first-child {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  color: #5c7080;
+}
+.bp3-callout .bp3-heading {
+  margin-top: 0;
+  margin-bottom: 5px;
+  line-height: 20px;
+}
+.bp3-callout .bp3-heading:last-child {
+  margin-bottom: 0;
+}
+.bp3-dark .bp3-callout {
+  background-color: rgba(138, 155, 168, 0.2);
+}
+.bp3-dark .bp3-callout[class*='bp3-icon-']::before {
+  color: #a7b6c2;
+}
+.bp3-callout.bp3-intent-primary {
+  background-color: rgba(19, 124, 189, 0.15);
+}
+.bp3-callout.bp3-intent-primary[class*='bp3-icon-']::before,
+.bp3-callout.bp3-intent-primary > .bp3-icon:first-child,
+.bp3-callout.bp3-intent-primary .bp3-heading {
+  color: #106ba3;
+}
+.bp3-dark .bp3-callout.bp3-intent-primary {
+  background-color: rgba(19, 124, 189, 0.25);
+}
+.bp3-dark .bp3-callout.bp3-intent-primary[class*='bp3-icon-']::before,
+.bp3-dark .bp3-callout.bp3-intent-primary > .bp3-icon:first-child,
+.bp3-dark .bp3-callout.bp3-intent-primary .bp3-heading {
+  color: #48aff0;
+}
+.bp3-callout.bp3-intent-success {
+  background-color: rgba(15, 153, 96, 0.15);
+}
+.bp3-callout.bp3-intent-success[class*='bp3-icon-']::before,
+.bp3-callout.bp3-intent-success > .bp3-icon:first-child,
+.bp3-callout.bp3-intent-success .bp3-heading {
+  color: #0d8050;
+}
+.bp3-dark .bp3-callout.bp3-intent-success {
+  background-color: rgba(15, 153, 96, 0.25);
+}
+.bp3-dark .bp3-callout.bp3-intent-success[class*='bp3-icon-']::before,
+.bp3-dark .bp3-callout.bp3-intent-success > .bp3-icon:first-child,
+.bp3-dark .bp3-callout.bp3-intent-success .bp3-heading {
+  color: #3dcc91;
+}
+.bp3-callout.bp3-intent-warning {
+  background-color: rgba(217, 130, 43, 0.15);
+}
+.bp3-callout.bp3-intent-warning[class*='bp3-icon-']::before,
+.bp3-callout.bp3-intent-warning > .bp3-icon:first-child,
+.bp3-callout.bp3-intent-warning .bp3-heading {
+  color: #bf7326;
+}
+.bp3-dark .bp3-callout.bp3-intent-warning {
+  background-color: rgba(217, 130, 43, 0.25);
+}
+.bp3-dark .bp3-callout.bp3-intent-warning[class*='bp3-icon-']::before,
+.bp3-dark .bp3-callout.bp3-intent-warning > .bp3-icon:first-child,
+.bp3-dark .bp3-callout.bp3-intent-warning .bp3-heading {
+  color: #ffb366;
+}
+.bp3-callout.bp3-intent-danger {
+  background-color: rgba(219, 55, 55, 0.15);
+}
+.bp3-callout.bp3-intent-danger[class*='bp3-icon-']::before,
+.bp3-callout.bp3-intent-danger > .bp3-icon:first-child,
+.bp3-callout.bp3-intent-danger .bp3-heading {
+  color: #c23030;
+}
+.bp3-dark .bp3-callout.bp3-intent-danger {
+  background-color: rgba(219, 55, 55, 0.25);
+}
+.bp3-dark .bp3-callout.bp3-intent-danger[class*='bp3-icon-']::before,
+.bp3-dark .bp3-callout.bp3-intent-danger > .bp3-icon:first-child,
+.bp3-dark .bp3-callout.bp3-intent-danger .bp3-heading {
+  color: #ff7373;
+}
+.bp3-running-text .bp3-callout {
+  margin: 20px 0;
+}
+.bp3-card {
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.15),
+    0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0),
+    0 0 0 rgba(16, 22, 26, 0);
+  background-color: #ffffff;
+  padding: 20px;
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-card.bp3-dark,
+.bp3-dark .bp3-card {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0),
+    0 0 0 rgba(16, 22, 26, 0);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0),
+    0 0 0 rgba(16, 22, 26, 0);
+  background-color: #30404d;
+}
 
-.bp3-elevation-0{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0); }
-  .bp3-elevation-0.bp3-dark,
-  .bp3-dark .bp3-elevation-0{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0); }
+.bp3-elevation-0 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.15),
+    0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0),
+    0 0 0 rgba(16, 22, 26, 0);
+}
+.bp3-elevation-0.bp3-dark,
+.bp3-dark .bp3-elevation-0 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0),
+    0 0 0 rgba(16, 22, 26, 0);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0),
+    0 0 0 rgba(16, 22, 26, 0);
+}
 
-.bp3-elevation-1{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-elevation-1.bp3-dark,
-  .bp3-dark .bp3-elevation-1{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
+.bp3-elevation-1 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-elevation-1.bp3-dark,
+.bp3-dark .bp3-elevation-1 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+}
 
-.bp3-elevation-2{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 1px 1px rgba(16, 22, 26, 0.2), 0 2px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 1px 1px rgba(16, 22, 26, 0.2), 0 2px 6px rgba(16, 22, 26, 0.2); }
-  .bp3-elevation-2.bp3-dark,
-  .bp3-dark .bp3-elevation-2{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.4), 0 2px 6px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.4), 0 2px 6px rgba(16, 22, 26, 0.4); }
+.bp3-elevation-2 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 1px 1px rgba(16, 22, 26, 0.2), 0 2px 6px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 1px 1px rgba(16, 22, 26, 0.2),
+    0 2px 6px rgba(16, 22, 26, 0.2);
+}
+.bp3-elevation-2.bp3-dark,
+.bp3-dark .bp3-elevation-2 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 1px 1px rgba(16, 22, 26, 0.4), 0 2px 6px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.4),
+    0 2px 6px rgba(16, 22, 26, 0.4);
+}
 
-.bp3-elevation-3{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2); }
-  .bp3-elevation-3.bp3-dark,
-  .bp3-dark .bp3-elevation-3{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
+.bp3-elevation-3 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
+    0 8px 24px rgba(16, 22, 26, 0.2);
+}
+.bp3-elevation-3.bp3-dark,
+.bp3-dark .bp3-elevation-3 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4),
+    0 8px 24px rgba(16, 22, 26, 0.4);
+}
 
-.bp3-elevation-4{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2); }
-  .bp3-elevation-4.bp3-dark,
-  .bp3-dark .bp3-elevation-4{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4); }
+.bp3-elevation-4 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2),
+    0 18px 46px 6px rgba(16, 22, 26, 0.2);
+}
+.bp3-elevation-4.bp3-dark,
+.bp3-dark .bp3-elevation-4 {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4),
+    0 18px 46px 6px rgba(16, 22, 26, 0.4);
+}
 
-.bp3-card.bp3-interactive:hover{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-  cursor:pointer; }
-  .bp3-card.bp3-interactive:hover.bp3-dark,
-  .bp3-dark .bp3-card.bp3-interactive:hover{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
+.bp3-card.bp3-interactive:hover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
+    0 8px 24px rgba(16, 22, 26, 0.2);
+  cursor: pointer;
+}
+.bp3-card.bp3-interactive:hover.bp3-dark,
+.bp3-dark .bp3-card.bp3-interactive:hover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4),
+    0 8px 24px rgba(16, 22, 26, 0.4);
+}
 
-.bp3-card.bp3-interactive:active{
-  opacity:0.9;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-  -webkit-transition-duration:0;
-          transition-duration:0; }
-  .bp3-card.bp3-interactive:active.bp3-dark,
-  .bp3-dark .bp3-card.bp3-interactive:active{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
+.bp3-card.bp3-interactive:active {
+  opacity: 0.9;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  -webkit-transition-duration: 0;
+  transition-duration: 0;
+}
+.bp3-card.bp3-interactive:active.bp3-dark,
+.bp3-dark .bp3-card.bp3-interactive:active {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+}
 
-.bp3-collapse{
-  height:0;
-  overflow-y:hidden;
-  -webkit-transition:height 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:height 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-  .bp3-collapse .bp3-collapse-body{
-    -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-    .bp3-collapse .bp3-collapse-body[aria-hidden="true"]{
-      display:none; }
+.bp3-collapse {
+  height: 0;
+  overflow-y: hidden;
+  -webkit-transition: height 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: height 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-collapse .bp3-collapse-body {
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-collapse .bp3-collapse-body[aria-hidden='true'] {
+  display: none;
+}
 
-.bp3-context-menu .bp3-popover-target{
-  display:block; }
+.bp3-context-menu .bp3-popover-target {
+  display: block;
+}
 
-.bp3-context-menu-popover-target{
-  position:fixed; }
+.bp3-context-menu-popover-target {
+  position: fixed;
+}
 
-.bp3-divider{
-  margin:5px;
-  border-right:1px solid rgba(16, 22, 26, 0.15);
-  border-bottom:1px solid rgba(16, 22, 26, 0.15); }
-  .bp3-dark .bp3-divider{
-    border-color:rgba(16, 22, 26, 0.4); }
-.bp3-dialog-container{
-  opacity:1;
-  -webkit-transform:scale(1);
-          transform:scale(1);
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
-  width:100%;
-  min-height:100%;
-  pointer-events:none;
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-dialog-container.bp3-overlay-enter > .bp3-dialog, .bp3-dialog-container.bp3-overlay-appear > .bp3-dialog{
-    opacity:0;
-    -webkit-transform:scale(0.5);
-            transform:scale(0.5); }
-  .bp3-dialog-container.bp3-overlay-enter-active > .bp3-dialog, .bp3-dialog-container.bp3-overlay-appear-active > .bp3-dialog{
-    opacity:1;
-    -webkit-transform:scale(1);
-            transform:scale(1);
-    -webkit-transition-property:opacity, -webkit-transform;
-    transition-property:opacity, -webkit-transform;
-    transition-property:opacity, transform;
-    transition-property:opacity, transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
-    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-dialog-container.bp3-overlay-exit > .bp3-dialog{
-    opacity:1;
-    -webkit-transform:scale(1);
-            transform:scale(1); }
-  .bp3-dialog-container.bp3-overlay-exit-active > .bp3-dialog{
-    opacity:0;
-    -webkit-transform:scale(0.5);
-            transform:scale(0.5);
-    -webkit-transition-property:opacity, -webkit-transform;
-    transition-property:opacity, -webkit-transform;
-    transition-property:opacity, transform;
-    transition-property:opacity, transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
-    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+.bp3-divider {
+  margin: 5px;
+  border-right: 1px solid rgba(16, 22, 26, 0.15);
+  border-bottom: 1px solid rgba(16, 22, 26, 0.15);
+}
+.bp3-dark .bp3-divider {
+  border-color: rgba(16, 22, 26, 0.4);
+}
+.bp3-dialog-container {
+  opacity: 1;
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 100%;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-dialog-container.bp3-overlay-enter > .bp3-dialog,
+.bp3-dialog-container.bp3-overlay-appear > .bp3-dialog {
+  opacity: 0;
+  -webkit-transform: scale(0.5);
+  transform: scale(0.5);
+}
+.bp3-dialog-container.bp3-overlay-enter-active > .bp3-dialog,
+.bp3-dialog-container.bp3-overlay-appear-active > .bp3-dialog {
+  opacity: 1;
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-property: opacity, -webkit-transform;
+  transition-property: opacity, -webkit-transform;
+  transition-property: opacity, transform;
+  transition-property: opacity, transform, -webkit-transform;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-dialog-container.bp3-overlay-exit > .bp3-dialog {
+  opacity: 1;
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+.bp3-dialog-container.bp3-overlay-exit-active > .bp3-dialog {
+  opacity: 0;
+  -webkit-transform: scale(0.5);
+  transform: scale(0.5);
+  -webkit-transition-property: opacity, -webkit-transform;
+  transition-property: opacity, -webkit-transform;
+  transition-property: opacity, transform;
+  transition-property: opacity, transform, -webkit-transform;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
 
-.bp3-dialog{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:vertical;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:column;
-          flex-direction:column;
-  margin:30px 0;
-  border-radius:6px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background:#ebf1f5;
-  width:500px;
-  padding-bottom:20px;
-  pointer-events:all;
-  -webkit-user-select:text;
-     -moz-user-select:text;
-      -ms-user-select:text;
-          user-select:text; }
-  .bp3-dialog:focus{
-    outline:0; }
-  .bp3-dialog.bp3-dark,
-  .bp3-dark .bp3-dialog{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background:#293742;
-    color:#f5f8fa; }
+.bp3-dialog {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 30px 0;
+  border-radius: 6px;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2),
+    0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  background: #ebf1f5;
+  width: 500px;
+  padding-bottom: 20px;
+  pointer-events: all;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+.bp3-dialog:focus {
+  outline: 0;
+}
+.bp3-dialog.bp3-dark,
+.bp3-dark .bp3-dialog {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4),
+    0 18px 46px 6px rgba(16, 22, 26, 0.4);
+  background: #293742;
+  color: #f5f8fa;
+}
 
-.bp3-dialog-header{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-flex:0;
-      -ms-flex:0 0 auto;
-          flex:0 0 auto;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  border-radius:6px 6px 0 0;
-  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-  background:#ffffff;
-  min-height:40px;
-  padding-right:5px;
-  padding-left:20px; }
-  .bp3-dialog-header .bp3-icon-large,
-  .bp3-dialog-header .bp3-icon{
-    -webkit-box-flex:0;
-        -ms-flex:0 0 auto;
-            flex:0 0 auto;
-    margin-right:10px;
-    color:#5c7080; }
-  .bp3-dialog-header .bp3-heading{
-    overflow:hidden;
-    text-overflow:ellipsis;
-    white-space:nowrap;
-    word-wrap:normal;
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto;
-    margin:0;
-    line-height:inherit; }
-    .bp3-dialog-header .bp3-heading:last-child{
-      margin-right:20px; }
-  .bp3-dark .bp3-dialog-header{
-    -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
-            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
-    background:#30404d; }
-    .bp3-dark .bp3-dialog-header .bp3-icon-large,
-    .bp3-dark .bp3-dialog-header .bp3-icon{
-      color:#a7b6c2; }
+.bp3-dialog-header {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 6px 6px 0 0;
+  -webkit-box-shadow: 0 1px 0 rgba(16, 22, 26, 0.15);
+  box-shadow: 0 1px 0 rgba(16, 22, 26, 0.15);
+  background: #ffffff;
+  min-height: 40px;
+  padding-right: 5px;
+  padding-left: 20px;
+}
+.bp3-dialog-header .bp3-icon-large,
+.bp3-dialog-header .bp3-icon {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin-right: 10px;
+  color: #5c7080;
+}
+.bp3-dialog-header .bp3-heading {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin: 0;
+  line-height: inherit;
+}
+.bp3-dialog-header .bp3-heading:last-child {
+  margin-right: 20px;
+}
+.bp3-dark .bp3-dialog-header {
+  -webkit-box-shadow: 0 1px 0 rgba(16, 22, 26, 0.4);
+  box-shadow: 0 1px 0 rgba(16, 22, 26, 0.4);
+  background: #30404d;
+}
+.bp3-dark .bp3-dialog-header .bp3-icon-large,
+.bp3-dark .bp3-dialog-header .bp3-icon {
+  color: #a7b6c2;
+}
 
-.bp3-dialog-body{
-  -webkit-box-flex:1;
-      -ms-flex:1 1 auto;
-          flex:1 1 auto;
-  margin:20px;
-  line-height:18px; }
+.bp3-dialog-body {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin: 20px;
+  line-height: 18px;
+}
 
-.bp3-dialog-footer{
-  -webkit-box-flex:0;
-      -ms-flex:0 0 auto;
-          flex:0 0 auto;
-  margin:0 20px; }
+.bp3-dialog-footer {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0 20px;
+}
 
-.bp3-dialog-footer-actions{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-pack:end;
-      -ms-flex-pack:end;
-          justify-content:flex-end; }
-  .bp3-dialog-footer-actions .bp3-button{
-    margin-left:10px; }
-.bp3-drawer{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:vertical;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:column;
-          flex-direction:column;
-  margin:0;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  padding:0; }
-  .bp3-drawer:focus{
-    outline:0; }
-  .bp3-drawer.bp3-position-top{
-    top:0;
-    right:0;
-    left:0;
-    height:50%; }
-    .bp3-drawer.bp3-position-top.bp3-overlay-enter, .bp3-drawer.bp3-position-top.bp3-overlay-appear{
-      -webkit-transform:translateY(-100%);
-              transform:translateY(-100%); }
-    .bp3-drawer.bp3-position-top.bp3-overlay-enter-active, .bp3-drawer.bp3-position-top.bp3-overlay-appear-active{
-      -webkit-transform:translateY(0);
-              transform:translateY(0);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-    .bp3-drawer.bp3-position-top.bp3-overlay-exit{
-      -webkit-transform:translateY(0);
-              transform:translateY(0); }
-    .bp3-drawer.bp3-position-top.bp3-overlay-exit-active{
-      -webkit-transform:translateY(-100%);
-              transform:translateY(-100%);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-  .bp3-drawer.bp3-position-bottom{
-    right:0;
-    bottom:0;
-    left:0;
-    height:50%; }
-    .bp3-drawer.bp3-position-bottom.bp3-overlay-enter, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear{
-      -webkit-transform:translateY(100%);
-              transform:translateY(100%); }
-    .bp3-drawer.bp3-position-bottom.bp3-overlay-enter-active, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear-active{
-      -webkit-transform:translateY(0);
-              transform:translateY(0);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-    .bp3-drawer.bp3-position-bottom.bp3-overlay-exit{
-      -webkit-transform:translateY(0);
-              transform:translateY(0); }
-    .bp3-drawer.bp3-position-bottom.bp3-overlay-exit-active{
-      -webkit-transform:translateY(100%);
-              transform:translateY(100%);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-  .bp3-drawer.bp3-position-left{
-    top:0;
-    bottom:0;
-    left:0;
-    width:50%; }
-    .bp3-drawer.bp3-position-left.bp3-overlay-enter, .bp3-drawer.bp3-position-left.bp3-overlay-appear{
-      -webkit-transform:translateX(-100%);
-              transform:translateX(-100%); }
-    .bp3-drawer.bp3-position-left.bp3-overlay-enter-active, .bp3-drawer.bp3-position-left.bp3-overlay-appear-active{
-      -webkit-transform:translateX(0);
-              transform:translateX(0);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-    .bp3-drawer.bp3-position-left.bp3-overlay-exit{
-      -webkit-transform:translateX(0);
-              transform:translateX(0); }
-    .bp3-drawer.bp3-position-left.bp3-overlay-exit-active{
-      -webkit-transform:translateX(-100%);
-              transform:translateX(-100%);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-  .bp3-drawer.bp3-position-right{
-    top:0;
-    right:0;
-    bottom:0;
-    width:50%; }
-    .bp3-drawer.bp3-position-right.bp3-overlay-enter, .bp3-drawer.bp3-position-right.bp3-overlay-appear{
-      -webkit-transform:translateX(100%);
-              transform:translateX(100%); }
-    .bp3-drawer.bp3-position-right.bp3-overlay-enter-active, .bp3-drawer.bp3-position-right.bp3-overlay-appear-active{
-      -webkit-transform:translateX(0);
-              transform:translateX(0);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-    .bp3-drawer.bp3-position-right.bp3-overlay-exit{
-      -webkit-transform:translateX(0);
-              transform:translateX(0); }
-    .bp3-drawer.bp3-position-right.bp3-overlay-exit-active{
-      -webkit-transform:translateX(100%);
-              transform:translateX(100%);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-  .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-  .bp3-position-right):not(.bp3-vertical){
-    top:0;
-    right:0;
-    bottom:0;
-    width:50%; }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right):not(.bp3-vertical).bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right):not(.bp3-vertical).bp3-overlay-appear{
-      -webkit-transform:translateX(100%);
-              transform:translateX(100%); }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right):not(.bp3-vertical).bp3-overlay-enter-active, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right):not(.bp3-vertical).bp3-overlay-appear-active{
-      -webkit-transform:translateX(0);
-              transform:translateX(0);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit{
-      -webkit-transform:translateX(0);
-              transform:translateX(0); }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit-active{
-      -webkit-transform:translateX(100%);
-              transform:translateX(100%);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-  .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-  .bp3-position-right).bp3-vertical{
-    right:0;
-    bottom:0;
-    left:0;
-    height:50%; }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right).bp3-vertical.bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right).bp3-vertical.bp3-overlay-appear{
-      -webkit-transform:translateY(100%);
-              transform:translateY(100%); }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right).bp3-vertical.bp3-overlay-enter-active, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right).bp3-vertical.bp3-overlay-appear-active{
-      -webkit-transform:translateY(0);
-              transform:translateY(0);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right).bp3-vertical.bp3-overlay-exit{
-      -webkit-transform:translateY(0);
-              transform:translateY(0); }
-    .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
-    .bp3-position-right).bp3-vertical.bp3-overlay-exit-active{
-      -webkit-transform:translateY(100%);
-              transform:translateY(100%);
-      -webkit-transition-property:-webkit-transform;
-      transition-property:-webkit-transform;
-      transition-property:transform;
-      transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
-      -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
-  .bp3-drawer.bp3-dark,
-  .bp3-dark .bp3-drawer{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background:#30404d;
-    color:#f5f8fa; }
+.bp3-dialog-footer-actions {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+.bp3-dialog-footer-actions .bp3-button {
+  margin-left: 10px;
+}
+.bp3-drawer {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2),
+    0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  background: #ffffff;
+  padding: 0;
+}
+.bp3-drawer:focus {
+  outline: 0;
+}
+.bp3-drawer.bp3-position-top {
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 50%;
+}
+.bp3-drawer.bp3-position-top.bp3-overlay-enter,
+.bp3-drawer.bp3-position-top.bp3-overlay-appear {
+  -webkit-transform: translateY(-100%);
+  transform: translateY(-100%);
+}
+.bp3-drawer.bp3-position-top.bp3-overlay-enter-active,
+.bp3-drawer.bp3-position-top.bp3-overlay-appear-active {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-position-top.bp3-overlay-exit {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+}
+.bp3-drawer.bp3-position-top.bp3-overlay-exit-active {
+  -webkit-transform: translateY(-100%);
+  transform: translateY(-100%);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-position-bottom {
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 50%;
+}
+.bp3-drawer.bp3-position-bottom.bp3-overlay-enter,
+.bp3-drawer.bp3-position-bottom.bp3-overlay-appear {
+  -webkit-transform: translateY(100%);
+  transform: translateY(100%);
+}
+.bp3-drawer.bp3-position-bottom.bp3-overlay-enter-active,
+.bp3-drawer.bp3-position-bottom.bp3-overlay-appear-active {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-position-bottom.bp3-overlay-exit {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+}
+.bp3-drawer.bp3-position-bottom.bp3-overlay-exit-active {
+  -webkit-transform: translateY(100%);
+  transform: translateY(100%);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-position-left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+}
+.bp3-drawer.bp3-position-left.bp3-overlay-enter,
+.bp3-drawer.bp3-position-left.bp3-overlay-appear {
+  -webkit-transform: translateX(-100%);
+  transform: translateX(-100%);
+}
+.bp3-drawer.bp3-position-left.bp3-overlay-enter-active,
+.bp3-drawer.bp3-position-left.bp3-overlay-appear-active {
+  -webkit-transform: translateX(0);
+  transform: translateX(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-position-left.bp3-overlay-exit {
+  -webkit-transform: translateX(0);
+  transform: translateX(0);
+}
+.bp3-drawer.bp3-position-left.bp3-overlay-exit-active {
+  -webkit-transform: translateX(-100%);
+  transform: translateX(-100%);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-position-right {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 50%;
+}
+.bp3-drawer.bp3-position-right.bp3-overlay-enter,
+.bp3-drawer.bp3-position-right.bp3-overlay-appear {
+  -webkit-transform: translateX(100%);
+  transform: translateX(100%);
+}
+.bp3-drawer.bp3-position-right.bp3-overlay-enter-active,
+.bp3-drawer.bp3-position-right.bp3-overlay-appear-active {
+  -webkit-transform: translateX(0);
+  transform: translateX(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-position-right.bp3-overlay-exit {
+  -webkit-transform: translateX(0);
+  transform: translateX(0);
+}
+.bp3-drawer.bp3-position-right.bp3-overlay-exit-active {
+  -webkit-transform: translateX(100%);
+  transform: translateX(100%);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right):not(.bp3-vertical) {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 50%;
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right):not(.bp3-vertical).bp3-overlay-enter,
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right):not(.bp3-vertical).bp3-overlay-appear {
+  -webkit-transform: translateX(100%);
+  transform: translateX(100%);
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right):not(.bp3-vertical).bp3-overlay-enter-active,
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right):not(.bp3-vertical).bp3-overlay-appear-active {
+  -webkit-transform: translateX(0);
+  transform: translateX(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right):not(.bp3-vertical).bp3-overlay-exit {
+  -webkit-transform: translateX(0);
+  transform: translateX(0);
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right):not(.bp3-vertical).bp3-overlay-exit-active {
+  -webkit-transform: translateX(100%);
+  transform: translateX(100%);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right).bp3-vertical {
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 50%;
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right).bp3-vertical.bp3-overlay-enter,
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right).bp3-vertical.bp3-overlay-appear {
+  -webkit-transform: translateY(100%);
+  transform: translateY(100%);
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right).bp3-vertical.bp3-overlay-enter-active,
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right).bp3-vertical.bp3-overlay-appear-active {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right).bp3-vertical.bp3-overlay-exit {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+}
+.bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(.bp3-position-right).bp3-vertical.bp3-overlay-exit-active {
+  -webkit-transform: translateY(100%);
+  transform: translateY(100%);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-drawer.bp3-dark,
+.bp3-dark .bp3-drawer {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4),
+    0 18px 46px 6px rgba(16, 22, 26, 0.4);
+  background: #30404d;
+  color: #f5f8fa;
+}
 
-.bp3-drawer-header{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-flex:0;
-      -ms-flex:0 0 auto;
-          flex:0 0 auto;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  position:relative;
-  border-radius:0;
-  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-  min-height:40px;
-  padding:5px;
-  padding-left:20px; }
-  .bp3-drawer-header .bp3-icon-large,
-  .bp3-drawer-header .bp3-icon{
-    -webkit-box-flex:0;
-        -ms-flex:0 0 auto;
-            flex:0 0 auto;
-    margin-right:10px;
-    color:#5c7080; }
-  .bp3-drawer-header .bp3-heading{
-    overflow:hidden;
-    text-overflow:ellipsis;
-    white-space:nowrap;
-    word-wrap:normal;
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto;
-    margin:0;
-    line-height:inherit; }
-    .bp3-drawer-header .bp3-heading:last-child{
-      margin-right:20px; }
-  .bp3-dark .bp3-drawer-header{
-    -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
-            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-drawer-header .bp3-icon-large,
-    .bp3-dark .bp3-drawer-header .bp3-icon{
-      color:#a7b6c2; }
+.bp3-drawer-header {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 0;
+  -webkit-box-shadow: 0 1px 0 rgba(16, 22, 26, 0.15);
+  box-shadow: 0 1px 0 rgba(16, 22, 26, 0.15);
+  min-height: 40px;
+  padding: 5px;
+  padding-left: 20px;
+}
+.bp3-drawer-header .bp3-icon-large,
+.bp3-drawer-header .bp3-icon {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin-right: 10px;
+  color: #5c7080;
+}
+.bp3-drawer-header .bp3-heading {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin: 0;
+  line-height: inherit;
+}
+.bp3-drawer-header .bp3-heading:last-child {
+  margin-right: 20px;
+}
+.bp3-dark .bp3-drawer-header {
+  -webkit-box-shadow: 0 1px 0 rgba(16, 22, 26, 0.4);
+  box-shadow: 0 1px 0 rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-drawer-header .bp3-icon-large,
+.bp3-dark .bp3-drawer-header .bp3-icon {
+  color: #a7b6c2;
+}
 
-.bp3-drawer-body{
-  -webkit-box-flex:1;
-      -ms-flex:1 1 auto;
-          flex:1 1 auto;
-  overflow:auto;
-  line-height:18px; }
+.bp3-drawer-body {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  overflow: auto;
+  line-height: 18px;
+}
 
-.bp3-drawer-footer{
-  -webkit-box-flex:0;
-      -ms-flex:0 0 auto;
-          flex:0 0 auto;
-  position:relative;
-  -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-  padding:10px 20px; }
-  .bp3-dark .bp3-drawer-footer{
-    -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4);
-            box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4); }
-.bp3-editable-text{
-  display:inline-block;
-  position:relative;
-  cursor:text;
-  max-width:100%;
-  vertical-align:top;
-  white-space:nowrap; }
-  .bp3-editable-text::before{
-    position:absolute;
-    top:-3px;
-    right:-3px;
-    bottom:-3px;
-    left:-3px;
-    border-radius:3px;
-    content:"";
-    -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-  .bp3-editable-text:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
-  .bp3-editable-text.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-    background-color:#ffffff; }
-  .bp3-editable-text.bp3-disabled::before{
-    -webkit-box-shadow:none;
-            box-shadow:none; }
-  .bp3-editable-text.bp3-intent-primary .bp3-editable-text-input,
-  .bp3-editable-text.bp3-intent-primary .bp3-editable-text-content{
-    color:#137cbd; }
-  .bp3-editable-text.bp3-intent-primary:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(19, 124, 189, 0.4);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(19, 124, 189, 0.4); }
-  .bp3-editable-text.bp3-intent-primary.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-editable-text.bp3-intent-success .bp3-editable-text-input,
-  .bp3-editable-text.bp3-intent-success .bp3-editable-text-content{
-    color:#0f9960; }
-  .bp3-editable-text.bp3-intent-success:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px rgba(15, 153, 96, 0.4);
-            box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px rgba(15, 153, 96, 0.4); }
-  .bp3-editable-text.bp3-intent-success.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-editable-text.bp3-intent-warning .bp3-editable-text-input,
-  .bp3-editable-text.bp3-intent-warning .bp3-editable-text-content{
-    color:#d9822b; }
-  .bp3-editable-text.bp3-intent-warning:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px rgba(217, 130, 43, 0.4);
-            box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px rgba(217, 130, 43, 0.4); }
-  .bp3-editable-text.bp3-intent-warning.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-editable-text.bp3-intent-danger .bp3-editable-text-input,
-  .bp3-editable-text.bp3-intent-danger .bp3-editable-text-content{
-    color:#db3737; }
-  .bp3-editable-text.bp3-intent-danger:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px rgba(219, 55, 55, 0.4);
-            box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px rgba(219, 55, 55, 0.4); }
-  .bp3-editable-text.bp3-intent-danger.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-dark .bp3-editable-text:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15); }
-  .bp3-dark .bp3-editable-text.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background-color:rgba(16, 22, 26, 0.3); }
-  .bp3-dark .bp3-editable-text.bp3-disabled::before{
-    -webkit-box-shadow:none;
-            box-shadow:none; }
-  .bp3-dark .bp3-editable-text.bp3-intent-primary .bp3-editable-text-content{
-    color:#48aff0; }
-  .bp3-dark .bp3-editable-text.bp3-intent-primary:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(72, 175, 240, 0), 0 0 0 0 rgba(72, 175, 240, 0), inset 0 0 0 1px rgba(72, 175, 240, 0.4);
-            box-shadow:0 0 0 0 rgba(72, 175, 240, 0), 0 0 0 0 rgba(72, 175, 240, 0), inset 0 0 0 1px rgba(72, 175, 240, 0.4); }
-  .bp3-dark .bp3-editable-text.bp3-intent-primary.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #48aff0, 0 0 0 3px rgba(72, 175, 240, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #48aff0, 0 0 0 3px rgba(72, 175, 240, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-editable-text.bp3-intent-success .bp3-editable-text-content{
-    color:#3dcc91; }
-  .bp3-dark .bp3-editable-text.bp3-intent-success:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(61, 204, 145, 0), 0 0 0 0 rgba(61, 204, 145, 0), inset 0 0 0 1px rgba(61, 204, 145, 0.4);
-            box-shadow:0 0 0 0 rgba(61, 204, 145, 0), 0 0 0 0 rgba(61, 204, 145, 0), inset 0 0 0 1px rgba(61, 204, 145, 0.4); }
-  .bp3-dark .bp3-editable-text.bp3-intent-success.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #3dcc91, 0 0 0 3px rgba(61, 204, 145, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #3dcc91, 0 0 0 3px rgba(61, 204, 145, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-editable-text.bp3-intent-warning .bp3-editable-text-content{
-    color:#ffb366; }
-  .bp3-dark .bp3-editable-text.bp3-intent-warning:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(255, 179, 102, 0), 0 0 0 0 rgba(255, 179, 102, 0), inset 0 0 0 1px rgba(255, 179, 102, 0.4);
-            box-shadow:0 0 0 0 rgba(255, 179, 102, 0), 0 0 0 0 rgba(255, 179, 102, 0), inset 0 0 0 1px rgba(255, 179, 102, 0.4); }
-  .bp3-dark .bp3-editable-text.bp3-intent-warning.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #ffb366, 0 0 0 3px rgba(255, 179, 102, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #ffb366, 0 0 0 3px rgba(255, 179, 102, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-editable-text.bp3-intent-danger .bp3-editable-text-content{
-    color:#ff7373; }
-  .bp3-dark .bp3-editable-text.bp3-intent-danger:hover::before{
-    -webkit-box-shadow:0 0 0 0 rgba(255, 115, 115, 0), 0 0 0 0 rgba(255, 115, 115, 0), inset 0 0 0 1px rgba(255, 115, 115, 0.4);
-            box-shadow:0 0 0 0 rgba(255, 115, 115, 0), 0 0 0 0 rgba(255, 115, 115, 0), inset 0 0 0 1px rgba(255, 115, 115, 0.4); }
-  .bp3-dark .bp3-editable-text.bp3-intent-danger.bp3-editable-text-editing::before{
-    -webkit-box-shadow:0 0 0 1px #ff7373, 0 0 0 3px rgba(255, 115, 115, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #ff7373, 0 0 0 3px rgba(255, 115, 115, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+.bp3-drawer-footer {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  position: relative;
+  -webkit-box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.15);
+  box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.15);
+  padding: 10px 20px;
+}
+.bp3-dark .bp3-drawer-footer {
+  -webkit-box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.4);
+}
+.bp3-editable-text {
+  display: inline-block;
+  position: relative;
+  cursor: text;
+  max-width: 100%;
+  vertical-align: top;
+  white-space: nowrap;
+}
+.bp3-editable-text::before {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  bottom: -3px;
+  left: -3px;
+  border-radius: 3px;
+  content: '';
+  -webkit-transition: background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-editable-text:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+}
+.bp3-editable-text.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  background-color: #ffffff;
+}
+.bp3-editable-text.bp3-disabled::before {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-editable-text.bp3-intent-primary .bp3-editable-text-input,
+.bp3-editable-text.bp3-intent-primary .bp3-editable-text-content {
+  color: #137cbd;
+}
+.bp3-editable-text.bp3-intent-primary:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(19, 124, 189, 0.4);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(19, 124, 189, 0.4);
+}
+.bp3-editable-text.bp3-intent-primary.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-editable-text.bp3-intent-success .bp3-editable-text-input,
+.bp3-editable-text.bp3-intent-success .bp3-editable-text-content {
+  color: #0f9960;
+}
+.bp3-editable-text.bp3-intent-success:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    inset 0 0 0 1px rgba(15, 153, 96, 0.4);
+  box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    inset 0 0 0 1px rgba(15, 153, 96, 0.4);
+}
+.bp3-editable-text.bp3-intent-success.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-editable-text.bp3-intent-warning .bp3-editable-text-input,
+.bp3-editable-text.bp3-intent-warning .bp3-editable-text-content {
+  color: #d9822b;
+}
+.bp3-editable-text.bp3-intent-warning:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(217, 130, 43, 0),
+    0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px rgba(217, 130, 43, 0.4);
+  box-shadow: 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0),
+    inset 0 0 0 1px rgba(217, 130, 43, 0.4);
+}
+.bp3-editable-text.bp3-intent-warning.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-editable-text.bp3-intent-danger .bp3-editable-text-input,
+.bp3-editable-text.bp3-intent-danger .bp3-editable-text-content {
+  color: #db3737;
+}
+.bp3-editable-text.bp3-intent-danger:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    inset 0 0 0 1px rgba(219, 55, 55, 0.4);
+  box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    inset 0 0 0 1px rgba(219, 55, 55, 0.4);
+}
+.bp3-editable-text.bp3-intent-danger.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-dark .bp3-editable-text:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+.bp3-dark .bp3-editable-text.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  background-color: rgba(16, 22, 26, 0.3);
+}
+.bp3-dark .bp3-editable-text.bp3-disabled::before {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-dark .bp3-editable-text.bp3-intent-primary .bp3-editable-text-content {
+  color: #48aff0;
+}
+.bp3-dark .bp3-editable-text.bp3-intent-primary:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(72, 175, 240, 0),
+    0 0 0 0 rgba(72, 175, 240, 0), inset 0 0 0 1px rgba(72, 175, 240, 0.4);
+  box-shadow: 0 0 0 0 rgba(72, 175, 240, 0), 0 0 0 0 rgba(72, 175, 240, 0),
+    inset 0 0 0 1px rgba(72, 175, 240, 0.4);
+}
+.bp3-dark
+  .bp3-editable-text.bp3-intent-primary.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #48aff0, 0 0 0 3px rgba(72, 175, 240, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #48aff0, 0 0 0 3px rgba(72, 175, 240, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-editable-text.bp3-intent-success .bp3-editable-text-content {
+  color: #3dcc91;
+}
+.bp3-dark .bp3-editable-text.bp3-intent-success:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(61, 204, 145, 0),
+    0 0 0 0 rgba(61, 204, 145, 0), inset 0 0 0 1px rgba(61, 204, 145, 0.4);
+  box-shadow: 0 0 0 0 rgba(61, 204, 145, 0), 0 0 0 0 rgba(61, 204, 145, 0),
+    inset 0 0 0 1px rgba(61, 204, 145, 0.4);
+}
+.bp3-dark
+  .bp3-editable-text.bp3-intent-success.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #3dcc91, 0 0 0 3px rgba(61, 204, 145, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #3dcc91, 0 0 0 3px rgba(61, 204, 145, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-editable-text.bp3-intent-warning .bp3-editable-text-content {
+  color: #ffb366;
+}
+.bp3-dark .bp3-editable-text.bp3-intent-warning:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(255, 179, 102, 0),
+    0 0 0 0 rgba(255, 179, 102, 0), inset 0 0 0 1px rgba(255, 179, 102, 0.4);
+  box-shadow: 0 0 0 0 rgba(255, 179, 102, 0), 0 0 0 0 rgba(255, 179, 102, 0),
+    inset 0 0 0 1px rgba(255, 179, 102, 0.4);
+}
+.bp3-dark
+  .bp3-editable-text.bp3-intent-warning.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #ffb366, 0 0 0 3px rgba(255, 179, 102, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #ffb366, 0 0 0 3px rgba(255, 179, 102, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-editable-text.bp3-intent-danger .bp3-editable-text-content {
+  color: #ff7373;
+}
+.bp3-dark .bp3-editable-text.bp3-intent-danger:hover::before {
+  -webkit-box-shadow: 0 0 0 0 rgba(255, 115, 115, 0),
+    0 0 0 0 rgba(255, 115, 115, 0), inset 0 0 0 1px rgba(255, 115, 115, 0.4);
+  box-shadow: 0 0 0 0 rgba(255, 115, 115, 0), 0 0 0 0 rgba(255, 115, 115, 0),
+    inset 0 0 0 1px rgba(255, 115, 115, 0.4);
+}
+.bp3-dark
+  .bp3-editable-text.bp3-intent-danger.bp3-editable-text-editing::before {
+  -webkit-box-shadow: 0 0 0 1px #ff7373, 0 0 0 3px rgba(255, 115, 115, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #ff7373, 0 0 0 3px rgba(255, 115, 115, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
 
 .bp3-editable-text-input,
-.bp3-editable-text-content{
-  display:inherit;
-  position:relative;
-  min-width:inherit;
-  max-width:inherit;
-  vertical-align:top;
-  text-transform:inherit;
-  letter-spacing:inherit;
-  color:inherit;
-  font:inherit;
-  resize:none; }
+.bp3-editable-text-content {
+  display: inherit;
+  position: relative;
+  min-width: inherit;
+  max-width: inherit;
+  vertical-align: top;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  font: inherit;
+  resize: none;
+}
 
-.bp3-editable-text-input{
-  border:none;
-  -webkit-box-shadow:none;
-          box-shadow:none;
-  background:none;
-  width:100%;
-  padding:0;
-  white-space:pre-wrap; }
-  .bp3-editable-text-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-editable-text-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-editable-text-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-editable-text-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-editable-text-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-editable-text-input:focus{
-    outline:none; }
-  .bp3-editable-text-input::-ms-clear{
-    display:none; }
+.bp3-editable-text-input {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  width: 100%;
+  padding: 0;
+  white-space: pre-wrap;
+}
+.bp3-editable-text-input::-webkit-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-editable-text-input::-moz-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-editable-text-input:-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-editable-text-input::-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-editable-text-input::placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-editable-text-input:focus {
+  outline: none;
+}
+.bp3-editable-text-input::-ms-clear {
+  display: none;
+}
 
-.bp3-editable-text-content{
-  overflow:hidden;
-  padding-right:2px;
-  text-overflow:ellipsis;
-  white-space:pre; }
-  .bp3-editable-text-editing > .bp3-editable-text-content{
-    position:absolute;
-    left:0;
-    visibility:hidden; }
-  .bp3-editable-text-placeholder > .bp3-editable-text-content{
-    color:rgba(92, 112, 128, 0.6); }
-    .bp3-dark .bp3-editable-text-placeholder > .bp3-editable-text-content{
-      color:rgba(167, 182, 194, 0.6); }
+.bp3-editable-text-content {
+  overflow: hidden;
+  padding-right: 2px;
+  text-overflow: ellipsis;
+  white-space: pre;
+}
+.bp3-editable-text-editing > .bp3-editable-text-content {
+  position: absolute;
+  left: 0;
+  visibility: hidden;
+}
+.bp3-editable-text-placeholder > .bp3-editable-text-content {
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-dark .bp3-editable-text-placeholder > .bp3-editable-text-content {
+  color: rgba(167, 182, 194, 0.6);
+}
 
-.bp3-editable-text.bp3-multiline{
-  display:block; }
-  .bp3-editable-text.bp3-multiline .bp3-editable-text-content{
-    overflow:auto;
-    white-space:pre-wrap;
-    word-wrap:break-word; }
-.bp3-control-group{
-  -webkit-transform:translateZ(0);
-          transform:translateZ(0);
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:row;
-          flex-direction:row;
-  -webkit-box-align:stretch;
-      -ms-flex-align:stretch;
-          align-items:stretch; }
-  .bp3-control-group > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-control-group > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-control-group .bp3-button,
-  .bp3-control-group .bp3-html-select,
-  .bp3-control-group .bp3-input,
-  .bp3-control-group .bp3-select{
-    position:relative; }
-  .bp3-control-group .bp3-input{
-    z-index:2;
-    border-radius:inherit; }
-    .bp3-control-group .bp3-input:focus{
-      z-index:14;
-      border-radius:3px; }
-    .bp3-control-group .bp3-input[class*="bp3-intent"]{
-      z-index:13; }
-      .bp3-control-group .bp3-input[class*="bp3-intent"]:focus{
-        z-index:15; }
-    .bp3-control-group .bp3-input[readonly], .bp3-control-group .bp3-input:disabled, .bp3-control-group .bp3-input.bp3-disabled{
-      z-index:1; }
-  .bp3-control-group .bp3-input-group[class*="bp3-intent"] .bp3-input{
-    z-index:13; }
-    .bp3-control-group .bp3-input-group[class*="bp3-intent"] .bp3-input:focus{
-      z-index:15; }
-  .bp3-control-group .bp3-button,
-  .bp3-control-group .bp3-html-select select,
-  .bp3-control-group .bp3-select select{
-    -webkit-transform:translateZ(0);
-            transform:translateZ(0);
-    z-index:4;
-    border-radius:inherit; }
-    .bp3-control-group .bp3-button:focus,
-    .bp3-control-group .bp3-html-select select:focus,
-    .bp3-control-group .bp3-select select:focus{
-      z-index:5; }
-    .bp3-control-group .bp3-button:hover,
-    .bp3-control-group .bp3-html-select select:hover,
-    .bp3-control-group .bp3-select select:hover{
-      z-index:6; }
-    .bp3-control-group .bp3-button:active,
-    .bp3-control-group .bp3-html-select select:active,
-    .bp3-control-group .bp3-select select:active{
-      z-index:7; }
-    .bp3-control-group .bp3-button[readonly], .bp3-control-group .bp3-button:disabled, .bp3-control-group .bp3-button.bp3-disabled,
-    .bp3-control-group .bp3-html-select select[readonly],
-    .bp3-control-group .bp3-html-select select:disabled,
-    .bp3-control-group .bp3-html-select select.bp3-disabled,
-    .bp3-control-group .bp3-select select[readonly],
-    .bp3-control-group .bp3-select select:disabled,
-    .bp3-control-group .bp3-select select.bp3-disabled{
-      z-index:3; }
-    .bp3-control-group .bp3-button[class*="bp3-intent"],
-    .bp3-control-group .bp3-html-select select[class*="bp3-intent"],
-    .bp3-control-group .bp3-select select[class*="bp3-intent"]{
-      z-index:9; }
-      .bp3-control-group .bp3-button[class*="bp3-intent"]:focus,
-      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:focus,
-      .bp3-control-group .bp3-select select[class*="bp3-intent"]:focus{
-        z-index:10; }
-      .bp3-control-group .bp3-button[class*="bp3-intent"]:hover,
-      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:hover,
-      .bp3-control-group .bp3-select select[class*="bp3-intent"]:hover{
-        z-index:11; }
-      .bp3-control-group .bp3-button[class*="bp3-intent"]:active,
-      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:active,
-      .bp3-control-group .bp3-select select[class*="bp3-intent"]:active{
-        z-index:12; }
-      .bp3-control-group .bp3-button[class*="bp3-intent"][readonly], .bp3-control-group .bp3-button[class*="bp3-intent"]:disabled, .bp3-control-group .bp3-button[class*="bp3-intent"].bp3-disabled,
-      .bp3-control-group .bp3-html-select select[class*="bp3-intent"][readonly],
-      .bp3-control-group .bp3-html-select select[class*="bp3-intent"]:disabled,
-      .bp3-control-group .bp3-html-select select[class*="bp3-intent"].bp3-disabled,
-      .bp3-control-group .bp3-select select[class*="bp3-intent"][readonly],
-      .bp3-control-group .bp3-select select[class*="bp3-intent"]:disabled,
-      .bp3-control-group .bp3-select select[class*="bp3-intent"].bp3-disabled{
-        z-index:8; }
-  .bp3-control-group .bp3-input-group > .bp3-icon,
-  .bp3-control-group .bp3-input-group > .bp3-button,
-  .bp3-control-group .bp3-input-group > .bp3-input-action{
-    z-index:16; }
-  .bp3-control-group .bp3-select::after,
-  .bp3-control-group .bp3-html-select::after,
-  .bp3-control-group .bp3-select > .bp3-icon,
-  .bp3-control-group .bp3-html-select > .bp3-icon{
-    z-index:17; }
-  .bp3-control-group:not(.bp3-vertical) > *{
-    margin-right:-1px; }
-  .bp3-dark .bp3-control-group:not(.bp3-vertical) > *{
-    margin-right:0; }
-  .bp3-dark .bp3-control-group:not(.bp3-vertical) > .bp3-button + .bp3-button{
-    margin-left:1px; }
-  .bp3-control-group .bp3-popover-wrapper,
-  .bp3-control-group .bp3-popover-target{
-    border-radius:inherit; }
-  .bp3-control-group > :first-child{
-    border-radius:3px 0 0 3px; }
-  .bp3-control-group > :last-child{
-    margin-right:0;
-    border-radius:0 3px 3px 0; }
-  .bp3-control-group > :only-child{
-    margin-right:0;
-    border-radius:3px; }
-  .bp3-control-group .bp3-input-group .bp3-button{
-    border-radius:3px; }
-  .bp3-control-group > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto; }
-  .bp3-control-group.bp3-fill > *:not(.bp3-fixed){
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto; }
-  .bp3-control-group.bp3-vertical{
-    -webkit-box-orient:vertical;
-    -webkit-box-direction:normal;
-        -ms-flex-direction:column;
-            flex-direction:column; }
-    .bp3-control-group.bp3-vertical > *{
-      margin-top:-1px; }
-    .bp3-control-group.bp3-vertical > :first-child{
-      margin-top:0;
-      border-radius:3px 3px 0 0; }
-    .bp3-control-group.bp3-vertical > :last-child{
-      border-radius:0 0 3px 3px; }
-.bp3-control{
-  display:block;
-  position:relative;
-  margin-bottom:10px;
-  cursor:pointer;
-  text-transform:none; }
-  .bp3-control input:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#137cbd;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-  .bp3-control:hover input:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#106ba3; }
-  .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#0e5a8a; }
-  .bp3-control input:disabled:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(19, 124, 189, 0.5); }
-  .bp3-dark .bp3-control input:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-control:hover input:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#106ba3; }
-  .bp3-dark .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#0e5a8a; }
-  .bp3-dark .bp3-control input:disabled:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(14, 90, 138, 0.5); }
-  .bp3-control:not(.bp3-align-right){
-    padding-left:26px; }
-    .bp3-control:not(.bp3-align-right) .bp3-control-indicator{
-      margin-left:-26px; }
-  .bp3-control.bp3-align-right{
-    padding-right:26px; }
-    .bp3-control.bp3-align-right .bp3-control-indicator{
-      margin-right:-26px; }
-  .bp3-control.bp3-disabled{
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-control.bp3-inline{
-    display:inline-block;
-    margin-right:20px; }
-  .bp3-control input{
-    position:absolute;
-    top:0;
-    left:0;
-    opacity:0;
-    z-index:-1; }
-  .bp3-control .bp3-control-indicator{
-    display:inline-block;
-    position:relative;
-    margin-top:-3px;
-    margin-right:10px;
-    border:none;
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-clip:padding-box;
-    background-color:#f5f8fa;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
-    cursor:pointer;
-    width:1em;
-    height:1em;
-    vertical-align:middle;
-    font-size:16px;
-    -webkit-user-select:none;
-       -moz-user-select:none;
-        -ms-user-select:none;
-            user-select:none; }
-    .bp3-control .bp3-control-indicator::before{
-      display:block;
-      width:1em;
-      height:1em;
-      content:""; }
-  .bp3-control:hover .bp3-control-indicator{
-    background-color:#ebf1f5; }
-  .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#d8e1e8; }
-  .bp3-control input:disabled ~ .bp3-control-indicator{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
-    cursor:not-allowed; }
-  .bp3-control input:focus ~ .bp3-control-indicator{
-    outline:rgba(19, 124, 189, 0.6) auto 2px;
-    outline-offset:2px;
-    -moz-outline-radius:6px; }
-  .bp3-control.bp3-align-right .bp3-control-indicator{
-    float:right;
-    margin-top:1px;
-    margin-left:10px; }
-  .bp3-control.bp3-large{
-    font-size:16px; }
-    .bp3-control.bp3-large:not(.bp3-align-right){
-      padding-left:30px; }
-      .bp3-control.bp3-large:not(.bp3-align-right) .bp3-control-indicator{
-        margin-left:-30px; }
-    .bp3-control.bp3-large.bp3-align-right{
-      padding-right:30px; }
-      .bp3-control.bp3-large.bp3-align-right .bp3-control-indicator{
-        margin-right:-30px; }
-    .bp3-control.bp3-large .bp3-control-indicator{
-      font-size:20px; }
-    .bp3-control.bp3-large.bp3-align-right .bp3-control-indicator{
-      margin-top:0; }
-  .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#137cbd;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-  .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#106ba3; }
-  .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#0e5a8a; }
-  .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(19, 124, 189, 0.5); }
-  .bp3-dark .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#106ba3; }
-  .bp3-dark .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#0e5a8a; }
-  .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(14, 90, 138, 0.5); }
-  .bp3-control.bp3-checkbox .bp3-control-indicator{
-    border-radius:3px; }
-  .bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator::before{
-    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='white'/%3e%3c/svg%3e"); }
-  .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator::before{
-    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M11 7H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z' fill='white'/%3e%3c/svg%3e"); }
-  .bp3-control.bp3-radio .bp3-control-indicator{
-    border-radius:50%; }
-  .bp3-control.bp3-radio input:checked ~ .bp3-control-indicator::before{
-    background-image:radial-gradient(#ffffff, #ffffff 28%, transparent 32%); }
-  .bp3-control.bp3-radio input:checked:disabled ~ .bp3-control-indicator::before{
-    opacity:0.5; }
-  .bp3-control.bp3-radio input:focus ~ .bp3-control-indicator{
-    -moz-outline-radius:16px; }
-  .bp3-control.bp3-switch input ~ .bp3-control-indicator{
-    background:rgba(167, 182, 194, 0.5); }
-  .bp3-control.bp3-switch:hover input ~ .bp3-control-indicator{
-    background:rgba(115, 134, 148, 0.5); }
-  .bp3-control.bp3-switch input:not(:disabled):active ~ .bp3-control-indicator{
-    background:rgba(92, 112, 128, 0.5); }
-  .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator{
-    background:rgba(206, 217, 224, 0.5); }
-    .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator::before{
-      background:rgba(255, 255, 255, 0.8); }
-  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator{
-    background:#137cbd; }
-  .bp3-control.bp3-switch:hover input:checked ~ .bp3-control-indicator{
-    background:#106ba3; }
-  .bp3-control.bp3-switch input:checked:not(:disabled):active ~ .bp3-control-indicator{
-    background:#0e5a8a; }
-  .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator{
-    background:rgba(19, 124, 189, 0.5); }
-    .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator::before{
-      background:rgba(255, 255, 255, 0.8); }
-  .bp3-control.bp3-switch:not(.bp3-align-right){
-    padding-left:38px; }
-    .bp3-control.bp3-switch:not(.bp3-align-right) .bp3-control-indicator{
-      margin-left:-38px; }
-  .bp3-control.bp3-switch.bp3-align-right{
-    padding-right:38px; }
-    .bp3-control.bp3-switch.bp3-align-right .bp3-control-indicator{
-      margin-right:-38px; }
-  .bp3-control.bp3-switch .bp3-control-indicator{
-    border:none;
-    border-radius:1.75em;
-    -webkit-box-shadow:none !important;
-            box-shadow:none !important;
-    width:auto;
-    min-width:1.75em;
-    -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-    .bp3-control.bp3-switch .bp3-control-indicator::before{
-      position:absolute;
-      left:0;
-      margin:2px;
-      border-radius:50%;
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-      background:#ffffff;
-      width:calc(1em - 4px);
-      height:calc(1em - 4px);
-      -webkit-transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-      transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
-    left:calc(100% - 1em); }
-  .bp3-control.bp3-switch.bp3-large:not(.bp3-align-right){
-    padding-left:45px; }
-    .bp3-control.bp3-switch.bp3-large:not(.bp3-align-right) .bp3-control-indicator{
-      margin-left:-45px; }
-  .bp3-control.bp3-switch.bp3-large.bp3-align-right{
-    padding-right:45px; }
-    .bp3-control.bp3-switch.bp3-large.bp3-align-right .bp3-control-indicator{
-      margin-right:-45px; }
-  .bp3-dark .bp3-control.bp3-switch input ~ .bp3-control-indicator{
-    background:rgba(16, 22, 26, 0.5); }
-  .bp3-dark .bp3-control.bp3-switch:hover input ~ .bp3-control-indicator{
-    background:rgba(16, 22, 26, 0.7); }
-  .bp3-dark .bp3-control.bp3-switch input:not(:disabled):active ~ .bp3-control-indicator{
-    background:rgba(16, 22, 26, 0.9); }
-  .bp3-dark .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator{
-    background:rgba(57, 75, 89, 0.5); }
-    .bp3-dark .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator::before{
-      background:rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator{
-    background:#137cbd; }
-  .bp3-dark .bp3-control.bp3-switch:hover input:checked ~ .bp3-control-indicator{
-    background:#106ba3; }
-  .bp3-dark .bp3-control.bp3-switch input:checked:not(:disabled):active ~ .bp3-control-indicator{
-    background:#0e5a8a; }
-  .bp3-dark .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator{
-    background:rgba(14, 90, 138, 0.5); }
-    .bp3-dark .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator::before{
-      background:rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-control.bp3-switch .bp3-control-indicator::before{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:#394b59; }
-  .bp3-dark .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
-  .bp3-control.bp3-switch .bp3-switch-inner-text{
-    text-align:center;
-    font-size:0.7em; }
-  .bp3-control.bp3-switch .bp3-control-indicator-child:first-child{
-    visibility:hidden;
-    margin-right:1.2em;
-    margin-left:0.5em;
-    line-height:0; }
-  .bp3-control.bp3-switch .bp3-control-indicator-child:last-child{
-    visibility:visible;
-    margin-right:0.5em;
-    margin-left:1.2em;
-    line-height:1em; }
-  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:first-child{
-    visibility:visible;
-    line-height:1em; }
-  .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:last-child{
-    visibility:hidden;
-    line-height:0; }
-  .bp3-dark .bp3-control{
-    color:#f5f8fa; }
-    .bp3-dark .bp3-control.bp3-disabled{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-control .bp3-control-indicator{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#394b59;
-      background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
-      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0)); }
-    .bp3-dark .bp3-control:hover .bp3-control-indicator{
-      background-color:#30404d; }
-    .bp3-dark .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background:#202b33; }
-    .bp3-dark .bp3-control input:disabled ~ .bp3-control-indicator{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
-      cursor:not-allowed; }
-    .bp3-dark .bp3-control.bp3-checkbox input:disabled:checked ~ .bp3-control-indicator, .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
-      color:rgba(167, 182, 194, 0.6); }
-.bp3-file-input{
-  display:inline-block;
-  position:relative;
-  cursor:pointer;
-  height:30px; }
-  .bp3-file-input input{
-    opacity:0;
-    margin:0;
-    min-width:200px; }
-    .bp3-file-input input:disabled + .bp3-file-upload-input,
-    .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(206, 217, 224, 0.5);
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6);
-      resize:none; }
-      .bp3-file-input input:disabled + .bp3-file-upload-input::after,
-      .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
-        outline:none;
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background-color:rgba(206, 217, 224, 0.5);
-        background-image:none;
-        cursor:not-allowed;
-        color:rgba(92, 112, 128, 0.6); }
-        .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active:hover,
-        .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active,
-        .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active:hover{
-          background:rgba(206, 217, 224, 0.7); }
-      .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input, .bp3-dark
-      .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background:rgba(57, 75, 89, 0.5);
-        color:rgba(167, 182, 194, 0.6); }
-        .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after, .bp3-dark
-        .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
-          -webkit-box-shadow:none;
-                  box-shadow:none;
-          background-color:rgba(57, 75, 89, 0.5);
-          background-image:none;
-          color:rgba(167, 182, 194, 0.6); }
-          .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-dark
-          .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active{
-            background:rgba(57, 75, 89, 0.7); }
-  .bp3-file-input.bp3-file-input-has-selection .bp3-file-upload-input{
-    color:#182026; }
-  .bp3-dark .bp3-file-input.bp3-file-input-has-selection .bp3-file-upload-input{
-    color:#f5f8fa; }
-  .bp3-file-input.bp3-fill{
-    width:100%; }
-  .bp3-file-input.bp3-large,
-  .bp3-large .bp3-file-input{
-    height:40px; }
-  .bp3-file-input .bp3-file-upload-input-custom-text::after{
-    content:attr(bp3-button-text); }
+.bp3-editable-text.bp3-multiline {
+  display: block;
+}
+.bp3-editable-text.bp3-multiline .bp3-editable-text-content {
+  overflow: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.bp3-control-group {
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+.bp3-control-group > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-control-group > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-control-group .bp3-button,
+.bp3-control-group .bp3-html-select,
+.bp3-control-group .bp3-input,
+.bp3-control-group .bp3-select {
+  position: relative;
+}
+.bp3-control-group .bp3-input {
+  z-index: 2;
+  border-radius: inherit;
+}
+.bp3-control-group .bp3-input:focus {
+  z-index: 14;
+  border-radius: 3px;
+}
+.bp3-control-group .bp3-input[class*='bp3-intent'] {
+  z-index: 13;
+}
+.bp3-control-group .bp3-input[class*='bp3-intent']:focus {
+  z-index: 15;
+}
+.bp3-control-group .bp3-input[readonly],
+.bp3-control-group .bp3-input:disabled,
+.bp3-control-group .bp3-input.bp3-disabled {
+  z-index: 1;
+}
+.bp3-control-group .bp3-input-group[class*='bp3-intent'] .bp3-input {
+  z-index: 13;
+}
+.bp3-control-group .bp3-input-group[class*='bp3-intent'] .bp3-input:focus {
+  z-index: 15;
+}
+.bp3-control-group .bp3-button,
+.bp3-control-group .bp3-html-select select,
+.bp3-control-group .bp3-select select {
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  z-index: 4;
+  border-radius: inherit;
+}
+.bp3-control-group .bp3-button:focus,
+.bp3-control-group .bp3-html-select select:focus,
+.bp3-control-group .bp3-select select:focus {
+  z-index: 5;
+}
+.bp3-control-group .bp3-button:hover,
+.bp3-control-group .bp3-html-select select:hover,
+.bp3-control-group .bp3-select select:hover {
+  z-index: 6;
+}
+.bp3-control-group .bp3-button:active,
+.bp3-control-group .bp3-html-select select:active,
+.bp3-control-group .bp3-select select:active {
+  z-index: 7;
+}
+.bp3-control-group .bp3-button[readonly],
+.bp3-control-group .bp3-button:disabled,
+.bp3-control-group .bp3-button.bp3-disabled,
+.bp3-control-group .bp3-html-select select[readonly],
+.bp3-control-group .bp3-html-select select:disabled,
+.bp3-control-group .bp3-html-select select.bp3-disabled,
+.bp3-control-group .bp3-select select[readonly],
+.bp3-control-group .bp3-select select:disabled,
+.bp3-control-group .bp3-select select.bp3-disabled {
+  z-index: 3;
+}
+.bp3-control-group .bp3-button[class*='bp3-intent'],
+.bp3-control-group .bp3-html-select select[class*='bp3-intent'],
+.bp3-control-group .bp3-select select[class*='bp3-intent'] {
+  z-index: 9;
+}
+.bp3-control-group .bp3-button[class*='bp3-intent']:focus,
+.bp3-control-group .bp3-html-select select[class*='bp3-intent']:focus,
+.bp3-control-group .bp3-select select[class*='bp3-intent']:focus {
+  z-index: 10;
+}
+.bp3-control-group .bp3-button[class*='bp3-intent']:hover,
+.bp3-control-group .bp3-html-select select[class*='bp3-intent']:hover,
+.bp3-control-group .bp3-select select[class*='bp3-intent']:hover {
+  z-index: 11;
+}
+.bp3-control-group .bp3-button[class*='bp3-intent']:active,
+.bp3-control-group .bp3-html-select select[class*='bp3-intent']:active,
+.bp3-control-group .bp3-select select[class*='bp3-intent']:active {
+  z-index: 12;
+}
+.bp3-control-group .bp3-button[class*='bp3-intent'][readonly],
+.bp3-control-group .bp3-button[class*='bp3-intent']:disabled,
+.bp3-control-group .bp3-button[class*='bp3-intent'].bp3-disabled,
+.bp3-control-group .bp3-html-select select[class*='bp3-intent'][readonly],
+.bp3-control-group .bp3-html-select select[class*='bp3-intent']:disabled,
+.bp3-control-group .bp3-html-select select[class*='bp3-intent'].bp3-disabled,
+.bp3-control-group .bp3-select select[class*='bp3-intent'][readonly],
+.bp3-control-group .bp3-select select[class*='bp3-intent']:disabled,
+.bp3-control-group .bp3-select select[class*='bp3-intent'].bp3-disabled {
+  z-index: 8;
+}
+.bp3-control-group .bp3-input-group > .bp3-icon,
+.bp3-control-group .bp3-input-group > .bp3-button,
+.bp3-control-group .bp3-input-group > .bp3-input-action {
+  z-index: 16;
+}
+.bp3-control-group .bp3-select::after,
+.bp3-control-group .bp3-html-select::after,
+.bp3-control-group .bp3-select > .bp3-icon,
+.bp3-control-group .bp3-html-select > .bp3-icon {
+  z-index: 17;
+}
+.bp3-control-group:not(.bp3-vertical) > * {
+  margin-right: -1px;
+}
+.bp3-dark .bp3-control-group:not(.bp3-vertical) > * {
+  margin-right: 0;
+}
+.bp3-dark .bp3-control-group:not(.bp3-vertical) > .bp3-button + .bp3-button {
+  margin-left: 1px;
+}
+.bp3-control-group .bp3-popover-wrapper,
+.bp3-control-group .bp3-popover-target {
+  border-radius: inherit;
+}
+.bp3-control-group > :first-child {
+  border-radius: 3px 0 0 3px;
+}
+.bp3-control-group > :last-child {
+  margin-right: 0;
+  border-radius: 0 3px 3px 0;
+}
+.bp3-control-group > :only-child {
+  margin-right: 0;
+  border-radius: 3px;
+}
+.bp3-control-group .bp3-input-group .bp3-button {
+  border-radius: 3px;
+}
+.bp3-control-group > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+.bp3-control-group.bp3-fill > *:not(.bp3-fixed) {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+.bp3-control-group.bp3-vertical {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+.bp3-control-group.bp3-vertical > * {
+  margin-top: -1px;
+}
+.bp3-control-group.bp3-vertical > :first-child {
+  margin-top: 0;
+  border-radius: 3px 3px 0 0;
+}
+.bp3-control-group.bp3-vertical > :last-child {
+  border-radius: 0 0 3px 3px;
+}
+.bp3-control {
+  display: block;
+  position: relative;
+  margin-bottom: 10px;
+  cursor: pointer;
+  text-transform: none;
+}
+.bp3-control input:checked ~ .bp3-control-indicator {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #137cbd;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.1)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0)
+  );
+  color: #ffffff;
+}
+.bp3-control:hover input:checked ~ .bp3-control-indicator {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #106ba3;
+}
+.bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background: #0e5a8a;
+}
+.bp3-control input:disabled:checked ~ .bp3-control-indicator {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(19, 124, 189, 0.5);
+}
+.bp3-dark .bp3-control input:checked ~ .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-control:hover input:checked ~ .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #106ba3;
+}
+.bp3-dark
+  .bp3-control
+  input:not(:disabled):active:checked
+  ~ .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #0e5a8a;
+}
+.bp3-dark .bp3-control input:disabled:checked ~ .bp3-control-indicator {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(14, 90, 138, 0.5);
+}
+.bp3-control:not(.bp3-align-right) {
+  padding-left: 26px;
+}
+.bp3-control:not(.bp3-align-right) .bp3-control-indicator {
+  margin-left: -26px;
+}
+.bp3-control.bp3-align-right {
+  padding-right: 26px;
+}
+.bp3-control.bp3-align-right .bp3-control-indicator {
+  margin-right: -26px;
+}
+.bp3-control.bp3-disabled {
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-control.bp3-inline {
+  display: inline-block;
+  margin-right: 20px;
+}
+.bp3-control input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: -1;
+}
+.bp3-control .bp3-control-indicator {
+  display: inline-block;
+  position: relative;
+  margin-top: -3px;
+  margin-right: 10px;
+  border: none;
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-clip: padding-box;
+  background-color: #f5f8fa;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.8)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.8),
+    rgba(255, 255, 255, 0)
+  );
+  cursor: pointer;
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+  font-size: 16px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-control .bp3-control-indicator::before {
+  display: block;
+  width: 1em;
+  height: 1em;
+  content: '';
+}
+.bp3-control:hover .bp3-control-indicator {
+  background-color: #ebf1f5;
+}
+.bp3-control input:not(:disabled):active ~ .bp3-control-indicator {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background: #d8e1e8;
+}
+.bp3-control input:disabled ~ .bp3-control-indicator {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(206, 217, 224, 0.5);
+  cursor: not-allowed;
+}
+.bp3-control input:focus ~ .bp3-control-indicator {
+  outline: rgba(19, 124, 189, 0.6) auto 2px;
+  outline-offset: 2px;
+  -moz-outline-radius: 6px;
+}
+.bp3-control.bp3-align-right .bp3-control-indicator {
+  float: right;
+  margin-top: 1px;
+  margin-left: 10px;
+}
+.bp3-control.bp3-large {
+  font-size: 16px;
+}
+.bp3-control.bp3-large:not(.bp3-align-right) {
+  padding-left: 30px;
+}
+.bp3-control.bp3-large:not(.bp3-align-right) .bp3-control-indicator {
+  margin-left: -30px;
+}
+.bp3-control.bp3-large.bp3-align-right {
+  padding-right: 30px;
+}
+.bp3-control.bp3-large.bp3-align-right .bp3-control-indicator {
+  margin-right: -30px;
+}
+.bp3-control.bp3-large .bp3-control-indicator {
+  font-size: 20px;
+}
+.bp3-control.bp3-large.bp3-align-right .bp3-control-indicator {
+  margin-top: 0;
+}
+.bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #137cbd;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.1)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0)
+  );
+  color: #ffffff;
+}
+.bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+  background-color: #106ba3;
+}
+.bp3-control.bp3-checkbox
+  input:not(:disabled):active:indeterminate
+  ~ .bp3-control-indicator {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background: #0e5a8a;
+}
+.bp3-control.bp3-checkbox
+  input:disabled:indeterminate
+  ~ .bp3-control-indicator {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(19, 124, 189, 0.5);
+}
+.bp3-dark
+  .bp3-control.bp3-checkbox
+  input:indeterminate
+  ~ .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark
+  .bp3-control.bp3-checkbox:hover
+  input:indeterminate
+  ~ .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #106ba3;
+}
+.bp3-dark
+  .bp3-control.bp3-checkbox
+  input:not(:disabled):active:indeterminate
+  ~ .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #0e5a8a;
+}
+.bp3-dark
+  .bp3-control.bp3-checkbox
+  input:disabled:indeterminate
+  ~ .bp3-control-indicator {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(14, 90, 138, 0.5);
+}
+.bp3-control.bp3-checkbox .bp3-control-indicator {
+  border-radius: 3px;
+}
+.bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator::before {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='white'/%3e%3c/svg%3e");
+}
+.bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator::before {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M11 7H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z' fill='white'/%3e%3c/svg%3e");
+}
+.bp3-control.bp3-radio .bp3-control-indicator {
+  border-radius: 50%;
+}
+.bp3-control.bp3-radio input:checked ~ .bp3-control-indicator::before {
+  background-image: radial-gradient(#ffffff, #ffffff 28%, transparent 32%);
+}
+.bp3-control.bp3-radio input:checked:disabled ~ .bp3-control-indicator::before {
+  opacity: 0.5;
+}
+.bp3-control.bp3-radio input:focus ~ .bp3-control-indicator {
+  -moz-outline-radius: 16px;
+}
+.bp3-control.bp3-switch input ~ .bp3-control-indicator {
+  background: rgba(167, 182, 194, 0.5);
+}
+.bp3-control.bp3-switch:hover input ~ .bp3-control-indicator {
+  background: rgba(115, 134, 148, 0.5);
+}
+.bp3-control.bp3-switch input:not(:disabled):active ~ .bp3-control-indicator {
+  background: rgba(92, 112, 128, 0.5);
+}
+.bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator {
+  background: rgba(206, 217, 224, 0.5);
+}
+.bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator::before {
+  background: rgba(255, 255, 255, 0.8);
+}
+.bp3-control.bp3-switch input:checked ~ .bp3-control-indicator {
+  background: #137cbd;
+}
+.bp3-control.bp3-switch:hover input:checked ~ .bp3-control-indicator {
+  background: #106ba3;
+}
+.bp3-control.bp3-switch
+  input:checked:not(:disabled):active
+  ~ .bp3-control-indicator {
+  background: #0e5a8a;
+}
+.bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator {
+  background: rgba(19, 124, 189, 0.5);
+}
+.bp3-control.bp3-switch
+  input:checked:disabled
+  ~ .bp3-control-indicator::before {
+  background: rgba(255, 255, 255, 0.8);
+}
+.bp3-control.bp3-switch:not(.bp3-align-right) {
+  padding-left: 38px;
+}
+.bp3-control.bp3-switch:not(.bp3-align-right) .bp3-control-indicator {
+  margin-left: -38px;
+}
+.bp3-control.bp3-switch.bp3-align-right {
+  padding-right: 38px;
+}
+.bp3-control.bp3-switch.bp3-align-right .bp3-control-indicator {
+  margin-right: -38px;
+}
+.bp3-control.bp3-switch .bp3-control-indicator {
+  border: none;
+  border-radius: 1.75em;
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+  width: auto;
+  min-width: 1.75em;
+  -webkit-transition: background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-control.bp3-switch .bp3-control-indicator::before {
+  position: absolute;
+  left: 0;
+  margin: 2px;
+  border-radius: 50%;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+  background: #ffffff;
+  width: calc(1em - 4px);
+  height: calc(1em - 4px);
+  -webkit-transition: left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before {
+  left: calc(100% - 1em);
+}
+.bp3-control.bp3-switch.bp3-large:not(.bp3-align-right) {
+  padding-left: 45px;
+}
+.bp3-control.bp3-switch.bp3-large:not(.bp3-align-right) .bp3-control-indicator {
+  margin-left: -45px;
+}
+.bp3-control.bp3-switch.bp3-large.bp3-align-right {
+  padding-right: 45px;
+}
+.bp3-control.bp3-switch.bp3-large.bp3-align-right .bp3-control-indicator {
+  margin-right: -45px;
+}
+.bp3-dark .bp3-control.bp3-switch input ~ .bp3-control-indicator {
+  background: rgba(16, 22, 26, 0.5);
+}
+.bp3-dark .bp3-control.bp3-switch:hover input ~ .bp3-control-indicator {
+  background: rgba(16, 22, 26, 0.7);
+}
+.bp3-dark
+  .bp3-control.bp3-switch
+  input:not(:disabled):active
+  ~ .bp3-control-indicator {
+  background: rgba(16, 22, 26, 0.9);
+}
+.bp3-dark .bp3-control.bp3-switch input:disabled ~ .bp3-control-indicator {
+  background: rgba(57, 75, 89, 0.5);
+}
+.bp3-dark
+  .bp3-control.bp3-switch
+  input:disabled
+  ~ .bp3-control-indicator::before {
+  background: rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator {
+  background: #137cbd;
+}
+.bp3-dark .bp3-control.bp3-switch:hover input:checked ~ .bp3-control-indicator {
+  background: #106ba3;
+}
+.bp3-dark
+  .bp3-control.bp3-switch
+  input:checked:not(:disabled):active
+  ~ .bp3-control-indicator {
+  background: #0e5a8a;
+}
+.bp3-dark
+  .bp3-control.bp3-switch
+  input:checked:disabled
+  ~ .bp3-control-indicator {
+  background: rgba(14, 90, 138, 0.5);
+}
+.bp3-dark
+  .bp3-control.bp3-switch
+  input:checked:disabled
+  ~ .bp3-control-indicator::before {
+  background: rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-control.bp3-switch .bp3-control-indicator::before {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background: #394b59;
+}
+.bp3-dark
+  .bp3-control.bp3-switch
+  input:checked
+  ~ .bp3-control-indicator::before {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-control.bp3-switch .bp3-switch-inner-text {
+  text-align: center;
+  font-size: 0.7em;
+}
+.bp3-control.bp3-switch .bp3-control-indicator-child:first-child {
+  visibility: hidden;
+  margin-right: 1.2em;
+  margin-left: 0.5em;
+  line-height: 0;
+}
+.bp3-control.bp3-switch .bp3-control-indicator-child:last-child {
+  visibility: visible;
+  margin-right: 0.5em;
+  margin-left: 1.2em;
+  line-height: 1em;
+}
+.bp3-control.bp3-switch
+  input:checked
+  ~ .bp3-control-indicator
+  .bp3-control-indicator-child:first-child {
+  visibility: visible;
+  line-height: 1em;
+}
+.bp3-control.bp3-switch
+  input:checked
+  ~ .bp3-control-indicator
+  .bp3-control-indicator-child:last-child {
+  visibility: hidden;
+  line-height: 0;
+}
+.bp3-dark .bp3-control {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-control.bp3-disabled {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-control .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #394b59;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.05)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0)
+  );
+}
+.bp3-dark .bp3-control:hover .bp3-control-indicator {
+  background-color: #30404d;
+}
+.bp3-dark .bp3-control input:not(:disabled):active ~ .bp3-control-indicator {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background: #202b33;
+}
+.bp3-dark .bp3-control input:disabled ~ .bp3-control-indicator {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(57, 75, 89, 0.5);
+  cursor: not-allowed;
+}
+.bp3-dark
+  .bp3-control.bp3-checkbox
+  input:disabled:checked
+  ~ .bp3-control-indicator,
+.bp3-dark
+  .bp3-control.bp3-checkbox
+  input:disabled:indeterminate
+  ~ .bp3-control-indicator {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-file-input {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  height: 30px;
+}
+.bp3-file-input input {
+  opacity: 0;
+  margin: 0;
+  min-width: 200px;
+}
+.bp3-file-input input:disabled + .bp3-file-upload-input,
+.bp3-file-input input.bp3-disabled + .bp3-file-upload-input {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(206, 217, 224, 0.5);
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+  resize: none;
+}
+.bp3-file-input input:disabled + .bp3-file-upload-input::after,
+.bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after {
+  outline: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(206, 217, 224, 0.5);
+  background-image: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active,
+.bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active:hover,
+.bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active,
+.bp3-file-input
+  input.bp3-disabled
+  + .bp3-file-upload-input::after.bp3-active:hover {
+  background: rgba(206, 217, 224, 0.7);
+}
+.bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input,
+.bp3-dark .bp3-file-input input.bp3-disabled + .bp3-file-upload-input {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(57, 75, 89, 0.5);
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after,
+.bp3-dark .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(57, 75, 89, 0.5);
+  background-image: none;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark
+  .bp3-file-input
+  input:disabled
+  + .bp3-file-upload-input::after.bp3-active,
+.bp3-dark
+  .bp3-file-input
+  input.bp3-disabled
+  + .bp3-file-upload-input::after.bp3-active {
+  background: rgba(57, 75, 89, 0.7);
+}
+.bp3-file-input.bp3-file-input-has-selection .bp3-file-upload-input {
+  color: #182026;
+}
+.bp3-dark .bp3-file-input.bp3-file-input-has-selection .bp3-file-upload-input {
+  color: #f5f8fa;
+}
+.bp3-file-input.bp3-fill {
+  width: 100%;
+}
+.bp3-file-input.bp3-large,
+.bp3-large .bp3-file-input {
+  height: 40px;
+}
+.bp3-file-input .bp3-file-upload-input-custom-text::after {
+  content: attr(bp3-button-text);
+}
 
-.bp3-file-upload-input{
-  outline:none;
-  border:none;
-  border-radius:3px;
-  -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  height:30px;
-  padding:0 10px;
-  vertical-align:middle;
-  line-height:30px;
-  color:#182026;
-  font-size:14px;
-  font-weight:400;
-  -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  -webkit-appearance:none;
-     -moz-appearance:none;
-          appearance:none;
-  overflow:hidden;
-  text-overflow:ellipsis;
-  white-space:nowrap;
-  word-wrap:normal;
-  position:absolute;
-  top:0;
-  right:0;
-  left:0;
-  padding-right:80px;
-  color:rgba(92, 112, 128, 0.6);
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-file-upload-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-file-upload-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-file-upload-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-file-upload-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-file-upload-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-file-upload-input:focus, .bp3-file-upload-input.bp3-active{
-    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-file-upload-input[type="search"], .bp3-file-upload-input.bp3-round{
-    border-radius:30px;
-    -webkit-box-sizing:border-box;
-            box-sizing:border-box;
-    padding-left:10px; }
-  .bp3-file-upload-input[readonly]{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
-  .bp3-file-upload-input:disabled, .bp3-file-upload-input.bp3-disabled{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6);
-    resize:none; }
-  .bp3-file-upload-input::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-color:#f5f8fa;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
-    color:#182026;
-    min-width:24px;
-    min-height:24px;
-    overflow:hidden;
-    text-overflow:ellipsis;
-    white-space:nowrap;
-    word-wrap:normal;
-    position:absolute;
-    top:0;
-    right:0;
-    margin:3px;
-    border-radius:3px;
-    width:70px;
-    text-align:center;
-    line-height:24px;
-    content:"Browse"; }
-    .bp3-file-upload-input::after:hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-      background-clip:padding-box;
-      background-color:#ebf1f5; }
-    .bp3-file-upload-input::after:active, .bp3-file-upload-input::after.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#d8e1e8;
-      background-image:none; }
-    .bp3-file-upload-input::after:disabled, .bp3-file-upload-input::after.bp3-disabled{
-      outline:none;
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(206, 217, 224, 0.5);
-      background-image:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
-      .bp3-file-upload-input::after:disabled.bp3-active, .bp3-file-upload-input::after:disabled.bp3-active:hover, .bp3-file-upload-input::after.bp3-disabled.bp3-active, .bp3-file-upload-input::after.bp3-disabled.bp3-active:hover{
-        background:rgba(206, 217, 224, 0.7); }
-  .bp3-file-upload-input:hover::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-clip:padding-box;
-    background-color:#ebf1f5; }
-  .bp3-file-upload-input:active::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#d8e1e8;
-    background-image:none; }
-  .bp3-large .bp3-file-upload-input{
-    height:40px;
-    line-height:40px;
-    font-size:16px;
-    padding-right:95px; }
-    .bp3-large .bp3-file-upload-input[type="search"], .bp3-large .bp3-file-upload-input.bp3-round{
-      padding:0 15px; }
-    .bp3-large .bp3-file-upload-input::after{
-      min-width:30px;
-      min-height:30px;
-      margin:5px;
-      width:85px;
-      line-height:30px; }
-  .bp3-dark .bp3-file-upload-input{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
-    color:#f5f8fa;
-    color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-file-upload-input::-webkit-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-file-upload-input::-moz-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-file-upload-input:-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-file-upload-input::-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-file-upload-input::placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-file-upload-input:focus{
-      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-file-upload-input[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-file-upload-input:disabled, .bp3-dark .bp3-file-upload-input.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-file-upload-input::after{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#394b59;
-      background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
-      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
-      color:#f5f8fa; }
-      .bp3-dark .bp3-file-upload-input::after:hover, .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
-        color:#f5f8fa; }
-      .bp3-dark .bp3-file-upload-input::after:hover{
-        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-        background-color:#30404d; }
-      .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
-        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-        background-color:#202b33;
-        background-image:none; }
-      .bp3-dark .bp3-file-upload-input::after:disabled, .bp3-dark .bp3-file-upload-input::after.bp3-disabled{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background-color:rgba(57, 75, 89, 0.5);
-        background-image:none;
-        color:rgba(167, 182, 194, 0.6); }
-        .bp3-dark .bp3-file-upload-input::after:disabled.bp3-active, .bp3-dark .bp3-file-upload-input::after.bp3-disabled.bp3-active{
-          background:rgba(57, 75, 89, 0.7); }
-      .bp3-dark .bp3-file-upload-input::after .bp3-button-spinner .bp3-spinner-head{
-        background:rgba(16, 22, 26, 0.5);
-        stroke:#8a9ba8; }
-    .bp3-dark .bp3-file-upload-input:hover::after{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
-    .bp3-dark .bp3-file-upload-input:active::after{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#202b33;
-      background-image:none; }
+.bp3-file-upload-input {
+  outline: none;
+  border: none;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  background: #ffffff;
+  height: 30px;
+  padding: 0 10px;
+  vertical-align: middle;
+  line-height: 30px;
+  color: #182026;
+  font-size: 14px;
+  font-weight: 400;
+  -webkit-transition: -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  padding-right: 80px;
+  color: rgba(92, 112, 128, 0.6);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-file-upload-input::-webkit-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-file-upload-input::-moz-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-file-upload-input:-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-file-upload-input::-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-file-upload-input::placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-file-upload-input:focus,
+.bp3-file-upload-input.bp3-active {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-file-upload-input[type='search'],
+.bp3-file-upload-input.bp3-round {
+  border-radius: 30px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  padding-left: 10px;
+}
+.bp3-file-upload-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+}
+.bp3-file-upload-input:disabled,
+.bp3-file-upload-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(206, 217, 224, 0.5);
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+  resize: none;
+}
+.bp3-file-upload-input::after {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-color: #f5f8fa;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.8)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.8),
+    rgba(255, 255, 255, 0)
+  );
+  color: #182026;
+  min-width: 24px;
+  min-height: 24px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 3px;
+  border-radius: 3px;
+  width: 70px;
+  text-align: center;
+  line-height: 24px;
+  content: 'Browse';
+}
+.bp3-file-upload-input::after:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-clip: padding-box;
+  background-color: #ebf1f5;
+}
+.bp3-file-upload-input::after:active,
+.bp3-file-upload-input::after.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #d8e1e8;
+  background-image: none;
+}
+.bp3-file-upload-input::after:disabled,
+.bp3-file-upload-input::after.bp3-disabled {
+  outline: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(206, 217, 224, 0.5);
+  background-image: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-file-upload-input::after:disabled.bp3-active,
+.bp3-file-upload-input::after:disabled.bp3-active:hover,
+.bp3-file-upload-input::after.bp3-disabled.bp3-active,
+.bp3-file-upload-input::after.bp3-disabled.bp3-active:hover {
+  background: rgba(206, 217, 224, 0.7);
+}
+.bp3-file-upload-input:hover::after {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-clip: padding-box;
+  background-color: #ebf1f5;
+}
+.bp3-file-upload-input:active::after {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #d8e1e8;
+  background-image: none;
+}
+.bp3-large .bp3-file-upload-input {
+  height: 40px;
+  line-height: 40px;
+  font-size: 16px;
+  padding-right: 95px;
+}
+.bp3-large .bp3-file-upload-input[type='search'],
+.bp3-large .bp3-file-upload-input.bp3-round {
+  padding: 0 15px;
+}
+.bp3-large .bp3-file-upload-input::after {
+  min-width: 30px;
+  min-height: 30px;
+  margin: 5px;
+  width: 85px;
+  line-height: 30px;
+}
+.bp3-dark .bp3-file-upload-input {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  background: rgba(16, 22, 26, 0.3);
+  color: #f5f8fa;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input::-webkit-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input::-moz-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input:-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input::-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input::placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input:focus {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-file-upload-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-file-upload-input:disabled,
+.bp3-dark .bp3-file-upload-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(57, 75, 89, 0.5);
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input::after {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #394b59;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.05)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0)
+  );
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-file-upload-input::after:hover,
+.bp3-dark .bp3-file-upload-input::after:active,
+.bp3-dark .bp3-file-upload-input::after.bp3-active {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-file-upload-input::after:hover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #30404d;
+}
+.bp3-dark .bp3-file-upload-input::after:active,
+.bp3-dark .bp3-file-upload-input::after.bp3-active {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #202b33;
+  background-image: none;
+}
+.bp3-dark .bp3-file-upload-input::after:disabled,
+.bp3-dark .bp3-file-upload-input::after.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(57, 75, 89, 0.5);
+  background-image: none;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-file-upload-input::after:disabled.bp3-active,
+.bp3-dark .bp3-file-upload-input::after.bp3-disabled.bp3-active {
+  background: rgba(57, 75, 89, 0.7);
+}
+.bp3-dark .bp3-file-upload-input::after .bp3-button-spinner .bp3-spinner-head {
+  background: rgba(16, 22, 26, 0.5);
+  stroke: #8a9ba8;
+}
+.bp3-dark .bp3-file-upload-input:hover::after {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #30404d;
+}
+.bp3-dark .bp3-file-upload-input:active::after {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #202b33;
+  background-image: none;
+}
 
-.bp3-file-upload-input::after{
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
-.bp3-form-group{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:vertical;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:column;
-          flex-direction:column;
-  margin:0 0 15px; }
-  .bp3-form-group label.bp3-label{
-    margin-bottom:5px; }
-  .bp3-form-group .bp3-control{
-    margin-top:7px; }
-  .bp3-form-group .bp3-form-helper-text{
-    margin-top:5px;
-    color:#5c7080;
-    font-size:12px; }
-  .bp3-form-group.bp3-intent-primary .bp3-form-helper-text{
-    color:#106ba3; }
-  .bp3-form-group.bp3-intent-success .bp3-form-helper-text{
-    color:#0d8050; }
-  .bp3-form-group.bp3-intent-warning .bp3-form-helper-text{
-    color:#bf7326; }
-  .bp3-form-group.bp3-intent-danger .bp3-form-helper-text{
-    color:#c23030; }
-  .bp3-form-group.bp3-inline{
-    -webkit-box-orient:horizontal;
-    -webkit-box-direction:normal;
-        -ms-flex-direction:row;
-            flex-direction:row;
-    -webkit-box-align:start;
-        -ms-flex-align:start;
-            align-items:flex-start; }
-    .bp3-form-group.bp3-inline.bp3-large label.bp3-label{
-      margin:0 10px 0 0;
-      line-height:40px; }
-    .bp3-form-group.bp3-inline label.bp3-label{
-      margin:0 10px 0 0;
-      line-height:30px; }
-  .bp3-form-group.bp3-disabled .bp3-label,
-  .bp3-form-group.bp3-disabled .bp3-text-muted,
-  .bp3-form-group.bp3-disabled .bp3-form-helper-text{
-    color:rgba(92, 112, 128, 0.6) !important; }
-  .bp3-dark .bp3-form-group.bp3-intent-primary .bp3-form-helper-text{
-    color:#48aff0; }
-  .bp3-dark .bp3-form-group.bp3-intent-success .bp3-form-helper-text{
-    color:#3dcc91; }
-  .bp3-dark .bp3-form-group.bp3-intent-warning .bp3-form-helper-text{
-    color:#ffb366; }
-  .bp3-dark .bp3-form-group.bp3-intent-danger .bp3-form-helper-text{
-    color:#ff7373; }
-  .bp3-dark .bp3-form-group .bp3-form-helper-text{
-    color:#a7b6c2; }
-  .bp3-dark .bp3-form-group.bp3-disabled .bp3-label,
-  .bp3-dark .bp3-form-group.bp3-disabled .bp3-text-muted,
-  .bp3-dark .bp3-form-group.bp3-disabled .bp3-form-helper-text{
-    color:rgba(167, 182, 194, 0.6) !important; }
-.bp3-input-group{
-  display:block;
-  position:relative; }
-  .bp3-input-group .bp3-input{
-    position:relative;
-    width:100%; }
-    .bp3-input-group .bp3-input:not(:first-child){
-      padding-left:30px; }
-    .bp3-input-group .bp3-input:not(:last-child){
-      padding-right:30px; }
-  .bp3-input-group .bp3-input-action,
-  .bp3-input-group > .bp3-button,
-  .bp3-input-group > .bp3-icon{
-    position:absolute;
-    top:0; }
-    .bp3-input-group .bp3-input-action:first-child,
-    .bp3-input-group > .bp3-button:first-child,
-    .bp3-input-group > .bp3-icon:first-child{
-      left:0; }
-    .bp3-input-group .bp3-input-action:last-child,
-    .bp3-input-group > .bp3-button:last-child,
-    .bp3-input-group > .bp3-icon:last-child{
-      right:0; }
-  .bp3-input-group .bp3-button{
-    min-width:24px;
-    min-height:24px;
-    margin:3px;
-    padding:0 7px; }
-    .bp3-input-group .bp3-button:empty{
-      padding:0; }
-  .bp3-input-group > .bp3-icon{
-    z-index:1;
-    color:#5c7080; }
-    .bp3-input-group > .bp3-icon:empty{
-      line-height:1;
-      font-family:"Icons16", sans-serif;
-      font-size:16px;
-      font-weight:400;
-      font-style:normal;
-      -moz-osx-font-smoothing:grayscale;
-      -webkit-font-smoothing:antialiased; }
-  .bp3-input-group > .bp3-icon,
-  .bp3-input-group .bp3-input-action > .bp3-spinner{
-    margin:7px; }
-  .bp3-input-group .bp3-tag{
-    margin:5px; }
-  .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus),
-  .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus){
-    color:#5c7080; }
-    .bp3-dark .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus), .bp3-dark
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus){
-      color:#a7b6c2; }
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-standard, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-large,
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon,
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-standard,
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:not(:hover):not(:focus) .bp3-icon-large{
-      color:#5c7080; }
-  .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled,
-  .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled{
-    color:rgba(92, 112, 128, 0.6) !important; }
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled .bp3-icon, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled .bp3-icon-standard, .bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled .bp3-icon-large,
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled .bp3-icon,
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled .bp3-icon-standard,
-    .bp3-input-group .bp3-input:not(:focus) + .bp3-input-action .bp3-button.bp3-minimal:disabled .bp3-icon-large{
-      color:rgba(92, 112, 128, 0.6) !important; }
-  .bp3-input-group.bp3-disabled{
-    cursor:not-allowed; }
-    .bp3-input-group.bp3-disabled .bp3-icon{
-      color:rgba(92, 112, 128, 0.6); }
-  .bp3-input-group.bp3-large .bp3-button{
-    min-width:30px;
-    min-height:30px;
-    margin:5px; }
-  .bp3-input-group.bp3-large > .bp3-icon,
-  .bp3-input-group.bp3-large .bp3-input-action > .bp3-spinner{
-    margin:12px; }
-  .bp3-input-group.bp3-large .bp3-input{
-    height:40px;
-    line-height:40px;
-    font-size:16px; }
-    .bp3-input-group.bp3-large .bp3-input[type="search"], .bp3-input-group.bp3-large .bp3-input.bp3-round{
-      padding:0 15px; }
-    .bp3-input-group.bp3-large .bp3-input:not(:first-child){
-      padding-left:40px; }
-    .bp3-input-group.bp3-large .bp3-input:not(:last-child){
-      padding-right:40px; }
-  .bp3-input-group.bp3-small .bp3-button{
-    min-width:20px;
-    min-height:20px;
-    margin:2px; }
-  .bp3-input-group.bp3-small .bp3-tag{
-    min-width:20px;
-    min-height:20px;
-    margin:2px; }
-  .bp3-input-group.bp3-small > .bp3-icon,
-  .bp3-input-group.bp3-small .bp3-input-action > .bp3-spinner{
-    margin:4px; }
-  .bp3-input-group.bp3-small .bp3-input{
-    height:24px;
-    padding-right:8px;
-    padding-left:8px;
-    line-height:24px;
-    font-size:12px; }
-    .bp3-input-group.bp3-small .bp3-input[type="search"], .bp3-input-group.bp3-small .bp3-input.bp3-round{
-      padding:0 12px; }
-    .bp3-input-group.bp3-small .bp3-input:not(:first-child){
-      padding-left:24px; }
-    .bp3-input-group.bp3-small .bp3-input:not(:last-child){
-      padding-right:24px; }
-  .bp3-input-group.bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto;
-    width:100%; }
-  .bp3-input-group.bp3-round .bp3-button,
-  .bp3-input-group.bp3-round .bp3-input,
-  .bp3-input-group.bp3-round .bp3-tag{
-    border-radius:30px; }
-  .bp3-dark .bp3-input-group .bp3-icon{
-    color:#a7b6c2; }
-  .bp3-dark .bp3-input-group.bp3-disabled .bp3-icon{
-    color:rgba(167, 182, 194, 0.6); }
-  .bp3-input-group.bp3-intent-primary .bp3-input{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-primary .bp3-input:focus{
-      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-primary .bp3-input[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #137cbd;
-              box-shadow:inset 0 0 0 1px #137cbd; }
-    .bp3-input-group.bp3-intent-primary .bp3-input:disabled, .bp3-input-group.bp3-intent-primary .bp3-input.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-  .bp3-input-group.bp3-intent-primary > .bp3-icon{
-    color:#106ba3; }
-    .bp3-dark .bp3-input-group.bp3-intent-primary > .bp3-icon{
-      color:#48aff0; }
-  .bp3-input-group.bp3-intent-success .bp3-input{
-    -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-success .bp3-input:focus{
-      -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-success .bp3-input[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #0f9960;
-              box-shadow:inset 0 0 0 1px #0f9960; }
-    .bp3-input-group.bp3-intent-success .bp3-input:disabled, .bp3-input-group.bp3-intent-success .bp3-input.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-  .bp3-input-group.bp3-intent-success > .bp3-icon{
-    color:#0d8050; }
-    .bp3-dark .bp3-input-group.bp3-intent-success > .bp3-icon{
-      color:#3dcc91; }
-  .bp3-input-group.bp3-intent-warning .bp3-input{
-    -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-warning .bp3-input:focus{
-      -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-warning .bp3-input[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #d9822b;
-              box-shadow:inset 0 0 0 1px #d9822b; }
-    .bp3-input-group.bp3-intent-warning .bp3-input:disabled, .bp3-input-group.bp3-intent-warning .bp3-input.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-  .bp3-input-group.bp3-intent-warning > .bp3-icon{
-    color:#bf7326; }
-    .bp3-dark .bp3-input-group.bp3-intent-warning > .bp3-icon{
-      color:#ffb366; }
-  .bp3-input-group.bp3-intent-danger .bp3-input{
-    -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-danger .bp3-input:focus{
-      -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input-group.bp3-intent-danger .bp3-input[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #db3737;
-              box-shadow:inset 0 0 0 1px #db3737; }
-    .bp3-input-group.bp3-intent-danger .bp3-input:disabled, .bp3-input-group.bp3-intent-danger .bp3-input.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-  .bp3-input-group.bp3-intent-danger > .bp3-icon{
-    color:#c23030; }
-    .bp3-dark .bp3-input-group.bp3-intent-danger > .bp3-icon{
-      color:#ff7373; }
-.bp3-input{
-  outline:none;
-  border:none;
-  border-radius:3px;
-  -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  height:30px;
-  padding:0 10px;
-  vertical-align:middle;
-  line-height:30px;
-  color:#182026;
-  font-size:14px;
-  font-weight:400;
-  -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  -webkit-appearance:none;
-     -moz-appearance:none;
-          appearance:none; }
-  .bp3-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input:focus, .bp3-input.bp3-active{
-    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-input[type="search"], .bp3-input.bp3-round{
-    border-radius:30px;
-    -webkit-box-sizing:border-box;
-            box-sizing:border-box;
-    padding-left:10px; }
-  .bp3-input[readonly]{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
-  .bp3-input:disabled, .bp3-input.bp3-disabled{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6);
-    resize:none; }
-  .bp3-input.bp3-large{
-    height:40px;
-    line-height:40px;
-    font-size:16px; }
-    .bp3-input.bp3-large[type="search"], .bp3-input.bp3-large.bp3-round{
-      padding:0 15px; }
-  .bp3-input.bp3-small{
-    height:24px;
-    padding-right:8px;
-    padding-left:8px;
-    line-height:24px;
-    font-size:12px; }
-    .bp3-input.bp3-small[type="search"], .bp3-input.bp3-small.bp3-round{
-      padding:0 12px; }
-  .bp3-input.bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto;
-    width:100%; }
-  .bp3-dark .bp3-input{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
-    color:#f5f8fa; }
-    .bp3-dark .bp3-input::-webkit-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-input::-moz-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-input:-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-input::-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-input::placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-input:focus{
-      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-input[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-input:disabled, .bp3-dark .bp3-input.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
-      color:rgba(167, 182, 194, 0.6); }
-  .bp3-input.bp3-intent-primary{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-primary:focus{
-      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-primary[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #137cbd;
-              box-shadow:inset 0 0 0 1px #137cbd; }
-    .bp3-input.bp3-intent-primary:disabled, .bp3-input.bp3-intent-primary.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-    .bp3-dark .bp3-input.bp3-intent-primary{
-      -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-primary:focus{
-        -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-                box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-primary[readonly]{
-        -webkit-box-shadow:inset 0 0 0 1px #137cbd;
-                box-shadow:inset 0 0 0 1px #137cbd; }
-      .bp3-dark .bp3-input.bp3-intent-primary:disabled, .bp3-dark .bp3-input.bp3-intent-primary.bp3-disabled{
-        -webkit-box-shadow:none;
-                box-shadow:none; }
-  .bp3-input.bp3-intent-success{
-    -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-success:focus{
-      -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-success[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #0f9960;
-              box-shadow:inset 0 0 0 1px #0f9960; }
-    .bp3-input.bp3-intent-success:disabled, .bp3-input.bp3-intent-success.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-    .bp3-dark .bp3-input.bp3-intent-success{
-      -webkit-box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-success:focus{
-        -webkit-box-shadow:0 0 0 1px #0f9960, 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-                box-shadow:0 0 0 1px #0f9960, 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-success[readonly]{
-        -webkit-box-shadow:inset 0 0 0 1px #0f9960;
-                box-shadow:inset 0 0 0 1px #0f9960; }
-      .bp3-dark .bp3-input.bp3-intent-success:disabled, .bp3-dark .bp3-input.bp3-intent-success.bp3-disabled{
-        -webkit-box-shadow:none;
-                box-shadow:none; }
-  .bp3-input.bp3-intent-warning{
-    -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-warning:focus{
-      -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-warning[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #d9822b;
-              box-shadow:inset 0 0 0 1px #d9822b; }
-    .bp3-input.bp3-intent-warning:disabled, .bp3-input.bp3-intent-warning.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-    .bp3-dark .bp3-input.bp3-intent-warning{
-      -webkit-box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-warning:focus{
-        -webkit-box-shadow:0 0 0 1px #d9822b, 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-                box-shadow:0 0 0 1px #d9822b, 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-warning[readonly]{
-        -webkit-box-shadow:inset 0 0 0 1px #d9822b;
-                box-shadow:inset 0 0 0 1px #d9822b; }
-      .bp3-dark .bp3-input.bp3-intent-warning:disabled, .bp3-dark .bp3-input.bp3-intent-warning.bp3-disabled{
-        -webkit-box-shadow:none;
-                box-shadow:none; }
-  .bp3-input.bp3-intent-danger{
-    -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-danger:focus{
-      -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-input.bp3-intent-danger[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px #db3737;
-              box-shadow:inset 0 0 0 1px #db3737; }
-    .bp3-input.bp3-intent-danger:disabled, .bp3-input.bp3-intent-danger.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-    .bp3-dark .bp3-input.bp3-intent-danger{
-      -webkit-box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-danger:focus{
-        -webkit-box-shadow:0 0 0 1px #db3737, 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-                box-shadow:0 0 0 1px #db3737, 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-      .bp3-dark .bp3-input.bp3-intent-danger[readonly]{
-        -webkit-box-shadow:inset 0 0 0 1px #db3737;
-                box-shadow:inset 0 0 0 1px #db3737; }
-      .bp3-dark .bp3-input.bp3-intent-danger:disabled, .bp3-dark .bp3-input.bp3-intent-danger.bp3-disabled{
-        -webkit-box-shadow:none;
-                box-shadow:none; }
-  .bp3-input::-ms-clear{
-    display:none; }
-textarea.bp3-input{
-  max-width:100%;
-  padding:10px; }
-  textarea.bp3-input, textarea.bp3-input.bp3-large, textarea.bp3-input.bp3-small{
-    height:auto;
-    line-height:inherit; }
-  textarea.bp3-input.bp3-small{
-    padding:8px; }
-  .bp3-dark textarea.bp3-input{
-    -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
-    color:#f5f8fa; }
-    .bp3-dark textarea.bp3-input::-webkit-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark textarea.bp3-input::-moz-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark textarea.bp3-input:-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark textarea.bp3-input::-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark textarea.bp3-input::placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark textarea.bp3-input:focus{
-      -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark textarea.bp3-input[readonly]{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark textarea.bp3-input:disabled, .bp3-dark textarea.bp3-input.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
-      color:rgba(167, 182, 194, 0.6); }
-label.bp3-label{
-  display:block;
-  margin-top:0;
-  margin-bottom:15px; }
-  label.bp3-label .bp3-html-select,
-  label.bp3-label .bp3-input,
-  label.bp3-label .bp3-select,
-  label.bp3-label .bp3-slider,
-  label.bp3-label .bp3-popover-wrapper{
-    display:block;
-    margin-top:5px;
-    text-transform:none; }
-  label.bp3-label .bp3-button-group{
-    margin-top:5px; }
-  label.bp3-label .bp3-select select,
-  label.bp3-label .bp3-html-select select{
-    width:100%;
-    vertical-align:top;
-    font-weight:400; }
-  label.bp3-label.bp3-disabled,
-  label.bp3-label.bp3-disabled .bp3-text-muted{
-    color:rgba(92, 112, 128, 0.6); }
-  label.bp3-label.bp3-inline{
-    line-height:30px; }
-    label.bp3-label.bp3-inline .bp3-html-select,
-    label.bp3-label.bp3-inline .bp3-input,
-    label.bp3-label.bp3-inline .bp3-input-group,
-    label.bp3-label.bp3-inline .bp3-select,
-    label.bp3-label.bp3-inline .bp3-popover-wrapper{
-      display:inline-block;
-      margin:0 0 0 5px;
-      vertical-align:top; }
-    label.bp3-label.bp3-inline .bp3-button-group{
-      margin:0 0 0 5px; }
-    label.bp3-label.bp3-inline .bp3-input-group .bp3-input{
-      margin-left:0; }
-    label.bp3-label.bp3-inline.bp3-large{
-      line-height:40px; }
-  label.bp3-label:not(.bp3-inline) .bp3-popover-target{
-    display:block; }
-  .bp3-dark label.bp3-label{
-    color:#f5f8fa; }
-    .bp3-dark label.bp3-label.bp3-disabled,
-    .bp3-dark label.bp3-label.bp3-disabled .bp3-text-muted{
-      color:rgba(167, 182, 194, 0.6); }
-.bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button{
-  -webkit-box-flex:1;
-      -ms-flex:1 1 14px;
-          flex:1 1 14px;
-  width:30px;
-  min-height:0;
-  padding:0; }
-  .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:first-child{
-    border-radius:0 3px 0 0; }
-  .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:last-child{
-    border-radius:0 0 3px 0; }
+.bp3-file-upload-input::after {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+}
+.bp3-form-group {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0 0 15px;
+}
+.bp3-form-group label.bp3-label {
+  margin-bottom: 5px;
+}
+.bp3-form-group .bp3-control {
+  margin-top: 7px;
+}
+.bp3-form-group .bp3-form-helper-text {
+  margin-top: 5px;
+  color: #5c7080;
+  font-size: 12px;
+}
+.bp3-form-group.bp3-intent-primary .bp3-form-helper-text {
+  color: #106ba3;
+}
+.bp3-form-group.bp3-intent-success .bp3-form-helper-text {
+  color: #0d8050;
+}
+.bp3-form-group.bp3-intent-warning .bp3-form-helper-text {
+  color: #bf7326;
+}
+.bp3-form-group.bp3-intent-danger .bp3-form-helper-text {
+  color: #c23030;
+}
+.bp3-form-group.bp3-inline {
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+}
+.bp3-form-group.bp3-inline.bp3-large label.bp3-label {
+  margin: 0 10px 0 0;
+  line-height: 40px;
+}
+.bp3-form-group.bp3-inline label.bp3-label {
+  margin: 0 10px 0 0;
+  line-height: 30px;
+}
+.bp3-form-group.bp3-disabled .bp3-label,
+.bp3-form-group.bp3-disabled .bp3-text-muted,
+.bp3-form-group.bp3-disabled .bp3-form-helper-text {
+  color: rgba(92, 112, 128, 0.6) !important;
+}
+.bp3-dark .bp3-form-group.bp3-intent-primary .bp3-form-helper-text {
+  color: #48aff0;
+}
+.bp3-dark .bp3-form-group.bp3-intent-success .bp3-form-helper-text {
+  color: #3dcc91;
+}
+.bp3-dark .bp3-form-group.bp3-intent-warning .bp3-form-helper-text {
+  color: #ffb366;
+}
+.bp3-dark .bp3-form-group.bp3-intent-danger .bp3-form-helper-text {
+  color: #ff7373;
+}
+.bp3-dark .bp3-form-group .bp3-form-helper-text {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-form-group.bp3-disabled .bp3-label,
+.bp3-dark .bp3-form-group.bp3-disabled .bp3-text-muted,
+.bp3-dark .bp3-form-group.bp3-disabled .bp3-form-helper-text {
+  color: rgba(167, 182, 194, 0.6) !important;
+}
+.bp3-input-group {
+  display: block;
+  position: relative;
+}
+.bp3-input-group .bp3-input {
+  position: relative;
+  width: 100%;
+}
+.bp3-input-group .bp3-input:not(:first-child) {
+  padding-left: 30px;
+}
+.bp3-input-group .bp3-input:not(:last-child) {
+  padding-right: 30px;
+}
+.bp3-input-group .bp3-input-action,
+.bp3-input-group > .bp3-button,
+.bp3-input-group > .bp3-icon {
+  position: absolute;
+  top: 0;
+}
+.bp3-input-group .bp3-input-action:first-child,
+.bp3-input-group > .bp3-button:first-child,
+.bp3-input-group > .bp3-icon:first-child {
+  left: 0;
+}
+.bp3-input-group .bp3-input-action:last-child,
+.bp3-input-group > .bp3-button:last-child,
+.bp3-input-group > .bp3-icon:last-child {
+  right: 0;
+}
+.bp3-input-group .bp3-button {
+  min-width: 24px;
+  min-height: 24px;
+  margin: 3px;
+  padding: 0 7px;
+}
+.bp3-input-group .bp3-button:empty {
+  padding: 0;
+}
+.bp3-input-group > .bp3-icon {
+  z-index: 1;
+  color: #5c7080;
+}
+.bp3-input-group > .bp3-icon:empty {
+  line-height: 1;
+  font-family: 'Icons16', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+.bp3-input-group > .bp3-icon,
+.bp3-input-group .bp3-input-action > .bp3-spinner {
+  margin: 7px;
+}
+.bp3-input-group .bp3-tag {
+  margin: 5px;
+}
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:not(:hover):not(:focus),
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:not(:hover):not(:focus) {
+  color: #5c7080;
+}
+.bp3-dark
+  .bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:not(:hover):not(:focus),
+.bp3-dark
+  .bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:not(:hover):not(:focus) {
+  color: #a7b6c2;
+}
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:not(:hover):not(:focus)
+  .bp3-icon,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:not(:hover):not(:focus)
+  .bp3-icon-standard,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:not(:hover):not(:focus)
+  .bp3-icon-large,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:not(:hover):not(:focus)
+  .bp3-icon,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:not(:hover):not(:focus)
+  .bp3-icon-standard,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:not(:hover):not(:focus)
+  .bp3-icon-large {
+  color: #5c7080;
+}
+.bp3-input-group .bp3-input:not(:focus) + .bp3-button.bp3-minimal:disabled,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:disabled {
+  color: rgba(92, 112, 128, 0.6) !important;
+}
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:disabled
+  .bp3-icon,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:disabled
+  .bp3-icon-standard,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-button.bp3-minimal:disabled
+  .bp3-icon-large,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:disabled
+  .bp3-icon,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:disabled
+  .bp3-icon-standard,
+.bp3-input-group
+  .bp3-input:not(:focus)
+  + .bp3-input-action
+  .bp3-button.bp3-minimal:disabled
+  .bp3-icon-large {
+  color: rgba(92, 112, 128, 0.6) !important;
+}
+.bp3-input-group.bp3-disabled {
+  cursor: not-allowed;
+}
+.bp3-input-group.bp3-disabled .bp3-icon {
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input-group.bp3-large .bp3-button {
+  min-width: 30px;
+  min-height: 30px;
+  margin: 5px;
+}
+.bp3-input-group.bp3-large > .bp3-icon,
+.bp3-input-group.bp3-large .bp3-input-action > .bp3-spinner {
+  margin: 12px;
+}
+.bp3-input-group.bp3-large .bp3-input {
+  height: 40px;
+  line-height: 40px;
+  font-size: 16px;
+}
+.bp3-input-group.bp3-large .bp3-input[type='search'],
+.bp3-input-group.bp3-large .bp3-input.bp3-round {
+  padding: 0 15px;
+}
+.bp3-input-group.bp3-large .bp3-input:not(:first-child) {
+  padding-left: 40px;
+}
+.bp3-input-group.bp3-large .bp3-input:not(:last-child) {
+  padding-right: 40px;
+}
+.bp3-input-group.bp3-small .bp3-button {
+  min-width: 20px;
+  min-height: 20px;
+  margin: 2px;
+}
+.bp3-input-group.bp3-small .bp3-tag {
+  min-width: 20px;
+  min-height: 20px;
+  margin: 2px;
+}
+.bp3-input-group.bp3-small > .bp3-icon,
+.bp3-input-group.bp3-small .bp3-input-action > .bp3-spinner {
+  margin: 4px;
+}
+.bp3-input-group.bp3-small .bp3-input {
+  height: 24px;
+  padding-right: 8px;
+  padding-left: 8px;
+  line-height: 24px;
+  font-size: 12px;
+}
+.bp3-input-group.bp3-small .bp3-input[type='search'],
+.bp3-input-group.bp3-small .bp3-input.bp3-round {
+  padding: 0 12px;
+}
+.bp3-input-group.bp3-small .bp3-input:not(:first-child) {
+  padding-left: 24px;
+}
+.bp3-input-group.bp3-small .bp3-input:not(:last-child) {
+  padding-right: 24px;
+}
+.bp3-input-group.bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 100%;
+}
+.bp3-input-group.bp3-round .bp3-button,
+.bp3-input-group.bp3-round .bp3-input,
+.bp3-input-group.bp3-round .bp3-tag {
+  border-radius: 30px;
+}
+.bp3-dark .bp3-input-group .bp3-icon {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-input-group.bp3-disabled .bp3-icon {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-input-group.bp3-intent-primary .bp3-input {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-primary .bp3-input:focus {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-primary .bp3-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #137cbd;
+  box-shadow: inset 0 0 0 1px #137cbd;
+}
+.bp3-input-group.bp3-intent-primary .bp3-input:disabled,
+.bp3-input-group.bp3-intent-primary .bp3-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input-group.bp3-intent-primary > .bp3-icon {
+  color: #106ba3;
+}
+.bp3-dark .bp3-input-group.bp3-intent-primary > .bp3-icon {
+  color: #48aff0;
+}
+.bp3-input-group.bp3-intent-success .bp3-input {
+  -webkit-box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-success .bp3-input:focus {
+  -webkit-box-shadow: 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-success .bp3-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #0f9960;
+  box-shadow: inset 0 0 0 1px #0f9960;
+}
+.bp3-input-group.bp3-intent-success .bp3-input:disabled,
+.bp3-input-group.bp3-intent-success .bp3-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input-group.bp3-intent-success > .bp3-icon {
+  color: #0d8050;
+}
+.bp3-dark .bp3-input-group.bp3-intent-success > .bp3-icon {
+  color: #3dcc91;
+}
+.bp3-input-group.bp3-intent-warning .bp3-input {
+  -webkit-box-shadow: 0 0 0 0 rgba(217, 130, 43, 0),
+    0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0),
+    inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-warning .bp3-input:focus {
+  -webkit-box-shadow: 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-warning .bp3-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #d9822b;
+  box-shadow: inset 0 0 0 1px #d9822b;
+}
+.bp3-input-group.bp3-intent-warning .bp3-input:disabled,
+.bp3-input-group.bp3-intent-warning .bp3-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input-group.bp3-intent-warning > .bp3-icon {
+  color: #bf7326;
+}
+.bp3-dark .bp3-input-group.bp3-intent-warning > .bp3-icon {
+  color: #ffb366;
+}
+.bp3-input-group.bp3-intent-danger .bp3-input {
+  -webkit-box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-danger .bp3-input:focus {
+  -webkit-box-shadow: 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input-group.bp3-intent-danger .bp3-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #db3737;
+  box-shadow: inset 0 0 0 1px #db3737;
+}
+.bp3-input-group.bp3-intent-danger .bp3-input:disabled,
+.bp3-input-group.bp3-intent-danger .bp3-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input-group.bp3-intent-danger > .bp3-icon {
+  color: #c23030;
+}
+.bp3-dark .bp3-input-group.bp3-intent-danger > .bp3-icon {
+  color: #ff7373;
+}
+.bp3-input {
+  outline: none;
+  border: none;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  background: #ffffff;
+  height: 30px;
+  padding: 0 10px;
+  vertical-align: middle;
+  line-height: 30px;
+  color: #182026;
+  font-size: 14px;
+  font-weight: 400;
+  -webkit-transition: -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+.bp3-input::-webkit-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input::-moz-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input:-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input::-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input::placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input:focus,
+.bp3-input.bp3-active {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input[type='search'],
+.bp3-input.bp3-round {
+  border-radius: 30px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  padding-left: 10px;
+}
+.bp3-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.15);
+}
+.bp3-input:disabled,
+.bp3-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(206, 217, 224, 0.5);
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+  resize: none;
+}
+.bp3-input.bp3-large {
+  height: 40px;
+  line-height: 40px;
+  font-size: 16px;
+}
+.bp3-input.bp3-large[type='search'],
+.bp3-input.bp3-large.bp3-round {
+  padding: 0 15px;
+}
+.bp3-input.bp3-small {
+  height: 24px;
+  padding-right: 8px;
+  padding-left: 8px;
+  line-height: 24px;
+  font-size: 12px;
+}
+.bp3-input.bp3-small[type='search'],
+.bp3-input.bp3-small.bp3-round {
+  padding: 0 12px;
+}
+.bp3-input.bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 100%;
+}
+.bp3-dark .bp3-input {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  background: rgba(16, 22, 26, 0.3);
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-input::-webkit-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-input::-moz-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-input:-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-input::-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-input::placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-input:focus {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input:disabled,
+.bp3-dark .bp3-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(57, 75, 89, 0.5);
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-input.bp3-intent-primary {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-primary:focus {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-primary[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #137cbd;
+  box-shadow: inset 0 0 0 1px #137cbd;
+}
+.bp3-input.bp3-intent-primary:disabled,
+.bp3-input.bp3-intent-primary.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-dark .bp3-input.bp3-intent-primary {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-primary:focus {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-primary[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #137cbd;
+  box-shadow: inset 0 0 0 1px #137cbd;
+}
+.bp3-dark .bp3-input.bp3-intent-primary:disabled,
+.bp3-dark .bp3-input.bp3-intent-primary.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input.bp3-intent-success {
+  -webkit-box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    inset 0 0 0 1px #0f9960, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-success:focus {
+  -webkit-box-shadow: 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #0f9960, 0 0 0 3px rgba(15, 153, 96, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-success[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #0f9960;
+  box-shadow: inset 0 0 0 1px #0f9960;
+}
+.bp3-input.bp3-intent-success:disabled,
+.bp3-input.bp3-intent-success.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-dark .bp3-input.bp3-intent-success {
+  -webkit-box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 0 rgba(15, 153, 96, 0), 0 0 0 0 rgba(15, 153, 96, 0),
+    0 0 0 0 rgba(15, 153, 96, 0), inset 0 0 0 1px #0f9960,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-success:focus {
+  -webkit-box-shadow: 0 0 0 1px #0f9960, 0 0 0 1px #0f9960,
+    0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #0f9960, 0 0 0 1px #0f9960,
+    0 0 0 3px rgba(15, 153, 96, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-success[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #0f9960;
+  box-shadow: inset 0 0 0 1px #0f9960;
+}
+.bp3-dark .bp3-input.bp3-intent-success:disabled,
+.bp3-dark .bp3-input.bp3-intent-success.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input.bp3-intent-warning {
+  -webkit-box-shadow: 0 0 0 0 rgba(217, 130, 43, 0),
+    0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0),
+    inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-warning:focus {
+  -webkit-box-shadow: 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #d9822b, 0 0 0 3px rgba(217, 130, 43, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-warning[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #d9822b;
+  box-shadow: inset 0 0 0 1px #d9822b;
+}
+.bp3-input.bp3-intent-warning:disabled,
+.bp3-input.bp3-intent-warning.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-dark .bp3-input.bp3-intent-warning {
+  -webkit-box-shadow: 0 0 0 0 rgba(217, 130, 43, 0),
+    0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0),
+    inset 0 0 0 1px #d9822b, inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 0 rgba(217, 130, 43, 0), 0 0 0 0 rgba(217, 130, 43, 0),
+    0 0 0 0 rgba(217, 130, 43, 0), inset 0 0 0 1px #d9822b,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-warning:focus {
+  -webkit-box-shadow: 0 0 0 1px #d9822b, 0 0 0 1px #d9822b,
+    0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #d9822b, 0 0 0 1px #d9822b,
+    0 0 0 3px rgba(217, 130, 43, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-warning[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #d9822b;
+  box-shadow: inset 0 0 0 1px #d9822b;
+}
+.bp3-dark .bp3-input.bp3-intent-warning:disabled,
+.bp3-dark .bp3-input.bp3-intent-warning.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input.bp3-intent-danger {
+  -webkit-box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    inset 0 0 0 1px #db3737, inset 0 0 0 1px rgba(16, 22, 26, 0.15),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-danger:focus {
+  -webkit-box-shadow: 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #db3737, 0 0 0 3px rgba(219, 55, 55, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-input.bp3-intent-danger[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #db3737;
+  box-shadow: inset 0 0 0 1px #db3737;
+}
+.bp3-input.bp3-intent-danger:disabled,
+.bp3-input.bp3-intent-danger.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-dark .bp3-input.bp3-intent-danger {
+  -webkit-box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 0 rgba(219, 55, 55, 0), 0 0 0 0 rgba(219, 55, 55, 0),
+    0 0 0 0 rgba(219, 55, 55, 0), inset 0 0 0 1px #db3737,
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-danger:focus {
+  -webkit-box-shadow: 0 0 0 1px #db3737, 0 0 0 1px #db3737,
+    0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #db3737, 0 0 0 1px #db3737,
+    0 0 0 3px rgba(219, 55, 55, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-input.bp3-intent-danger[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px #db3737;
+  box-shadow: inset 0 0 0 1px #db3737;
+}
+.bp3-dark .bp3-input.bp3-intent-danger:disabled,
+.bp3-dark .bp3-input.bp3-intent-danger.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-input::-ms-clear {
+  display: none;
+}
+textarea.bp3-input {
+  max-width: 100%;
+  padding: 10px;
+}
+textarea.bp3-input,
+textarea.bp3-input.bp3-large,
+textarea.bp3-input.bp3-small {
+  height: auto;
+  line-height: inherit;
+}
+textarea.bp3-input.bp3-small {
+  padding: 8px;
+}
+.bp3-dark textarea.bp3-input {
+  -webkit-box-shadow: 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0),
+    0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  background: rgba(16, 22, 26, 0.3);
+  color: #f5f8fa;
+}
+.bp3-dark textarea.bp3-input::-webkit-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark textarea.bp3-input::-moz-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark textarea.bp3-input:-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark textarea.bp3-input::-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark textarea.bp3-input::placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark textarea.bp3-input:focus {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark textarea.bp3-input[readonly] {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark textarea.bp3-input:disabled,
+.bp3-dark textarea.bp3-input.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(57, 75, 89, 0.5);
+  color: rgba(167, 182, 194, 0.6);
+}
+label.bp3-label {
+  display: block;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+label.bp3-label .bp3-html-select,
+label.bp3-label .bp3-input,
+label.bp3-label .bp3-select,
+label.bp3-label .bp3-slider,
+label.bp3-label .bp3-popover-wrapper {
+  display: block;
+  margin-top: 5px;
+  text-transform: none;
+}
+label.bp3-label .bp3-button-group {
+  margin-top: 5px;
+}
+label.bp3-label .bp3-select select,
+label.bp3-label .bp3-html-select select {
+  width: 100%;
+  vertical-align: top;
+  font-weight: 400;
+}
+label.bp3-label.bp3-disabled,
+label.bp3-label.bp3-disabled .bp3-text-muted {
+  color: rgba(92, 112, 128, 0.6);
+}
+label.bp3-label.bp3-inline {
+  line-height: 30px;
+}
+label.bp3-label.bp3-inline .bp3-html-select,
+label.bp3-label.bp3-inline .bp3-input,
+label.bp3-label.bp3-inline .bp3-input-group,
+label.bp3-label.bp3-inline .bp3-select,
+label.bp3-label.bp3-inline .bp3-popover-wrapper {
+  display: inline-block;
+  margin: 0 0 0 5px;
+  vertical-align: top;
+}
+label.bp3-label.bp3-inline .bp3-button-group {
+  margin: 0 0 0 5px;
+}
+label.bp3-label.bp3-inline .bp3-input-group .bp3-input {
+  margin-left: 0;
+}
+label.bp3-label.bp3-inline.bp3-large {
+  line-height: 40px;
+}
+label.bp3-label:not(.bp3-inline) .bp3-popover-target {
+  display: block;
+}
+.bp3-dark label.bp3-label {
+  color: #f5f8fa;
+}
+.bp3-dark label.bp3-label.bp3-disabled,
+.bp3-dark label.bp3-label.bp3-disabled .bp3-text-muted {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 14px;
+  flex: 1 1 14px;
+  width: 30px;
+  min-height: 0;
+  padding: 0;
+}
+.bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:first-child {
+  border-radius: 0 3px 0 0;
+}
+.bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:last-child {
+  border-radius: 0 0 3px 0;
+}
 
-.bp3-numeric-input .bp3-button-group.bp3-vertical:first-child > .bp3-button:first-child{
-  border-radius:3px 0 0 0; }
+.bp3-numeric-input
+  .bp3-button-group.bp3-vertical:first-child
+  > .bp3-button:first-child {
+  border-radius: 3px 0 0 0;
+}
 
-.bp3-numeric-input .bp3-button-group.bp3-vertical:first-child > .bp3-button:last-child{
-  border-radius:0 0 0 3px; }
+.bp3-numeric-input
+  .bp3-button-group.bp3-vertical:first-child
+  > .bp3-button:last-child {
+  border-radius: 0 0 0 3px;
+}
 
-.bp3-numeric-input.bp3-large .bp3-button-group.bp3-vertical > .bp3-button{
-  width:40px; }
+.bp3-numeric-input.bp3-large .bp3-button-group.bp3-vertical > .bp3-button {
+  width: 40px;
+}
 
-form{
-  display:block; }
+form {
+  display: block;
+}
 .bp3-html-select select,
-.bp3-select select{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:row;
-          flex-direction:row;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
-  border:none;
-  border-radius:3px;
-  cursor:pointer;
-  padding:5px 10px;
-  vertical-align:middle;
-  text-align:left;
-  font-size:14px;
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-  background-color:#f5f8fa;
-  background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
-  background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
-  color:#182026;
-  border-radius:3px;
-  width:100%;
-  height:30px;
-  padding:0 25px 0 10px;
-  -moz-appearance:none;
-  -webkit-appearance:none; }
-  .bp3-html-select select > *, .bp3-select select > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-html-select select > .bp3-fill, .bp3-select select > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-html-select select::before,
-  .bp3-select select::before, .bp3-html-select select > *, .bp3-select select > *{
-    margin-right:7px; }
-  .bp3-html-select select:empty::before,
-  .bp3-select select:empty::before,
-  .bp3-html-select select > :last-child,
-  .bp3-select select > :last-child{
-    margin-right:0; }
-  .bp3-html-select select:hover,
-  .bp3-select select:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-clip:padding-box;
-    background-color:#ebf1f5; }
-  .bp3-html-select select:active,
-  .bp3-select select:active, .bp3-html-select select.bp3-active,
-  .bp3-select select.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#d8e1e8;
-    background-image:none; }
-  .bp3-html-select select:disabled,
-  .bp3-select select:disabled, .bp3-html-select select.bp3-disabled,
-  .bp3-select select.bp3-disabled{
-    outline:none;
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background-color:rgba(206, 217, 224, 0.5);
-    background-image:none;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
-    .bp3-html-select select:disabled.bp3-active,
-    .bp3-select select:disabled.bp3-active, .bp3-html-select select:disabled.bp3-active:hover,
-    .bp3-select select:disabled.bp3-active:hover, .bp3-html-select select.bp3-disabled.bp3-active,
-    .bp3-select select.bp3-disabled.bp3-active, .bp3-html-select select.bp3-disabled.bp3-active:hover,
-    .bp3-select select.bp3-disabled.bp3-active:hover{
-      background:rgba(206, 217, 224, 0.7); }
+.bp3-select select {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 5px 10px;
+  vertical-align: middle;
+  text-align: left;
+  font-size: 14px;
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-color: #f5f8fa;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.8)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.8),
+    rgba(255, 255, 255, 0)
+  );
+  color: #182026;
+  border-radius: 3px;
+  width: 100%;
+  height: 30px;
+  padding: 0 25px 0 10px;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+}
+.bp3-html-select select > *,
+.bp3-select select > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-html-select select > .bp3-fill,
+.bp3-select select > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-html-select select::before,
+.bp3-select select::before,
+.bp3-html-select select > *,
+.bp3-select select > * {
+  margin-right: 7px;
+}
+.bp3-html-select select:empty::before,
+.bp3-select select:empty::before,
+.bp3-html-select select > :last-child,
+.bp3-select select > :last-child {
+  margin-right: 0;
+}
+.bp3-html-select select:hover,
+.bp3-select select:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-clip: padding-box;
+  background-color: #ebf1f5;
+}
+.bp3-html-select select:active,
+.bp3-select select:active,
+.bp3-html-select select.bp3-active,
+.bp3-select select.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #d8e1e8;
+  background-image: none;
+}
+.bp3-html-select select:disabled,
+.bp3-select select:disabled,
+.bp3-html-select select.bp3-disabled,
+.bp3-select select.bp3-disabled {
+  outline: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(206, 217, 224, 0.5);
+  background-image: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-html-select select:disabled.bp3-active,
+.bp3-select select:disabled.bp3-active,
+.bp3-html-select select:disabled.bp3-active:hover,
+.bp3-select select:disabled.bp3-active:hover,
+.bp3-html-select select.bp3-disabled.bp3-active,
+.bp3-select select.bp3-disabled.bp3-active,
+.bp3-html-select select.bp3-disabled.bp3-active:hover,
+.bp3-select select.bp3-disabled.bp3-active:hover {
+  background: rgba(206, 217, 224, 0.7);
+}
 
 .bp3-html-select.bp3-minimal select,
-.bp3-select.bp3-minimal select{
-  -webkit-box-shadow:none;
-          box-shadow:none;
-  background:none; }
-  .bp3-html-select.bp3-minimal select:hover,
-  .bp3-select.bp3-minimal select:hover{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(167, 182, 194, 0.3);
-    text-decoration:none;
-    color:#182026; }
-  .bp3-html-select.bp3-minimal select:active,
-  .bp3-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal select.bp3-active,
-  .bp3-select.bp3-minimal select.bp3-active{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(115, 134, 148, 0.3);
-    color:#182026; }
-  .bp3-html-select.bp3-minimal select:disabled,
-  .bp3-select.bp3-minimal select:disabled, .bp3-html-select.bp3-minimal select:disabled:hover,
-  .bp3-select.bp3-minimal select:disabled:hover, .bp3-html-select.bp3-minimal select.bp3-disabled,
-  .bp3-select.bp3-minimal select.bp3-disabled, .bp3-html-select.bp3-minimal select.bp3-disabled:hover,
-  .bp3-select.bp3-minimal select.bp3-disabled:hover{
-    background:none;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
-    .bp3-html-select.bp3-minimal select:disabled.bp3-active,
-    .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active,
-    .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-disabled:hover.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-disabled:hover.bp3-active{
-      background:rgba(115, 134, 148, 0.3); }
-  .bp3-dark .bp3-html-select.bp3-minimal select, .bp3-html-select.bp3-minimal .bp3-dark select,
-  .bp3-dark .bp3-select.bp3-minimal select, .bp3-select.bp3-minimal .bp3-dark select{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none;
-    color:inherit; }
-    .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
-    .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover, .bp3-dark .bp3-html-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal .bp3-dark select:active,
-    .bp3-dark .bp3-select.bp3-minimal select:active, .bp3-select.bp3-minimal .bp3-dark select:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-active{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none; }
-    .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
-    .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover{
-      background:rgba(138, 155, 168, 0.15); }
-    .bp3-dark .bp3-html-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal .bp3-dark select:active,
-    .bp3-dark .bp3-select.bp3-minimal select:active, .bp3-select.bp3-minimal .bp3-dark select:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-active{
-      background:rgba(138, 155, 168, 0.3);
-      color:#f5f8fa; }
-    .bp3-dark .bp3-html-select.bp3-minimal select:disabled, .bp3-html-select.bp3-minimal .bp3-dark select:disabled,
-    .bp3-dark .bp3-select.bp3-minimal select:disabled, .bp3-select.bp3-minimal .bp3-dark select:disabled, .bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover, .bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover,
-    .bp3-dark .bp3-select.bp3-minimal select:disabled:hover, .bp3-select.bp3-minimal .bp3-dark select:disabled:hover, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover{
-      background:none;
-      cursor:not-allowed;
-      color:rgba(167, 182, 194, 0.6); }
-      .bp3-dark .bp3-html-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover.bp3-active{
-        background:rgba(138, 155, 168, 0.3); }
-  .bp3-html-select.bp3-minimal select.bp3-intent-primary,
-  .bp3-select.bp3-minimal select.bp3-intent-primary{
-    color:#106ba3; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
-    .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none;
-      color:#106ba3; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-primary:hover{
-      background:rgba(19, 124, 189, 0.15);
-      color:#106ba3; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
-    .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active{
-      background:rgba(19, 124, 189, 0.3);
-      color:#106ba3; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-primary:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled{
-      background:none;
-      color:rgba(16, 107, 163, 0.5); }
-      .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active{
-        background:rgba(19, 124, 189, 0.3); }
-    .bp3-html-select.bp3-minimal select.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
-      stroke:#106ba3; }
-    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary{
-      color:#48aff0; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:hover,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:hover{
-        background:rgba(19, 124, 189, 0.2);
-        color:#48aff0; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-active{
-        background:rgba(19, 124, 189, 0.3);
-        color:#48aff0; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled{
-        background:none;
-        color:rgba(72, 175, 240, 0.5); }
-        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled.bp3-active{
-          background:rgba(19, 124, 189, 0.3); }
-  .bp3-html-select.bp3-minimal select.bp3-intent-success,
-  .bp3-select.bp3-minimal select.bp3-intent-success{
-    color:#0d8050; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-success:hover, .bp3-html-select.bp3-minimal select.bp3-intent-success:active,
-    .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none;
-      color:#0d8050; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-success:hover{
-      background:rgba(15, 153, 96, 0.15);
-      color:#0d8050; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-success:active,
-    .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active{
-      background:rgba(15, 153, 96, 0.3);
-      color:#0d8050; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-success:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled{
-      background:none;
-      color:rgba(13, 128, 80, 0.5); }
-      .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active{
-        background:rgba(15, 153, 96, 0.3); }
-    .bp3-html-select.bp3-minimal select.bp3-intent-success .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
-      stroke:#0d8050; }
-    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success{
-      color:#3dcc91; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:hover,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:hover{
-        background:rgba(15, 153, 96, 0.2);
-        color:#3dcc91; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-active{
-        background:rgba(15, 153, 96, 0.3);
-        color:#3dcc91; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled{
-        background:none;
-        color:rgba(61, 204, 145, 0.5); }
-        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled.bp3-active{
-          background:rgba(15, 153, 96, 0.3); }
-  .bp3-html-select.bp3-minimal select.bp3-intent-warning,
-  .bp3-select.bp3-minimal select.bp3-intent-warning{
-    color:#bf7326; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
-    .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none;
-      color:#bf7326; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-warning:hover{
-      background:rgba(217, 130, 43, 0.15);
-      color:#bf7326; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
-    .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active{
-      background:rgba(217, 130, 43, 0.3);
-      color:#bf7326; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-warning:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled{
-      background:none;
-      color:rgba(191, 115, 38, 0.5); }
-      .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active{
-        background:rgba(217, 130, 43, 0.3); }
-    .bp3-html-select.bp3-minimal select.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
-      stroke:#bf7326; }
-    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning{
-      color:#ffb366; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:hover,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:hover{
-        background:rgba(217, 130, 43, 0.2);
-        color:#ffb366; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-active{
-        background:rgba(217, 130, 43, 0.3);
-        color:#ffb366; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled{
-        background:none;
-        color:rgba(255, 179, 102, 0.5); }
-        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled.bp3-active{
-          background:rgba(217, 130, 43, 0.3); }
-  .bp3-html-select.bp3-minimal select.bp3-intent-danger,
-  .bp3-select.bp3-minimal select.bp3-intent-danger{
-    color:#c23030; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
-    .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none;
-      color:#c23030; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
-    .bp3-select.bp3-minimal select.bp3-intent-danger:hover{
-      background:rgba(219, 55, 55, 0.15);
-      color:#c23030; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
-    .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
-    .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active{
-      background:rgba(219, 55, 55, 0.3);
-      color:#c23030; }
-    .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-danger:disabled, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled,
-    .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled{
-      background:none;
-      color:rgba(194, 48, 48, 0.5); }
-      .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active,
-      .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active{
-        background:rgba(219, 55, 55, 0.3); }
-    .bp3-html-select.bp3-minimal select.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head, .bp3-select.bp3-minimal select.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
-      stroke:#c23030; }
-    .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger,
-    .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger{
-      color:#ff7373; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:hover,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:hover{
-        background:rgba(219, 55, 55, 0.2);
-        color:#ff7373; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-active,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-active{
-        background:rgba(219, 55, 55, 0.3);
-        color:#ff7373; }
-      .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled,
-      .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled{
-        background:none;
-        color:rgba(255, 115, 115, 0.5); }
-        .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled.bp3-active,
-        .bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled.bp3-active{
-          background:rgba(219, 55, 55, 0.3); }
+.bp3-select.bp3-minimal select {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+}
+.bp3-html-select.bp3-minimal select:hover,
+.bp3-select.bp3-minimal select:hover {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(167, 182, 194, 0.3);
+  text-decoration: none;
+  color: #182026;
+}
+.bp3-html-select.bp3-minimal select:active,
+.bp3-select.bp3-minimal select:active,
+.bp3-html-select.bp3-minimal select.bp3-active,
+.bp3-select.bp3-minimal select.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: rgba(115, 134, 148, 0.3);
+  color: #182026;
+}
+.bp3-html-select.bp3-minimal select:disabled,
+.bp3-select.bp3-minimal select:disabled,
+.bp3-html-select.bp3-minimal select:disabled:hover,
+.bp3-select.bp3-minimal select:disabled:hover,
+.bp3-html-select.bp3-minimal select.bp3-disabled,
+.bp3-select.bp3-minimal select.bp3-disabled,
+.bp3-html-select.bp3-minimal select.bp3-disabled:hover,
+.bp3-select.bp3-minimal select.bp3-disabled:hover {
+  background: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-html-select.bp3-minimal select:disabled.bp3-active,
+.bp3-select.bp3-minimal select:disabled.bp3-active,
+.bp3-html-select.bp3-minimal select:disabled:hover.bp3-active,
+.bp3-select.bp3-minimal select:disabled:hover.bp3-active,
+.bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-disabled.bp3-active,
+.bp3-html-select.bp3-minimal select.bp3-disabled:hover.bp3-active,
+.bp3-select.bp3-minimal select.bp3-disabled:hover.bp3-active {
+  background: rgba(115, 134, 148, 0.3);
+}
+.bp3-dark .bp3-html-select.bp3-minimal select,
+.bp3-html-select.bp3-minimal .bp3-dark select,
+.bp3-dark .bp3-select.bp3-minimal select,
+.bp3-select.bp3-minimal .bp3-dark select {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: inherit;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select:hover,
+.bp3-dark .bp3-select.bp3-minimal select:hover,
+.bp3-select.bp3-minimal .bp3-dark select:hover,
+.bp3-dark .bp3-html-select.bp3-minimal select:active,
+.bp3-html-select.bp3-minimal .bp3-dark select:active,
+.bp3-dark .bp3-select.bp3-minimal select:active,
+.bp3-select.bp3-minimal .bp3-dark select:active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select:hover,
+.bp3-dark .bp3-select.bp3-minimal select:hover,
+.bp3-select.bp3-minimal .bp3-dark select:hover {
+  background: rgba(138, 155, 168, 0.15);
+}
+.bp3-dark .bp3-html-select.bp3-minimal select:active,
+.bp3-html-select.bp3-minimal .bp3-dark select:active,
+.bp3-dark .bp3-select.bp3-minimal select:active,
+.bp3-select.bp3-minimal .bp3-dark select:active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-active {
+  background: rgba(138, 155, 168, 0.3);
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select:disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select:disabled,
+.bp3-dark .bp3-select.bp3-minimal select:disabled,
+.bp3-select.bp3-minimal .bp3-dark select:disabled,
+.bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover,
+.bp3-dark .bp3-select.bp3-minimal select:disabled:hover,
+.bp3-select.bp3-minimal .bp3-dark select:disabled:hover,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-disabled,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover {
+  background: none;
+  cursor: not-allowed;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-html-select.bp3-minimal select:disabled.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select:disabled.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select:disabled.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select:disabled.bp3-active,
+.bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select:disabled:hover.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover.bp3-active {
+  background: rgba(138, 155, 168, 0.3);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-primary,
+.bp3-select.bp3-minimal select.bp3-intent-primary {
+  color: #106ba3;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
+.bp3-select.bp3-minimal select.bp3-intent-primary:hover,
+.bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
+.bp3-select.bp3-minimal select.bp3-intent-primary:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #106ba3;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
+.bp3-select.bp3-minimal select.bp3-intent-primary:hover {
+  background: rgba(19, 124, 189, 0.15);
+  color: #106ba3;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
+.bp3-select.bp3-minimal select.bp3-intent-primary:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+  color: #106ba3;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled,
+.bp3-select.bp3-minimal select.bp3-intent-primary:disabled,
+.bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled,
+.bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled {
+  background: none;
+  color: rgba(16, 107, 163, 0.5);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active,
+.bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+}
+.bp3-html-select.bp3-minimal
+  select.bp3-intent-primary
+  .bp3-button-spinner
+  .bp3-spinner-head,
+.bp3-select.bp3-minimal
+  select.bp3-intent-primary
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #106ba3;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary {
+  color: #48aff0;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:hover,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:hover,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:hover {
+  background: rgba(19, 124, 189, 0.2);
+  color: #48aff0;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+  color: #48aff0;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary:disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary.bp3-disabled {
+  background: none;
+  color: rgba(72, 175, 240, 0.5);
+}
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-primary:disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-primary:disabled.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-primary:disabled.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-primary:disabled.bp3-active,
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-primary.bp3-disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-primary.bp3-disabled.bp3-active,
+.bp3-dark
+  .bp3-select.bp3-minimal
+  select.bp3-intent-primary.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-primary.bp3-disabled.bp3-active {
+  background: rgba(19, 124, 189, 0.3);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-success,
+.bp3-select.bp3-minimal select.bp3-intent-success {
+  color: #0d8050;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
+.bp3-select.bp3-minimal select.bp3-intent-success:hover,
+.bp3-html-select.bp3-minimal select.bp3-intent-success:active,
+.bp3-select.bp3-minimal select.bp3-intent-success:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-success.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #0d8050;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
+.bp3-select.bp3-minimal select.bp3-intent-success:hover {
+  background: rgba(15, 153, 96, 0.15);
+  color: #0d8050;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-success:active,
+.bp3-select.bp3-minimal select.bp3-intent-success:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-success.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+  color: #0d8050;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-success:disabled,
+.bp3-select.bp3-minimal select.bp3-intent-success:disabled,
+.bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled,
+.bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled {
+  background: none;
+  color: rgba(13, 128, 80, 0.5);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active,
+.bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+}
+.bp3-html-select.bp3-minimal
+  select.bp3-intent-success
+  .bp3-button-spinner
+  .bp3-spinner-head,
+.bp3-select.bp3-minimal
+  select.bp3-intent-success
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #0d8050;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success {
+  color: #3dcc91;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:hover,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:hover,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:hover {
+  background: rgba(15, 153, 96, 0.2);
+  color: #3dcc91;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+  color: #3dcc91;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success:disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success.bp3-disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success.bp3-disabled {
+  background: none;
+  color: rgba(61, 204, 145, 0.5);
+}
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-success:disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-success:disabled.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-success:disabled.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-success:disabled.bp3-active,
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-success.bp3-disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-success.bp3-disabled.bp3-active,
+.bp3-dark
+  .bp3-select.bp3-minimal
+  select.bp3-intent-success.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-success.bp3-disabled.bp3-active {
+  background: rgba(15, 153, 96, 0.3);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-warning,
+.bp3-select.bp3-minimal select.bp3-intent-warning {
+  color: #bf7326;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
+.bp3-select.bp3-minimal select.bp3-intent-warning:hover,
+.bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
+.bp3-select.bp3-minimal select.bp3-intent-warning:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #bf7326;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
+.bp3-select.bp3-minimal select.bp3-intent-warning:hover {
+  background: rgba(217, 130, 43, 0.15);
+  color: #bf7326;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
+.bp3-select.bp3-minimal select.bp3-intent-warning:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+  color: #bf7326;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled,
+.bp3-select.bp3-minimal select.bp3-intent-warning:disabled,
+.bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled,
+.bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled {
+  background: none;
+  color: rgba(191, 115, 38, 0.5);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active,
+.bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+}
+.bp3-html-select.bp3-minimal
+  select.bp3-intent-warning
+  .bp3-button-spinner
+  .bp3-spinner-head,
+.bp3-select.bp3-minimal
+  select.bp3-intent-warning
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #bf7326;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning {
+  color: #ffb366;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:hover,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:hover,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:hover {
+  background: rgba(217, 130, 43, 0.2);
+  color: #ffb366;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+  color: #ffb366;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning:disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning.bp3-disabled {
+  background: none;
+  color: rgba(255, 179, 102, 0.5);
+}
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-warning:disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-warning:disabled.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-warning:disabled.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-warning:disabled.bp3-active,
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-warning.bp3-disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-warning.bp3-disabled.bp3-active,
+.bp3-dark
+  .bp3-select.bp3-minimal
+  select.bp3-intent-warning.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-warning.bp3-disabled.bp3-active {
+  background: rgba(217, 130, 43, 0.3);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-danger,
+.bp3-select.bp3-minimal select.bp3-intent-danger {
+  color: #c23030;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
+.bp3-select.bp3-minimal select.bp3-intent-danger:hover,
+.bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
+.bp3-select.bp3-minimal select.bp3-intent-danger:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  color: #c23030;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
+.bp3-select.bp3-minimal select.bp3-intent-danger:hover {
+  background: rgba(219, 55, 55, 0.15);
+  color: #c23030;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
+.bp3-select.bp3-minimal select.bp3-intent-danger:active,
+.bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+  color: #c23030;
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled,
+.bp3-select.bp3-minimal select.bp3-intent-danger:disabled,
+.bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled,
+.bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled {
+  background: none;
+  color: rgba(194, 48, 48, 0.5);
+}
+.bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active,
+.bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+}
+.bp3-html-select.bp3-minimal
+  select.bp3-intent-danger
+  .bp3-button-spinner
+  .bp3-spinner-head,
+.bp3-select.bp3-minimal
+  select.bp3-intent-danger
+  .bp3-button-spinner
+  .bp3-spinner-head {
+  stroke: #c23030;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger {
+  color: #ff7373;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:hover,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:hover,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:hover {
+  background: rgba(219, 55, 55, 0.2);
+  color: #ff7373;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:active,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+  color: #ff7373;
+}
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger:disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled,
+.bp3-dark .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-disabled,
+.bp3-html-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-disabled,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger.bp3-disabled {
+  background: none;
+  color: rgba(255, 115, 115, 0.5);
+}
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-danger:disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-danger:disabled.bp3-active,
+.bp3-dark .bp3-select.bp3-minimal select.bp3-intent-danger:disabled.bp3-active,
+.bp3-select.bp3-minimal .bp3-dark select.bp3-intent-danger:disabled.bp3-active,
+.bp3-dark
+  .bp3-html-select.bp3-minimal
+  select.bp3-intent-danger.bp3-disabled.bp3-active,
+.bp3-html-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-danger.bp3-disabled.bp3-active,
+.bp3-dark
+  .bp3-select.bp3-minimal
+  select.bp3-intent-danger.bp3-disabled.bp3-active,
+.bp3-select.bp3-minimal
+  .bp3-dark
+  select.bp3-intent-danger.bp3-disabled.bp3-active {
+  background: rgba(219, 55, 55, 0.3);
+}
 
 .bp3-html-select.bp3-large select,
-.bp3-select.bp3-large select{
-  height:40px;
-  padding-right:35px;
-  font-size:16px; }
+.bp3-select.bp3-large select {
+  height: 40px;
+  padding-right: 35px;
+  font-size: 16px;
+}
 
-.bp3-dark .bp3-html-select select, .bp3-dark .bp3-select select{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-  background-color:#394b59;
-  background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
-  background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
-  color:#f5f8fa; }
-  .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover, .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
-    color:#f5f8fa; }
-  .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#30404d; }
-  .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#202b33;
-    background-image:none; }
-  .bp3-dark .bp3-html-select select:disabled, .bp3-dark .bp3-select select:disabled, .bp3-dark .bp3-html-select select.bp3-disabled, .bp3-dark .bp3-select select.bp3-disabled{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background-color:rgba(57, 75, 89, 0.5);
-    background-image:none;
-    color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-html-select select:disabled.bp3-active, .bp3-dark .bp3-select select:disabled.bp3-active, .bp3-dark .bp3-html-select select.bp3-disabled.bp3-active, .bp3-dark .bp3-select select.bp3-disabled.bp3-active{
-      background:rgba(57, 75, 89, 0.7); }
-  .bp3-dark .bp3-html-select select .bp3-button-spinner .bp3-spinner-head, .bp3-dark .bp3-select select .bp3-button-spinner .bp3-spinner-head{
-    background:rgba(16, 22, 26, 0.5);
-    stroke:#8a9ba8; }
+.bp3-dark .bp3-html-select select,
+.bp3-dark .bp3-select select {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #394b59;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.05)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0)
+  );
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-html-select select:hover,
+.bp3-dark .bp3-select select:hover,
+.bp3-dark .bp3-html-select select:active,
+.bp3-dark .bp3-select select:active,
+.bp3-dark .bp3-html-select select.bp3-active,
+.bp3-dark .bp3-select select.bp3-active {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-html-select select:hover,
+.bp3-dark .bp3-select select:hover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #30404d;
+}
+.bp3-dark .bp3-html-select select:active,
+.bp3-dark .bp3-select select:active,
+.bp3-dark .bp3-html-select select.bp3-active,
+.bp3-dark .bp3-select select.bp3-active {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #202b33;
+  background-image: none;
+}
+.bp3-dark .bp3-html-select select:disabled,
+.bp3-dark .bp3-select select:disabled,
+.bp3-dark .bp3-html-select select.bp3-disabled,
+.bp3-dark .bp3-select select.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(57, 75, 89, 0.5);
+  background-image: none;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-html-select select:disabled.bp3-active,
+.bp3-dark .bp3-select select:disabled.bp3-active,
+.bp3-dark .bp3-html-select select.bp3-disabled.bp3-active,
+.bp3-dark .bp3-select select.bp3-disabled.bp3-active {
+  background: rgba(57, 75, 89, 0.7);
+}
+.bp3-dark .bp3-html-select select .bp3-button-spinner .bp3-spinner-head,
+.bp3-dark .bp3-select select .bp3-button-spinner .bp3-spinner-head {
+  background: rgba(16, 22, 26, 0.5);
+  stroke: #8a9ba8;
+}
 
 .bp3-html-select select:disabled,
-.bp3-select select:disabled{
-  -webkit-box-shadow:none;
-          box-shadow:none;
-  background-color:rgba(206, 217, 224, 0.5);
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+.bp3-select select:disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(206, 217, 224, 0.5);
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
 
 .bp3-html-select .bp3-icon,
-.bp3-select .bp3-icon, .bp3-select::after{
-  position:absolute;
-  top:7px;
-  right:7px;
-  color:#5c7080;
-  pointer-events:none; }
-  .bp3-html-select .bp3-disabled.bp3-icon,
-  .bp3-select .bp3-disabled.bp3-icon, .bp3-disabled.bp3-select::after{
-    color:rgba(92, 112, 128, 0.6); }
+.bp3-select .bp3-icon,
+.bp3-select::after {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  color: #5c7080;
+  pointer-events: none;
+}
+.bp3-html-select .bp3-disabled.bp3-icon,
+.bp3-select .bp3-disabled.bp3-icon,
+.bp3-disabled.bp3-select::after {
+  color: rgba(92, 112, 128, 0.6);
+}
 .bp3-html-select,
-.bp3-select{
-  display:inline-block;
-  position:relative;
-  vertical-align:middle;
-  letter-spacing:normal; }
-  .bp3-html-select select::-ms-expand,
-  .bp3-select select::-ms-expand{
-    display:none; }
-  .bp3-html-select .bp3-icon,
-  .bp3-select .bp3-icon{
-    color:#5c7080; }
-    .bp3-html-select .bp3-icon:hover,
-    .bp3-select .bp3-icon:hover{
-      color:#182026; }
-    .bp3-dark .bp3-html-select .bp3-icon, .bp3-dark
-    .bp3-select .bp3-icon{
-      color:#a7b6c2; }
-      .bp3-dark .bp3-html-select .bp3-icon:hover, .bp3-dark
-      .bp3-select .bp3-icon:hover{
-        color:#f5f8fa; }
-  .bp3-html-select.bp3-large::after,
-  .bp3-html-select.bp3-large .bp3-icon,
-  .bp3-select.bp3-large::after,
-  .bp3-select.bp3-large .bp3-icon{
-    top:12px;
-    right:12px; }
-  .bp3-html-select.bp3-fill,
-  .bp3-html-select.bp3-fill select,
-  .bp3-select.bp3-fill,
-  .bp3-select.bp3-fill select{
-    width:100%; }
-  .bp3-dark .bp3-html-select option, .bp3-dark
-  .bp3-select option{
-    background-color:#30404d;
-    color:#f5f8fa; }
-  .bp3-dark .bp3-html-select::after, .bp3-dark
-  .bp3-select::after{
-    color:#a7b6c2; }
+.bp3-select {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  letter-spacing: normal;
+}
+.bp3-html-select select::-ms-expand,
+.bp3-select select::-ms-expand {
+  display: none;
+}
+.bp3-html-select .bp3-icon,
+.bp3-select .bp3-icon {
+  color: #5c7080;
+}
+.bp3-html-select .bp3-icon:hover,
+.bp3-select .bp3-icon:hover {
+  color: #182026;
+}
+.bp3-dark .bp3-html-select .bp3-icon,
+.bp3-dark .bp3-select .bp3-icon {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-html-select .bp3-icon:hover,
+.bp3-dark .bp3-select .bp3-icon:hover {
+  color: #f5f8fa;
+}
+.bp3-html-select.bp3-large::after,
+.bp3-html-select.bp3-large .bp3-icon,
+.bp3-select.bp3-large::after,
+.bp3-select.bp3-large .bp3-icon {
+  top: 12px;
+  right: 12px;
+}
+.bp3-html-select.bp3-fill,
+.bp3-html-select.bp3-fill select,
+.bp3-select.bp3-fill,
+.bp3-select.bp3-fill select {
+  width: 100%;
+}
+.bp3-dark .bp3-html-select option,
+.bp3-dark .bp3-select option {
+  background-color: #30404d;
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-html-select::after,
+.bp3-dark .bp3-select::after {
+  color: #a7b6c2;
+}
 
-.bp3-select::after{
-  line-height:1;
-  font-family:"Icons16", sans-serif;
-  font-size:16px;
-  font-weight:400;
-  font-style:normal;
-  -moz-osx-font-smoothing:grayscale;
-  -webkit-font-smoothing:antialiased;
-  content:""; }
-.bp3-running-text table, table.bp3-html-table{
-  border-spacing:0;
-  font-size:14px; }
-  .bp3-running-text table th, table.bp3-html-table th,
-  .bp3-running-text table td,
-  table.bp3-html-table td{
-    padding:11px;
-    vertical-align:top;
-    text-align:left; }
-  .bp3-running-text table th, table.bp3-html-table th{
-    color:#182026;
-    font-weight:600; }
-  
-  .bp3-running-text table td,
-  table.bp3-html-table td{
-    color:#182026; }
-  .bp3-running-text table tbody tr:first-child th, table.bp3-html-table tbody tr:first-child th,
-  .bp3-running-text table tbody tr:first-child td,
-  table.bp3-html-table tbody tr:first-child td{
-    -webkit-box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
-            box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15); }
-  .bp3-dark .bp3-running-text table th, .bp3-running-text .bp3-dark table th, .bp3-dark table.bp3-html-table th{
-    color:#f5f8fa; }
-  .bp3-dark .bp3-running-text table td, .bp3-running-text .bp3-dark table td, .bp3-dark table.bp3-html-table td{
-    color:#f5f8fa; }
-  .bp3-dark .bp3-running-text table tbody tr:first-child th, .bp3-running-text .bp3-dark table tbody tr:first-child th, .bp3-dark table.bp3-html-table tbody tr:first-child th,
-  .bp3-dark .bp3-running-text table tbody tr:first-child td,
-  .bp3-running-text .bp3-dark table tbody tr:first-child td,
-  .bp3-dark table.bp3-html-table tbody tr:first-child td{
-    -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
-            box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
+.bp3-select::after {
+  line-height: 1;
+  font-family: 'Icons16', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  content: '';
+}
+.bp3-running-text table,
+table.bp3-html-table {
+  border-spacing: 0;
+  font-size: 14px;
+}
+.bp3-running-text table th,
+table.bp3-html-table th,
+.bp3-running-text table td,
+table.bp3-html-table td {
+  padding: 11px;
+  vertical-align: top;
+  text-align: left;
+}
+.bp3-running-text table th,
+table.bp3-html-table th {
+  color: #182026;
+  font-weight: 600;
+}
+
+.bp3-running-text table td,
+table.bp3-html-table td {
+  color: #182026;
+}
+.bp3-running-text table tbody tr:first-child th,
+table.bp3-html-table tbody tr:first-child th,
+.bp3-running-text table tbody tr:first-child td,
+table.bp3-html-table tbody tr:first-child td {
+  -webkit-box-shadow: inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
+  box-shadow: inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
+}
+.bp3-dark .bp3-running-text table th,
+.bp3-running-text .bp3-dark table th,
+.bp3-dark table.bp3-html-table th {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-running-text table td,
+.bp3-running-text .bp3-dark table td,
+.bp3-dark table.bp3-html-table td {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-running-text table tbody tr:first-child th,
+.bp3-running-text .bp3-dark table tbody tr:first-child th,
+.bp3-dark table.bp3-html-table tbody tr:first-child th,
+.bp3-dark .bp3-running-text table tbody tr:first-child td,
+.bp3-running-text .bp3-dark table tbody tr:first-child td,
+.bp3-dark table.bp3-html-table tbody tr:first-child td {
+  -webkit-box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+}
 
 table.bp3-html-table.bp3-html-table-condensed th,
-table.bp3-html-table.bp3-html-table-condensed td, table.bp3-html-table.bp3-small th,
-table.bp3-html-table.bp3-small td{
-  padding-top:6px;
-  padding-bottom:6px; }
-
-table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
-  background:rgba(191, 204, 214, 0.15); }
-
-table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
-  -webkit-box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
-          box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15); }
-
-table.bp3-html-table.bp3-html-table-bordered tbody tr td{
-  -webkit-box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
-          box-shadow:inset 0 1px 0 0 rgba(16, 22, 26, 0.15); }
-  table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
-    -webkit-box-shadow:inset 1px 1px 0 0 rgba(16, 22, 26, 0.15);
-            box-shadow:inset 1px 1px 0 0 rgba(16, 22, 26, 0.15); }
-
-table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
-  -webkit-box-shadow:none;
-          box-shadow:none; }
-  table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:not(:first-child){
-    -webkit-box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
-            box-shadow:inset 1px 0 0 0 rgba(16, 22, 26, 0.15); }
-
-table.bp3-html-table.bp3-interactive tbody tr:hover td{
-  background-color:rgba(191, 204, 214, 0.3);
-  cursor:pointer; }
-
-table.bp3-html-table.bp3-interactive tbody tr:active td{
-  background-color:rgba(191, 204, 214, 0.4); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
-  background:rgba(92, 112, 128, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
-  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td{
-  -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
-  .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
-    -webkit-box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
-            box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
-  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
-  .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:first-child{
-    -webkit-box-shadow:none;
-            box-shadow:none; }
-
-.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:hover td{
-  background-color:rgba(92, 112, 128, 0.3);
-  cursor:pointer; }
-
-.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:active td{
-  background-color:rgba(92, 112, 128, 0.4); }
-
-.bp3-key-combo{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:row;
-          flex-direction:row;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center; }
-  .bp3-key-combo > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-key-combo > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-key-combo::before,
-  .bp3-key-combo > *{
-    margin-right:5px; }
-  .bp3-key-combo:empty::before,
-  .bp3-key-combo > :last-child{
-    margin-right:0; }
-
-.bp3-hotkey-dialog{
-  top:40px;
-  padding-bottom:0; }
-  .bp3-hotkey-dialog .bp3-dialog-body{
-    margin:0;
-    padding:0; }
-  .bp3-hotkey-dialog .bp3-hotkey-label{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1; }
-
-.bp3-hotkey-column{
-  margin:auto;
-  max-height:80vh;
-  overflow-y:auto;
-  padding:30px; }
-  .bp3-hotkey-column .bp3-heading{
-    margin-bottom:20px; }
-    .bp3-hotkey-column .bp3-heading:not(:first-child){
-      margin-top:40px; }
-
-.bp3-hotkey{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  -webkit-box-pack:justify;
-      -ms-flex-pack:justify;
-          justify-content:space-between;
-  margin-right:0;
-  margin-left:0; }
-  .bp3-hotkey:not(:last-child){
-    margin-bottom:10px; }
-.bp3-icon{
-  display:inline-block;
-  -webkit-box-flex:0;
-      -ms-flex:0 0 auto;
-          flex:0 0 auto;
-  vertical-align:text-bottom; }
-  .bp3-icon:not(:empty)::before{
-    content:"" !important;
-    content:unset !important; }
-  .bp3-icon > svg{
-    display:block; }
-    .bp3-icon > svg:not([fill]){
-      fill:currentColor; }
-
-.bp3-icon.bp3-intent-primary, .bp3-icon-standard.bp3-intent-primary, .bp3-icon-large.bp3-intent-primary{
-  color:#106ba3; }
-  .bp3-dark .bp3-icon.bp3-intent-primary, .bp3-dark .bp3-icon-standard.bp3-intent-primary, .bp3-dark .bp3-icon-large.bp3-intent-primary{
-    color:#48aff0; }
-
-.bp3-icon.bp3-intent-success, .bp3-icon-standard.bp3-intent-success, .bp3-icon-large.bp3-intent-success{
-  color:#0d8050; }
-  .bp3-dark .bp3-icon.bp3-intent-success, .bp3-dark .bp3-icon-standard.bp3-intent-success, .bp3-dark .bp3-icon-large.bp3-intent-success{
-    color:#3dcc91; }
-
-.bp3-icon.bp3-intent-warning, .bp3-icon-standard.bp3-intent-warning, .bp3-icon-large.bp3-intent-warning{
-  color:#bf7326; }
-  .bp3-dark .bp3-icon.bp3-intent-warning, .bp3-dark .bp3-icon-standard.bp3-intent-warning, .bp3-dark .bp3-icon-large.bp3-intent-warning{
-    color:#ffb366; }
-
-.bp3-icon.bp3-intent-danger, .bp3-icon-standard.bp3-intent-danger, .bp3-icon-large.bp3-intent-danger{
-  color:#c23030; }
-  .bp3-dark .bp3-icon.bp3-intent-danger, .bp3-dark .bp3-icon-standard.bp3-intent-danger, .bp3-dark .bp3-icon-large.bp3-intent-danger{
-    color:#ff7373; }
-
-span.bp3-icon-standard{
-  line-height:1;
-  font-family:"Icons16", sans-serif;
-  font-size:16px;
-  font-weight:400;
-  font-style:normal;
-  -moz-osx-font-smoothing:grayscale;
-  -webkit-font-smoothing:antialiased;
-  display:inline-block; }
-
-span.bp3-icon-large{
-  line-height:1;
-  font-family:"Icons20", sans-serif;
-  font-size:20px;
-  font-weight:400;
-  font-style:normal;
-  -moz-osx-font-smoothing:grayscale;
-  -webkit-font-smoothing:antialiased;
-  display:inline-block; }
-
-span.bp3-icon:empty{
-  line-height:1;
-  font-family:"Icons20";
-  font-size:inherit;
-  font-weight:400;
-  font-style:normal; }
-  span.bp3-icon:empty::before{
-    -moz-osx-font-smoothing:grayscale;
-    -webkit-font-smoothing:antialiased; }
-
-.bp3-icon-add::before{
-  content:""; }
-
-.bp3-icon-add-column-left::before{
-  content:""; }
-
-.bp3-icon-add-column-right::before{
-  content:""; }
-
-.bp3-icon-add-row-bottom::before{
-  content:""; }
-
-.bp3-icon-add-row-top::before{
-  content:""; }
-
-.bp3-icon-add-to-artifact::before{
-  content:""; }
-
-.bp3-icon-add-to-folder::before{
-  content:""; }
-
-.bp3-icon-airplane::before{
-  content:""; }
-
-.bp3-icon-align-center::before{
-  content:""; }
-
-.bp3-icon-align-justify::before{
-  content:""; }
-
-.bp3-icon-align-left::before{
-  content:""; }
-
-.bp3-icon-align-right::before{
-  content:""; }
-
-.bp3-icon-alignment-bottom::before{
-  content:""; }
-
-.bp3-icon-alignment-horizontal-center::before{
-  content:""; }
-
-.bp3-icon-alignment-left::before{
-  content:""; }
-
-.bp3-icon-alignment-right::before{
-  content:""; }
-
-.bp3-icon-alignment-top::before{
-  content:""; }
-
-.bp3-icon-alignment-vertical-center::before{
-  content:""; }
-
-.bp3-icon-annotation::before{
-  content:""; }
-
-.bp3-icon-application::before{
-  content:""; }
-
-.bp3-icon-applications::before{
-  content:""; }
-
-.bp3-icon-archive::before{
-  content:""; }
-
-.bp3-icon-arrow-bottom-left::before{
-  content:"↙"; }
-
-.bp3-icon-arrow-bottom-right::before{
-  content:"↘"; }
-
-.bp3-icon-arrow-down::before{
-  content:"↓"; }
-
-.bp3-icon-arrow-left::before{
-  content:"←"; }
-
-.bp3-icon-arrow-right::before{
-  content:"→"; }
-
-.bp3-icon-arrow-top-left::before{
-  content:"↖"; }
-
-.bp3-icon-arrow-top-right::before{
-  content:"↗"; }
-
-.bp3-icon-arrow-up::before{
-  content:"↑"; }
-
-.bp3-icon-arrows-horizontal::before{
-  content:"↔"; }
-
-.bp3-icon-arrows-vertical::before{
-  content:"↕"; }
-
-.bp3-icon-asterisk::before{
-  content:"*"; }
-
-.bp3-icon-automatic-updates::before{
-  content:""; }
-
-.bp3-icon-badge::before{
-  content:""; }
-
-.bp3-icon-ban-circle::before{
-  content:""; }
-
-.bp3-icon-bank-account::before{
-  content:""; }
-
-.bp3-icon-barcode::before{
-  content:""; }
-
-.bp3-icon-blank::before{
-  content:""; }
-
-.bp3-icon-blocked-person::before{
-  content:""; }
-
-.bp3-icon-bold::before{
-  content:""; }
-
-.bp3-icon-book::before{
-  content:""; }
-
-.bp3-icon-bookmark::before{
-  content:""; }
-
-.bp3-icon-box::before{
-  content:""; }
-
-.bp3-icon-briefcase::before{
-  content:""; }
-
-.bp3-icon-bring-data::before{
-  content:""; }
-
-.bp3-icon-build::before{
-  content:""; }
-
-.bp3-icon-calculator::before{
-  content:""; }
-
-.bp3-icon-calendar::before{
-  content:""; }
-
-.bp3-icon-camera::before{
-  content:""; }
-
-.bp3-icon-caret-down::before{
-  content:"⌄"; }
-
-.bp3-icon-caret-left::before{
-  content:"〈"; }
-
-.bp3-icon-caret-right::before{
-  content:"〉"; }
-
-.bp3-icon-caret-up::before{
-  content:"⌃"; }
-
-.bp3-icon-cell-tower::before{
-  content:""; }
-
-.bp3-icon-changes::before{
-  content:""; }
-
-.bp3-icon-chart::before{
-  content:""; }
-
-.bp3-icon-chat::before{
-  content:""; }
-
-.bp3-icon-chevron-backward::before{
-  content:""; }
-
-.bp3-icon-chevron-down::before{
-  content:""; }
-
-.bp3-icon-chevron-forward::before{
-  content:""; }
-
-.bp3-icon-chevron-left::before{
-  content:""; }
-
-.bp3-icon-chevron-right::before{
-  content:""; }
-
-.bp3-icon-chevron-up::before{
-  content:""; }
-
-.bp3-icon-circle::before{
-  content:""; }
-
-.bp3-icon-circle-arrow-down::before{
-  content:""; }
-
-.bp3-icon-circle-arrow-left::before{
-  content:""; }
-
-.bp3-icon-circle-arrow-right::before{
-  content:""; }
-
-.bp3-icon-circle-arrow-up::before{
-  content:""; }
-
-.bp3-icon-citation::before{
-  content:""; }
-
-.bp3-icon-clean::before{
-  content:""; }
-
-.bp3-icon-clipboard::before{
-  content:""; }
-
-.bp3-icon-cloud::before{
-  content:"☁"; }
-
-.bp3-icon-cloud-download::before{
-  content:""; }
-
-.bp3-icon-cloud-upload::before{
-  content:""; }
-
-.bp3-icon-code::before{
-  content:""; }
-
-.bp3-icon-code-block::before{
-  content:""; }
-
-.bp3-icon-cog::before{
-  content:""; }
-
-.bp3-icon-collapse-all::before{
-  content:""; }
-
-.bp3-icon-column-layout::before{
-  content:""; }
-
-.bp3-icon-comment::before{
-  content:""; }
-
-.bp3-icon-comparison::before{
-  content:""; }
-
-.bp3-icon-compass::before{
-  content:""; }
-
-.bp3-icon-compressed::before{
-  content:""; }
-
-.bp3-icon-confirm::before{
-  content:""; }
-
-.bp3-icon-console::before{
-  content:""; }
-
-.bp3-icon-contrast::before{
-  content:""; }
-
-.bp3-icon-control::before{
-  content:""; }
-
-.bp3-icon-credit-card::before{
-  content:""; }
-
-.bp3-icon-cross::before{
-  content:"✗"; }
-
-.bp3-icon-crown::before{
-  content:""; }
-
-.bp3-icon-cube::before{
-  content:""; }
-
-.bp3-icon-cube-add::before{
-  content:""; }
-
-.bp3-icon-cube-remove::before{
-  content:""; }
-
-.bp3-icon-curved-range-chart::before{
-  content:""; }
-
-.bp3-icon-cut::before{
-  content:""; }
-
-.bp3-icon-dashboard::before{
-  content:""; }
-
-.bp3-icon-data-lineage::before{
-  content:""; }
-
-.bp3-icon-database::before{
-  content:""; }
-
-.bp3-icon-delete::before{
-  content:""; }
-
-.bp3-icon-delta::before{
-  content:"Δ"; }
-
-.bp3-icon-derive-column::before{
-  content:""; }
-
-.bp3-icon-desktop::before{
-  content:""; }
-
-.bp3-icon-diagram-tree::before{
-  content:""; }
-
-.bp3-icon-direction-left::before{
-  content:""; }
-
-.bp3-icon-direction-right::before{
-  content:""; }
-
-.bp3-icon-disable::before{
-  content:""; }
-
-.bp3-icon-document::before{
-  content:""; }
-
-.bp3-icon-document-open::before{
-  content:""; }
-
-.bp3-icon-document-share::before{
-  content:""; }
-
-.bp3-icon-dollar::before{
-  content:"$"; }
-
-.bp3-icon-dot::before{
-  content:"•"; }
-
-.bp3-icon-double-caret-horizontal::before{
-  content:""; }
-
-.bp3-icon-double-caret-vertical::before{
-  content:""; }
-
-.bp3-icon-double-chevron-down::before{
-  content:""; }
-
-.bp3-icon-double-chevron-left::before{
-  content:""; }
-
-.bp3-icon-double-chevron-right::before{
-  content:""; }
-
-.bp3-icon-double-chevron-up::before{
-  content:""; }
-
-.bp3-icon-doughnut-chart::before{
-  content:""; }
-
-.bp3-icon-download::before{
-  content:""; }
-
-.bp3-icon-drag-handle-horizontal::before{
-  content:""; }
-
-.bp3-icon-drag-handle-vertical::before{
-  content:""; }
-
-.bp3-icon-draw::before{
-  content:""; }
-
-.bp3-icon-drive-time::before{
-  content:""; }
-
-.bp3-icon-duplicate::before{
-  content:""; }
-
-.bp3-icon-edit::before{
-  content:"✎"; }
-
-.bp3-icon-eject::before{
-  content:"⏏"; }
-
-.bp3-icon-endorsed::before{
-  content:""; }
-
-.bp3-icon-envelope::before{
-  content:"✉"; }
-
-.bp3-icon-equals::before{
-  content:""; }
-
-.bp3-icon-eraser::before{
-  content:""; }
-
-.bp3-icon-error::before{
-  content:""; }
-
-.bp3-icon-euro::before{
-  content:"€"; }
-
-.bp3-icon-exchange::before{
-  content:""; }
-
-.bp3-icon-exclude-row::before{
-  content:""; }
-
-.bp3-icon-expand-all::before{
-  content:""; }
-
-.bp3-icon-export::before{
-  content:""; }
-
-.bp3-icon-eye-off::before{
-  content:""; }
-
-.bp3-icon-eye-on::before{
-  content:""; }
-
-.bp3-icon-eye-open::before{
-  content:""; }
-
-.bp3-icon-fast-backward::before{
-  content:""; }
-
-.bp3-icon-fast-forward::before{
-  content:""; }
-
-.bp3-icon-feed::before{
-  content:""; }
-
-.bp3-icon-feed-subscribed::before{
-  content:""; }
-
-.bp3-icon-film::before{
-  content:""; }
-
-.bp3-icon-filter::before{
-  content:""; }
-
-.bp3-icon-filter-keep::before{
-  content:""; }
-
-.bp3-icon-filter-list::before{
-  content:""; }
-
-.bp3-icon-filter-open::before{
-  content:""; }
-
-.bp3-icon-filter-remove::before{
-  content:""; }
-
-.bp3-icon-flag::before{
-  content:"⚑"; }
-
-.bp3-icon-flame::before{
-  content:""; }
-
-.bp3-icon-flash::before{
-  content:""; }
-
-.bp3-icon-floppy-disk::before{
-  content:""; }
-
-.bp3-icon-flow-branch::before{
-  content:""; }
-
-.bp3-icon-flow-end::before{
-  content:""; }
-
-.bp3-icon-flow-linear::before{
-  content:""; }
-
-.bp3-icon-flow-review::before{
-  content:""; }
-
-.bp3-icon-flow-review-branch::before{
-  content:""; }
-
-.bp3-icon-flows::before{
-  content:""; }
-
-.bp3-icon-folder-close::before{
-  content:""; }
-
-.bp3-icon-folder-new::before{
-  content:""; }
-
-.bp3-icon-folder-open::before{
-  content:""; }
-
-.bp3-icon-folder-shared::before{
-  content:""; }
-
-.bp3-icon-folder-shared-open::before{
-  content:""; }
-
-.bp3-icon-follower::before{
-  content:""; }
-
-.bp3-icon-following::before{
-  content:""; }
-
-.bp3-icon-font::before{
-  content:""; }
-
-.bp3-icon-fork::before{
-  content:""; }
-
-.bp3-icon-form::before{
-  content:""; }
-
-.bp3-icon-full-circle::before{
-  content:""; }
-
-.bp3-icon-full-stacked-chart::before{
-  content:""; }
-
-.bp3-icon-fullscreen::before{
-  content:""; }
-
-.bp3-icon-function::before{
-  content:""; }
-
-.bp3-icon-gantt-chart::before{
-  content:""; }
-
-.bp3-icon-geolocation::before{
-  content:""; }
-
-.bp3-icon-geosearch::before{
-  content:""; }
-
-.bp3-icon-git-branch::before{
-  content:""; }
-
-.bp3-icon-git-commit::before{
-  content:""; }
-
-.bp3-icon-git-merge::before{
-  content:""; }
-
-.bp3-icon-git-new-branch::before{
-  content:""; }
-
-.bp3-icon-git-pull::before{
-  content:""; }
-
-.bp3-icon-git-push::before{
-  content:""; }
-
-.bp3-icon-git-repo::before{
-  content:""; }
-
-.bp3-icon-glass::before{
-  content:""; }
-
-.bp3-icon-globe::before{
-  content:""; }
-
-.bp3-icon-globe-network::before{
-  content:""; }
-
-.bp3-icon-graph::before{
-  content:""; }
-
-.bp3-icon-graph-remove::before{
-  content:""; }
-
-.bp3-icon-greater-than::before{
-  content:""; }
-
-.bp3-icon-greater-than-or-equal-to::before{
-  content:""; }
-
-.bp3-icon-grid::before{
-  content:""; }
-
-.bp3-icon-grid-view::before{
-  content:""; }
-
-.bp3-icon-group-objects::before{
-  content:""; }
-
-.bp3-icon-grouped-bar-chart::before{
-  content:""; }
-
-.bp3-icon-hand::before{
-  content:""; }
-
-.bp3-icon-hand-down::before{
-  content:""; }
-
-.bp3-icon-hand-left::before{
-  content:""; }
-
-.bp3-icon-hand-right::before{
-  content:""; }
-
-.bp3-icon-hand-up::before{
-  content:""; }
-
-.bp3-icon-header::before{
-  content:""; }
-
-.bp3-icon-header-one::before{
-  content:""; }
-
-.bp3-icon-header-two::before{
-  content:""; }
-
-.bp3-icon-headset::before{
-  content:""; }
-
-.bp3-icon-heart::before{
-  content:"♥"; }
-
-.bp3-icon-heart-broken::before{
-  content:""; }
-
-.bp3-icon-heat-grid::before{
-  content:""; }
-
-.bp3-icon-heatmap::before{
-  content:""; }
-
-.bp3-icon-help::before{
-  content:"?"; }
-
-.bp3-icon-helper-management::before{
-  content:""; }
-
-.bp3-icon-highlight::before{
-  content:""; }
-
-.bp3-icon-history::before{
-  content:""; }
-
-.bp3-icon-home::before{
-  content:"⌂"; }
-
-.bp3-icon-horizontal-bar-chart::before{
-  content:""; }
-
-.bp3-icon-horizontal-bar-chart-asc::before{
-  content:""; }
-
-.bp3-icon-horizontal-bar-chart-desc::before{
-  content:""; }
-
-.bp3-icon-horizontal-distribution::before{
-  content:""; }
-
-.bp3-icon-id-number::before{
-  content:""; }
-
-.bp3-icon-image-rotate-left::before{
-  content:""; }
-
-.bp3-icon-image-rotate-right::before{
-  content:""; }
-
-.bp3-icon-import::before{
-  content:""; }
-
-.bp3-icon-inbox::before{
-  content:""; }
-
-.bp3-icon-inbox-filtered::before{
-  content:""; }
-
-.bp3-icon-inbox-geo::before{
-  content:""; }
-
-.bp3-icon-inbox-search::before{
-  content:""; }
-
-.bp3-icon-inbox-update::before{
-  content:""; }
-
-.bp3-icon-info-sign::before{
-  content:"ℹ"; }
-
-.bp3-icon-inheritance::before{
-  content:""; }
-
-.bp3-icon-inner-join::before{
-  content:""; }
-
-.bp3-icon-insert::before{
-  content:""; }
-
-.bp3-icon-intersection::before{
-  content:""; }
-
-.bp3-icon-ip-address::before{
-  content:""; }
-
-.bp3-icon-issue::before{
-  content:""; }
-
-.bp3-icon-issue-closed::before{
-  content:""; }
-
-.bp3-icon-issue-new::before{
-  content:""; }
-
-.bp3-icon-italic::before{
-  content:""; }
-
-.bp3-icon-join-table::before{
-  content:""; }
-
-.bp3-icon-key::before{
-  content:""; }
-
-.bp3-icon-key-backspace::before{
-  content:""; }
-
-.bp3-icon-key-command::before{
-  content:""; }
-
-.bp3-icon-key-control::before{
-  content:""; }
-
-.bp3-icon-key-delete::before{
-  content:""; }
-
-.bp3-icon-key-enter::before{
-  content:""; }
-
-.bp3-icon-key-escape::before{
-  content:""; }
-
-.bp3-icon-key-option::before{
-  content:""; }
-
-.bp3-icon-key-shift::before{
-  content:""; }
-
-.bp3-icon-key-tab::before{
-  content:""; }
-
-.bp3-icon-known-vehicle::before{
-  content:""; }
-
-.bp3-icon-label::before{
-  content:""; }
-
-.bp3-icon-layer::before{
-  content:""; }
-
-.bp3-icon-layers::before{
-  content:""; }
-
-.bp3-icon-layout::before{
-  content:""; }
-
-.bp3-icon-layout-auto::before{
-  content:""; }
-
-.bp3-icon-layout-balloon::before{
-  content:""; }
-
-.bp3-icon-layout-circle::before{
-  content:""; }
-
-.bp3-icon-layout-grid::before{
-  content:""; }
-
-.bp3-icon-layout-group-by::before{
-  content:""; }
-
-.bp3-icon-layout-hierarchy::before{
-  content:""; }
-
-.bp3-icon-layout-linear::before{
-  content:""; }
-
-.bp3-icon-layout-skew-grid::before{
-  content:""; }
-
-.bp3-icon-layout-sorted-clusters::before{
-  content:""; }
-
-.bp3-icon-learning::before{
-  content:""; }
-
-.bp3-icon-left-join::before{
-  content:""; }
-
-.bp3-icon-less-than::before{
-  content:""; }
-
-.bp3-icon-less-than-or-equal-to::before{
-  content:""; }
-
-.bp3-icon-lifesaver::before{
-  content:""; }
-
-.bp3-icon-lightbulb::before{
-  content:""; }
-
-.bp3-icon-link::before{
-  content:""; }
-
-.bp3-icon-list::before{
-  content:"☰"; }
-
-.bp3-icon-list-columns::before{
-  content:""; }
-
-.bp3-icon-list-detail-view::before{
-  content:""; }
-
-.bp3-icon-locate::before{
-  content:""; }
-
-.bp3-icon-lock::before{
-  content:""; }
-
-.bp3-icon-log-in::before{
-  content:""; }
-
-.bp3-icon-log-out::before{
-  content:""; }
-
-.bp3-icon-manual::before{
-  content:""; }
-
-.bp3-icon-manually-entered-data::before{
-  content:""; }
-
-.bp3-icon-map::before{
-  content:""; }
-
-.bp3-icon-map-create::before{
-  content:""; }
-
-.bp3-icon-map-marker::before{
-  content:""; }
-
-.bp3-icon-maximize::before{
-  content:""; }
-
-.bp3-icon-media::before{
-  content:""; }
-
-.bp3-icon-menu::before{
-  content:""; }
-
-.bp3-icon-menu-closed::before{
-  content:""; }
-
-.bp3-icon-menu-open::before{
-  content:""; }
-
-.bp3-icon-merge-columns::before{
-  content:""; }
-
-.bp3-icon-merge-links::before{
-  content:""; }
-
-.bp3-icon-minimize::before{
-  content:""; }
-
-.bp3-icon-minus::before{
-  content:"−"; }
-
-.bp3-icon-mobile-phone::before{
-  content:""; }
-
-.bp3-icon-mobile-video::before{
-  content:""; }
-
-.bp3-icon-moon::before{
-  content:""; }
-
-.bp3-icon-more::before{
-  content:""; }
-
-.bp3-icon-mountain::before{
-  content:""; }
-
-.bp3-icon-move::before{
-  content:""; }
-
-.bp3-icon-mugshot::before{
-  content:""; }
-
-.bp3-icon-multi-select::before{
-  content:""; }
-
-.bp3-icon-music::before{
-  content:""; }
-
-.bp3-icon-new-drawing::before{
-  content:""; }
-
-.bp3-icon-new-grid-item::before{
-  content:""; }
-
-.bp3-icon-new-layer::before{
-  content:""; }
-
-.bp3-icon-new-layers::before{
-  content:""; }
-
-.bp3-icon-new-link::before{
-  content:""; }
-
-.bp3-icon-new-object::before{
-  content:""; }
-
-.bp3-icon-new-person::before{
-  content:""; }
-
-.bp3-icon-new-prescription::before{
-  content:""; }
-
-.bp3-icon-new-text-box::before{
-  content:""; }
-
-.bp3-icon-ninja::before{
-  content:""; }
-
-.bp3-icon-not-equal-to::before{
-  content:""; }
-
-.bp3-icon-notifications::before{
-  content:""; }
-
-.bp3-icon-notifications-updated::before{
-  content:""; }
-
-.bp3-icon-numbered-list::before{
-  content:""; }
-
-.bp3-icon-numerical::before{
-  content:""; }
-
-.bp3-icon-office::before{
-  content:""; }
-
-.bp3-icon-offline::before{
-  content:""; }
-
-.bp3-icon-oil-field::before{
-  content:""; }
-
-.bp3-icon-one-column::before{
-  content:""; }
-
-.bp3-icon-outdated::before{
-  content:""; }
-
-.bp3-icon-page-layout::before{
-  content:""; }
-
-.bp3-icon-panel-stats::before{
-  content:""; }
-
-.bp3-icon-panel-table::before{
-  content:""; }
-
-.bp3-icon-paperclip::before{
-  content:""; }
-
-.bp3-icon-paragraph::before{
-  content:""; }
-
-.bp3-icon-path::before{
-  content:""; }
-
-.bp3-icon-path-search::before{
-  content:""; }
-
-.bp3-icon-pause::before{
-  content:""; }
-
-.bp3-icon-people::before{
-  content:""; }
-
-.bp3-icon-percentage::before{
-  content:""; }
-
-.bp3-icon-person::before{
-  content:""; }
-
-.bp3-icon-phone::before{
-  content:"☎"; }
-
-.bp3-icon-pie-chart::before{
-  content:""; }
-
-.bp3-icon-pin::before{
-  content:""; }
-
-.bp3-icon-pivot::before{
-  content:""; }
-
-.bp3-icon-pivot-table::before{
-  content:""; }
-
-.bp3-icon-play::before{
-  content:""; }
-
-.bp3-icon-plus::before{
-  content:"+"; }
-
-.bp3-icon-polygon-filter::before{
-  content:""; }
-
-.bp3-icon-power::before{
-  content:""; }
-
-.bp3-icon-predictive-analysis::before{
-  content:""; }
-
-.bp3-icon-prescription::before{
-  content:""; }
-
-.bp3-icon-presentation::before{
-  content:""; }
-
-.bp3-icon-print::before{
-  content:"⎙"; }
-
-.bp3-icon-projects::before{
-  content:""; }
-
-.bp3-icon-properties::before{
-  content:""; }
-
-.bp3-icon-property::before{
-  content:""; }
-
-.bp3-icon-publish-function::before{
-  content:""; }
-
-.bp3-icon-pulse::before{
-  content:""; }
-
-.bp3-icon-random::before{
-  content:""; }
-
-.bp3-icon-record::before{
-  content:""; }
-
-.bp3-icon-redo::before{
-  content:""; }
-
-.bp3-icon-refresh::before{
-  content:""; }
-
-.bp3-icon-regression-chart::before{
-  content:""; }
-
-.bp3-icon-remove::before{
-  content:""; }
-
-.bp3-icon-remove-column::before{
-  content:""; }
-
-.bp3-icon-remove-column-left::before{
-  content:""; }
-
-.bp3-icon-remove-column-right::before{
-  content:""; }
-
-.bp3-icon-remove-row-bottom::before{
-  content:""; }
-
-.bp3-icon-remove-row-top::before{
-  content:""; }
-
-.bp3-icon-repeat::before{
-  content:""; }
-
-.bp3-icon-reset::before{
-  content:""; }
-
-.bp3-icon-resolve::before{
-  content:""; }
-
-.bp3-icon-rig::before{
-  content:""; }
-
-.bp3-icon-right-join::before{
-  content:""; }
-
-.bp3-icon-ring::before{
-  content:""; }
-
-.bp3-icon-rotate-document::before{
-  content:""; }
-
-.bp3-icon-rotate-page::before{
-  content:""; }
-
-.bp3-icon-satellite::before{
-  content:""; }
-
-.bp3-icon-saved::before{
-  content:""; }
-
-.bp3-icon-scatter-plot::before{
-  content:""; }
-
-.bp3-icon-search::before{
-  content:""; }
-
-.bp3-icon-search-around::before{
-  content:""; }
-
-.bp3-icon-search-template::before{
-  content:""; }
-
-.bp3-icon-search-text::before{
-  content:""; }
-
-.bp3-icon-segmented-control::before{
-  content:""; }
-
-.bp3-icon-select::before{
-  content:""; }
-
-.bp3-icon-selection::before{
-  content:"⦿"; }
-
-.bp3-icon-send-to::before{
-  content:""; }
-
-.bp3-icon-send-to-graph::before{
-  content:""; }
-
-.bp3-icon-send-to-map::before{
-  content:""; }
-
-.bp3-icon-series-add::before{
-  content:""; }
-
-.bp3-icon-series-configuration::before{
-  content:""; }
-
-.bp3-icon-series-derived::before{
-  content:""; }
-
-.bp3-icon-series-filtered::before{
-  content:""; }
-
-.bp3-icon-series-search::before{
-  content:""; }
-
-.bp3-icon-settings::before{
-  content:""; }
-
-.bp3-icon-share::before{
-  content:""; }
-
-.bp3-icon-shield::before{
-  content:""; }
-
-.bp3-icon-shop::before{
-  content:""; }
-
-.bp3-icon-shopping-cart::before{
-  content:""; }
-
-.bp3-icon-signal-search::before{
-  content:""; }
-
-.bp3-icon-sim-card::before{
-  content:""; }
-
-.bp3-icon-slash::before{
-  content:""; }
-
-.bp3-icon-small-cross::before{
-  content:""; }
-
-.bp3-icon-small-minus::before{
-  content:""; }
-
-.bp3-icon-small-plus::before{
-  content:""; }
-
-.bp3-icon-small-tick::before{
-  content:""; }
-
-.bp3-icon-snowflake::before{
-  content:""; }
-
-.bp3-icon-social-media::before{
-  content:""; }
-
-.bp3-icon-sort::before{
-  content:""; }
-
-.bp3-icon-sort-alphabetical::before{
-  content:""; }
-
-.bp3-icon-sort-alphabetical-desc::before{
-  content:""; }
-
-.bp3-icon-sort-asc::before{
-  content:""; }
-
-.bp3-icon-sort-desc::before{
-  content:""; }
-
-.bp3-icon-sort-numerical::before{
-  content:""; }
-
-.bp3-icon-sort-numerical-desc::before{
-  content:""; }
-
-.bp3-icon-split-columns::before{
-  content:""; }
-
-.bp3-icon-square::before{
-  content:""; }
-
-.bp3-icon-stacked-chart::before{
-  content:""; }
-
-.bp3-icon-star::before{
-  content:"★"; }
-
-.bp3-icon-star-empty::before{
-  content:"☆"; }
-
-.bp3-icon-step-backward::before{
-  content:""; }
-
-.bp3-icon-step-chart::before{
-  content:""; }
-
-.bp3-icon-step-forward::before{
-  content:""; }
-
-.bp3-icon-stop::before{
-  content:""; }
-
-.bp3-icon-stopwatch::before{
-  content:""; }
-
-.bp3-icon-strikethrough::before{
-  content:""; }
-
-.bp3-icon-style::before{
-  content:""; }
-
-.bp3-icon-swap-horizontal::before{
-  content:""; }
-
-.bp3-icon-swap-vertical::before{
-  content:""; }
-
-.bp3-icon-symbol-circle::before{
-  content:""; }
-
-.bp3-icon-symbol-cross::before{
-  content:""; }
-
-.bp3-icon-symbol-diamond::before{
-  content:""; }
-
-.bp3-icon-symbol-square::before{
-  content:""; }
-
-.bp3-icon-symbol-triangle-down::before{
-  content:""; }
-
-.bp3-icon-symbol-triangle-up::before{
-  content:""; }
-
-.bp3-icon-tag::before{
-  content:""; }
-
-.bp3-icon-take-action::before{
-  content:""; }
-
-.bp3-icon-taxi::before{
-  content:""; }
-
-.bp3-icon-text-highlight::before{
-  content:""; }
-
-.bp3-icon-th::before{
-  content:""; }
-
-.bp3-icon-th-derived::before{
-  content:""; }
-
-.bp3-icon-th-disconnect::before{
-  content:""; }
-
-.bp3-icon-th-filtered::before{
-  content:""; }
-
-.bp3-icon-th-list::before{
-  content:""; }
-
-.bp3-icon-thumbs-down::before{
-  content:""; }
-
-.bp3-icon-thumbs-up::before{
-  content:""; }
-
-.bp3-icon-tick::before{
-  content:"✓"; }
-
-.bp3-icon-tick-circle::before{
-  content:""; }
-
-.bp3-icon-time::before{
-  content:"⏲"; }
-
-.bp3-icon-timeline-area-chart::before{
-  content:""; }
-
-.bp3-icon-timeline-bar-chart::before{
-  content:""; }
-
-.bp3-icon-timeline-events::before{
-  content:""; }
-
-.bp3-icon-timeline-line-chart::before{
-  content:""; }
-
-.bp3-icon-tint::before{
-  content:""; }
-
-.bp3-icon-torch::before{
-  content:""; }
-
-.bp3-icon-tractor::before{
-  content:""; }
-
-.bp3-icon-train::before{
-  content:""; }
-
-.bp3-icon-translate::before{
-  content:""; }
-
-.bp3-icon-trash::before{
-  content:""; }
-
-.bp3-icon-tree::before{
-  content:""; }
-
-.bp3-icon-trending-down::before{
-  content:""; }
-
-.bp3-icon-trending-up::before{
-  content:""; }
-
-.bp3-icon-truck::before{
-  content:""; }
-
-.bp3-icon-two-columns::before{
-  content:""; }
-
-.bp3-icon-unarchive::before{
-  content:""; }
-
-.bp3-icon-underline::before{
-  content:"⎁"; }
-
-.bp3-icon-undo::before{
-  content:"⎌"; }
-
-.bp3-icon-ungroup-objects::before{
-  content:""; }
-
-.bp3-icon-unknown-vehicle::before{
-  content:""; }
-
-.bp3-icon-unlock::before{
-  content:""; }
-
-.bp3-icon-unpin::before{
-  content:""; }
-
-.bp3-icon-unresolve::before{
-  content:""; }
-
-.bp3-icon-updated::before{
-  content:""; }
-
-.bp3-icon-upload::before{
-  content:""; }
-
-.bp3-icon-user::before{
-  content:""; }
-
-.bp3-icon-variable::before{
-  content:""; }
-
-.bp3-icon-vertical-bar-chart-asc::before{
-  content:""; }
-
-.bp3-icon-vertical-bar-chart-desc::before{
-  content:""; }
-
-.bp3-icon-vertical-distribution::before{
-  content:""; }
-
-.bp3-icon-video::before{
-  content:""; }
-
-.bp3-icon-volume-down::before{
-  content:""; }
-
-.bp3-icon-volume-off::before{
-  content:""; }
-
-.bp3-icon-volume-up::before{
-  content:""; }
-
-.bp3-icon-walk::before{
-  content:""; }
-
-.bp3-icon-warning-sign::before{
-  content:""; }
-
-.bp3-icon-waterfall-chart::before{
-  content:""; }
-
-.bp3-icon-widget::before{
-  content:""; }
-
-.bp3-icon-widget-button::before{
-  content:""; }
-
-.bp3-icon-widget-footer::before{
-  content:""; }
-
-.bp3-icon-widget-header::before{
-  content:""; }
-
-.bp3-icon-wrench::before{
-  content:""; }
-
-.bp3-icon-zoom-in::before{
-  content:""; }
-
-.bp3-icon-zoom-out::before{
-  content:""; }
-
-.bp3-icon-zoom-to-fit::before{
-  content:""; }
-.bp3-submenu > .bp3-popover-wrapper{
-  display:block; }
-
-.bp3-submenu .bp3-popover-target{
-  display:block; }
-
-.bp3-submenu.bp3-popover{
-  -webkit-box-shadow:none;
-          box-shadow:none;
-  padding:0 5px; }
-  .bp3-submenu.bp3-popover > .bp3-popover-content{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2); }
-  .bp3-dark .bp3-submenu.bp3-popover, .bp3-submenu.bp3-popover.bp3-dark{
-    -webkit-box-shadow:none;
-            box-shadow:none; }
-    .bp3-dark .bp3-submenu.bp3-popover > .bp3-popover-content, .bp3-submenu.bp3-popover.bp3-dark > .bp3-popover-content{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
-.bp3-menu{
-  margin:0;
-  border-radius:3px;
-  background:#ffffff;
-  min-width:180px;
-  padding:5px;
-  list-style:none;
-  text-align:left;
-  color:#182026; }
-
-.bp3-menu-divider{
-  display:block;
-  margin:5px;
-  border-top:1px solid rgba(16, 22, 26, 0.15); }
-  .bp3-dark .bp3-menu-divider{
-    border-top-color:rgba(255, 255, 255, 0.15); }
-
-.bp3-menu-item{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:row;
-          flex-direction:row;
-  -webkit-box-align:start;
-      -ms-flex-align:start;
-          align-items:flex-start;
-  border-radius:2px;
-  padding:5px 7px;
-  text-decoration:none;
-  line-height:20px;
-  color:inherit;
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-menu-item > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-menu-item > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-menu-item::before,
-  .bp3-menu-item > *{
-    margin-right:7px; }
-  .bp3-menu-item:empty::before,
-  .bp3-menu-item > :last-child{
-    margin-right:0; }
-  .bp3-menu-item > .bp3-fill{
-    word-break:break-word; }
-  .bp3-menu-item:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
-    background-color:rgba(167, 182, 194, 0.3);
-    cursor:pointer;
-    text-decoration:none; }
-  .bp3-menu-item.bp3-disabled{
-    background-color:inherit;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-dark .bp3-menu-item{
-    color:inherit; }
-    .bp3-dark .bp3-menu-item:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
-      background-color:rgba(138, 155, 168, 0.15);
-      color:inherit; }
-    .bp3-dark .bp3-menu-item.bp3-disabled{
-      background-color:inherit;
-      color:rgba(167, 182, 194, 0.6); }
-  .bp3-menu-item.bp3-intent-primary{
-    color:#106ba3; }
-    .bp3-menu-item.bp3-intent-primary .bp3-icon{
-      color:inherit; }
-    .bp3-menu-item.bp3-intent-primary::before, .bp3-menu-item.bp3-intent-primary::after,
-    .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
-      color:#106ba3; }
-    .bp3-menu-item.bp3-intent-primary:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-menu-item.bp3-intent-primary.bp3-active{
-      background-color:#137cbd; }
-    .bp3-menu-item.bp3-intent-primary:active{
-      background-color:#106ba3; }
-    .bp3-menu-item.bp3-intent-primary:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
-    .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
-    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-primary:active, .bp3-menu-item.bp3-intent-primary:active::before, .bp3-menu-item.bp3-intent-primary:active::after,
-    .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-menu-item.bp3-intent-primary.bp3-active::after,
-    .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
-      color:#ffffff; }
-  .bp3-menu-item.bp3-intent-success{
-    color:#0d8050; }
-    .bp3-menu-item.bp3-intent-success .bp3-icon{
-      color:inherit; }
-    .bp3-menu-item.bp3-intent-success::before, .bp3-menu-item.bp3-intent-success::after,
-    .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
-      color:#0d8050; }
-    .bp3-menu-item.bp3-intent-success:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-menu-item.bp3-intent-success.bp3-active{
-      background-color:#0f9960; }
-    .bp3-menu-item.bp3-intent-success:active{
-      background-color:#0d8050; }
-    .bp3-menu-item.bp3-intent-success:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-menu-item.bp3-intent-success:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-menu-item.bp3-intent-success:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
-    .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
-    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-success:active, .bp3-menu-item.bp3-intent-success:active::before, .bp3-menu-item.bp3-intent-success:active::after,
-    .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-menu-item.bp3-intent-success.bp3-active::after,
-    .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
-      color:#ffffff; }
-  .bp3-menu-item.bp3-intent-warning{
-    color:#bf7326; }
-    .bp3-menu-item.bp3-intent-warning .bp3-icon{
-      color:inherit; }
-    .bp3-menu-item.bp3-intent-warning::before, .bp3-menu-item.bp3-intent-warning::after,
-    .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
-      color:#bf7326; }
-    .bp3-menu-item.bp3-intent-warning:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-menu-item.bp3-intent-warning.bp3-active{
-      background-color:#d9822b; }
-    .bp3-menu-item.bp3-intent-warning:active{
-      background-color:#bf7326; }
-    .bp3-menu-item.bp3-intent-warning:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
-    .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
-    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-warning:active, .bp3-menu-item.bp3-intent-warning:active::before, .bp3-menu-item.bp3-intent-warning:active::after,
-    .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-menu-item.bp3-intent-warning.bp3-active::after,
-    .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
-      color:#ffffff; }
-  .bp3-menu-item.bp3-intent-danger{
-    color:#c23030; }
-    .bp3-menu-item.bp3-intent-danger .bp3-icon{
-      color:inherit; }
-    .bp3-menu-item.bp3-intent-danger::before, .bp3-menu-item.bp3-intent-danger::after,
-    .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
-      color:#c23030; }
-    .bp3-menu-item.bp3-intent-danger:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-menu-item.bp3-intent-danger.bp3-active{
-      background-color:#db3737; }
-    .bp3-menu-item.bp3-intent-danger:active{
-      background-color:#c23030; }
-    .bp3-menu-item.bp3-intent-danger:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
-    .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
-    .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-menu-item.bp3-intent-danger:active, .bp3-menu-item.bp3-intent-danger:active::before, .bp3-menu-item.bp3-intent-danger:active::after,
-    .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-menu-item.bp3-intent-danger.bp3-active::after,
-    .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
-      color:#ffffff; }
-  .bp3-menu-item::before{
-    line-height:1;
-    font-family:"Icons16", sans-serif;
-    font-size:16px;
-    font-weight:400;
-    font-style:normal;
-    -moz-osx-font-smoothing:grayscale;
-    -webkit-font-smoothing:antialiased;
-    margin-right:7px; }
-  .bp3-menu-item::before,
-  .bp3-menu-item > .bp3-icon{
-    margin-top:2px;
-    color:#5c7080; }
-  .bp3-menu-item .bp3-menu-item-label{
-    color:#5c7080; }
-  .bp3-menu-item:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
-    color:inherit; }
-  .bp3-menu-item.bp3-active, .bp3-menu-item:active{
-    background-color:rgba(115, 134, 148, 0.3); }
-  .bp3-menu-item.bp3-disabled{
-    outline:none !important;
-    background-color:inherit !important;
-    cursor:not-allowed !important;
-    color:rgba(92, 112, 128, 0.6) !important; }
-    .bp3-menu-item.bp3-disabled::before,
-    .bp3-menu-item.bp3-disabled > .bp3-icon,
-    .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
-      color:rgba(92, 112, 128, 0.6) !important; }
-  .bp3-large .bp3-menu-item{
-    padding:9px 7px;
-    line-height:22px;
-    font-size:16px; }
-    .bp3-large .bp3-menu-item .bp3-icon{
-      margin-top:3px; }
-    .bp3-large .bp3-menu-item::before{
-      line-height:1;
-      font-family:"Icons20", sans-serif;
-      font-size:20px;
-      font-weight:400;
-      font-style:normal;
-      -moz-osx-font-smoothing:grayscale;
-      -webkit-font-smoothing:antialiased;
-      margin-top:1px;
-      margin-right:10px; }
-
-button.bp3-menu-item{
-  border:none;
-  background:none;
-  width:100%;
-  text-align:left; }
-.bp3-menu-header{
-  display:block;
-  margin:5px;
-  border-top:1px solid rgba(16, 22, 26, 0.15);
-  cursor:default;
-  padding-left:2px; }
-  .bp3-dark .bp3-menu-header{
-    border-top-color:rgba(255, 255, 255, 0.15); }
-  .bp3-menu-header:first-of-type{
-    border-top:none; }
-  .bp3-menu-header > h6{
-    color:#182026;
-    font-weight:600;
-    overflow:hidden;
-    text-overflow:ellipsis;
-    white-space:nowrap;
-    word-wrap:normal;
-    margin:0;
-    padding:10px 7px 0 1px;
-    line-height:17px; }
-    .bp3-dark .bp3-menu-header > h6{
-      color:#f5f8fa; }
-  .bp3-menu-header:first-of-type > h6{
-    padding-top:0; }
-  .bp3-large .bp3-menu-header > h6{
-    padding-top:15px;
-    padding-bottom:5px;
-    font-size:18px; }
-  .bp3-large .bp3-menu-header:first-of-type > h6{
-    padding-top:0; }
-
-.bp3-dark .bp3-menu{
-  background:#30404d;
-  color:#f5f8fa; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-primary{
-  color:#48aff0; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary::before, .bp3-dark .bp3-menu-item.bp3-intent-primary::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
-    color:#48aff0; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active{
-    background-color:#137cbd; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:active{
-    background-color:#106ba3; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary:active, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-success{
-  color:#3dcc91; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success::before, .bp3-dark .bp3-menu-item.bp3-intent-success::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
-    color:#3dcc91; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active{
-    background-color:#0f9960; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:active{
-    background-color:#0d8050; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success:active, .bp3-dark .bp3-menu-item.bp3-intent-success:active::before, .bp3-dark .bp3-menu-item.bp3-intent-success:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-warning{
-  color:#ffb366; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning::before, .bp3-dark .bp3-menu-item.bp3-intent-warning::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
-    color:#ffb366; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active{
-    background-color:#d9822b; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:active{
-    background-color:#bf7326; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning:active, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-danger{
-  color:#ff7373; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger::before, .bp3-dark .bp3-menu-item.bp3-intent-danger::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
-    color:#ff7373; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active{
-    background-color:#db3737; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:active{
-    background-color:#c23030; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger:active, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
+table.bp3-html-table.bp3-html-table-condensed td,
+table.bp3-html-table.bp3-small th,
+table.bp3-html-table.bp3-small td {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td {
+  background: rgba(191, 204, 214, 0.15);
+}
+
+table.bp3-html-table.bp3-html-table-bordered th:not(:first-child) {
+  -webkit-box-shadow: inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
+  box-shadow: inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
+}
+
+table.bp3-html-table.bp3-html-table-bordered tbody tr td {
+  -webkit-box-shadow: inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
+  box-shadow: inset 0 1px 0 0 rgba(16, 22, 26, 0.15);
+}
+table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child) {
+  -webkit-box-shadow: inset 1px 1px 0 0 rgba(16, 22, 26, 0.15);
+  box-shadow: inset 1px 1px 0 0 rgba(16, 22, 26, 0.15);
+}
+
+table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped
+  tbody
+  tr:not(:first-child)
+  td {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped
+  tbody
+  tr:not(:first-child)
+  td:not(:first-child) {
+  -webkit-box-shadow: inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
+  box-shadow: inset 1px 0 0 0 rgba(16, 22, 26, 0.15);
+}
+
+table.bp3-html-table.bp3-interactive tbody tr:hover td {
+  background-color: rgba(191, 204, 214, 0.3);
+  cursor: pointer;
+}
+
+table.bp3-html-table.bp3-interactive tbody tr:active td {
+  background-color: rgba(191, 204, 214, 0.4);
+}
+
+.bp3-dark
+  table.bp3-html-table.bp3-html-table-striped
+  tbody
+  tr:nth-child(odd)
+  td {
+  background: rgba(92, 112, 128, 0.15);
+}
+
+.bp3-dark table.bp3-html-table.bp3-html-table-bordered th:not(:first-child) {
+  -webkit-box-shadow: inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+  box-shadow: inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+}
+
+.bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td {
+  -webkit-box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+}
+.bp3-dark
+  table.bp3-html-table.bp3-html-table-bordered
+  tbody
+  tr
+  td:not(:first-child) {
+  -webkit-box-shadow: inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
+  box-shadow: inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
+}
+
+.bp3-dark
+  table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped
+  tbody
+  tr:not(:first-child)
+  td {
+  -webkit-box-shadow: inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+  box-shadow: inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+}
+.bp3-dark
+  table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped
+  tbody
+  tr:not(:first-child)
+  td:first-child {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+
+.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:hover td {
+  background-color: rgba(92, 112, 128, 0.3);
+  cursor: pointer;
+}
+
+.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:active td {
+  background-color: rgba(92, 112, 128, 0.4);
+}
+
+.bp3-key-combo {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+.bp3-key-combo > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-key-combo > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-key-combo::before,
+.bp3-key-combo > * {
+  margin-right: 5px;
+}
+.bp3-key-combo:empty::before,
+.bp3-key-combo > :last-child {
+  margin-right: 0;
+}
+
+.bp3-hotkey-dialog {
+  top: 40px;
+  padding-bottom: 0;
+}
+.bp3-hotkey-dialog .bp3-dialog-body {
+  margin: 0;
+  padding: 0;
+}
+.bp3-hotkey-dialog .bp3-hotkey-label {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.bp3-hotkey-column {
+  margin: auto;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 30px;
+}
+.bp3-hotkey-column .bp3-heading {
+  margin-bottom: 20px;
+}
+.bp3-hotkey-column .bp3-heading:not(:first-child) {
+  margin-top: 40px;
+}
+
+.bp3-hotkey {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-right: 0;
+  margin-left: 0;
+}
+.bp3-hotkey:not(:last-child) {
+  margin-bottom: 10px;
+}
+.bp3-icon {
+  display: inline-block;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  vertical-align: text-bottom;
+}
+.bp3-icon:not(:empty)::before {
+  content: '' !important;
+  content: unset !important;
+}
+.bp3-icon > svg {
+  display: block;
+}
+.bp3-icon > svg:not([fill]) {
+  fill: currentColor;
+}
+
+.bp3-icon.bp3-intent-primary,
+.bp3-icon-standard.bp3-intent-primary,
+.bp3-icon-large.bp3-intent-primary {
+  color: #106ba3;
+}
+.bp3-dark .bp3-icon.bp3-intent-primary,
+.bp3-dark .bp3-icon-standard.bp3-intent-primary,
+.bp3-dark .bp3-icon-large.bp3-intent-primary {
+  color: #48aff0;
+}
+
+.bp3-icon.bp3-intent-success,
+.bp3-icon-standard.bp3-intent-success,
+.bp3-icon-large.bp3-intent-success {
+  color: #0d8050;
+}
+.bp3-dark .bp3-icon.bp3-intent-success,
+.bp3-dark .bp3-icon-standard.bp3-intent-success,
+.bp3-dark .bp3-icon-large.bp3-intent-success {
+  color: #3dcc91;
+}
+
+.bp3-icon.bp3-intent-warning,
+.bp3-icon-standard.bp3-intent-warning,
+.bp3-icon-large.bp3-intent-warning {
+  color: #bf7326;
+}
+.bp3-dark .bp3-icon.bp3-intent-warning,
+.bp3-dark .bp3-icon-standard.bp3-intent-warning,
+.bp3-dark .bp3-icon-large.bp3-intent-warning {
+  color: #ffb366;
+}
+
+.bp3-icon.bp3-intent-danger,
+.bp3-icon-standard.bp3-intent-danger,
+.bp3-icon-large.bp3-intent-danger {
+  color: #c23030;
+}
+.bp3-dark .bp3-icon.bp3-intent-danger,
+.bp3-dark .bp3-icon-standard.bp3-intent-danger,
+.bp3-dark .bp3-icon-large.bp3-intent-danger {
+  color: #ff7373;
+}
+
+span.bp3-icon-standard {
+  line-height: 1;
+  font-family: 'Icons16', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+}
+
+span.bp3-icon-large {
+  line-height: 1;
+  font-family: 'Icons20', sans-serif;
+  font-size: 20px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+}
+
+span.bp3-icon:empty {
+  line-height: 1;
+  font-family: 'Icons20';
+  font-size: inherit;
+  font-weight: 400;
+  font-style: normal;
+}
+span.bp3-icon:empty::before {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.bp3-icon-add::before {
+  content: '';
+}
+
+.bp3-icon-add-column-left::before {
+  content: '';
+}
+
+.bp3-icon-add-column-right::before {
+  content: '';
+}
+
+.bp3-icon-add-row-bottom::before {
+  content: '';
+}
+
+.bp3-icon-add-row-top::before {
+  content: '';
+}
+
+.bp3-icon-add-to-artifact::before {
+  content: '';
+}
+
+.bp3-icon-add-to-folder::before {
+  content: '';
+}
+
+.bp3-icon-airplane::before {
+  content: '';
+}
+
+.bp3-icon-align-center::before {
+  content: '';
+}
+
+.bp3-icon-align-justify::before {
+  content: '';
+}
+
+.bp3-icon-align-left::before {
+  content: '';
+}
+
+.bp3-icon-align-right::before {
+  content: '';
+}
+
+.bp3-icon-alignment-bottom::before {
+  content: '';
+}
+
+.bp3-icon-alignment-horizontal-center::before {
+  content: '';
+}
+
+.bp3-icon-alignment-left::before {
+  content: '';
+}
+
+.bp3-icon-alignment-right::before {
+  content: '';
+}
+
+.bp3-icon-alignment-top::before {
+  content: '';
+}
+
+.bp3-icon-alignment-vertical-center::before {
+  content: '';
+}
+
+.bp3-icon-annotation::before {
+  content: '';
+}
+
+.bp3-icon-application::before {
+  content: '';
+}
+
+.bp3-icon-applications::before {
+  content: '';
+}
+
+.bp3-icon-archive::before {
+  content: '';
+}
+
+.bp3-icon-arrow-bottom-left::before {
+  content: '↙';
+}
+
+.bp3-icon-arrow-bottom-right::before {
+  content: '↘';
+}
+
+.bp3-icon-arrow-down::before {
+  content: '↓';
+}
+
+.bp3-icon-arrow-left::before {
+  content: '←';
+}
+
+.bp3-icon-arrow-right::before {
+  content: '→';
+}
+
+.bp3-icon-arrow-top-left::before {
+  content: '↖';
+}
+
+.bp3-icon-arrow-top-right::before {
+  content: '↗';
+}
+
+.bp3-icon-arrow-up::before {
+  content: '↑';
+}
+
+.bp3-icon-arrows-horizontal::before {
+  content: '↔';
+}
+
+.bp3-icon-arrows-vertical::before {
+  content: '↕';
+}
+
+.bp3-icon-asterisk::before {
+  content: '*';
+}
+
+.bp3-icon-automatic-updates::before {
+  content: '';
+}
+
+.bp3-icon-badge::before {
+  content: '';
+}
+
+.bp3-icon-ban-circle::before {
+  content: '';
+}
+
+.bp3-icon-bank-account::before {
+  content: '';
+}
+
+.bp3-icon-barcode::before {
+  content: '';
+}
+
+.bp3-icon-blank::before {
+  content: '';
+}
+
+.bp3-icon-blocked-person::before {
+  content: '';
+}
+
+.bp3-icon-bold::before {
+  content: '';
+}
+
+.bp3-icon-book::before {
+  content: '';
+}
+
+.bp3-icon-bookmark::before {
+  content: '';
+}
+
+.bp3-icon-box::before {
+  content: '';
+}
+
+.bp3-icon-briefcase::before {
+  content: '';
+}
+
+.bp3-icon-bring-data::before {
+  content: '';
+}
+
+.bp3-icon-build::before {
+  content: '';
+}
+
+.bp3-icon-calculator::before {
+  content: '';
+}
+
+.bp3-icon-calendar::before {
+  content: '';
+}
+
+.bp3-icon-camera::before {
+  content: '';
+}
+
+.bp3-icon-caret-down::before {
+  content: '⌄';
+}
+
+.bp3-icon-caret-left::before {
+  content: '〈';
+}
+
+.bp3-icon-caret-right::before {
+  content: '〉';
+}
+
+.bp3-icon-caret-up::before {
+  content: '⌃';
+}
+
+.bp3-icon-cell-tower::before {
+  content: '';
+}
+
+.bp3-icon-changes::before {
+  content: '';
+}
+
+.bp3-icon-chart::before {
+  content: '';
+}
+
+.bp3-icon-chat::before {
+  content: '';
+}
+
+.bp3-icon-chevron-backward::before {
+  content: '';
+}
+
+.bp3-icon-chevron-down::before {
+  content: '';
+}
+
+.bp3-icon-chevron-forward::before {
+  content: '';
+}
+
+.bp3-icon-chevron-left::before {
+  content: '';
+}
+
+.bp3-icon-chevron-right::before {
+  content: '';
+}
+
+.bp3-icon-chevron-up::before {
+  content: '';
+}
+
+.bp3-icon-circle::before {
+  content: '';
+}
+
+.bp3-icon-circle-arrow-down::before {
+  content: '';
+}
+
+.bp3-icon-circle-arrow-left::before {
+  content: '';
+}
+
+.bp3-icon-circle-arrow-right::before {
+  content: '';
+}
+
+.bp3-icon-circle-arrow-up::before {
+  content: '';
+}
+
+.bp3-icon-citation::before {
+  content: '';
+}
+
+.bp3-icon-clean::before {
+  content: '';
+}
+
+.bp3-icon-clipboard::before {
+  content: '';
+}
+
+.bp3-icon-cloud::before {
+  content: '☁';
+}
+
+.bp3-icon-cloud-download::before {
+  content: '';
+}
+
+.bp3-icon-cloud-upload::before {
+  content: '';
+}
+
+.bp3-icon-code::before {
+  content: '';
+}
+
+.bp3-icon-code-block::before {
+  content: '';
+}
+
+.bp3-icon-cog::before {
+  content: '';
+}
+
+.bp3-icon-collapse-all::before {
+  content: '';
+}
+
+.bp3-icon-column-layout::before {
+  content: '';
+}
+
+.bp3-icon-comment::before {
+  content: '';
+}
+
+.bp3-icon-comparison::before {
+  content: '';
+}
+
+.bp3-icon-compass::before {
+  content: '';
+}
+
+.bp3-icon-compressed::before {
+  content: '';
+}
+
+.bp3-icon-confirm::before {
+  content: '';
+}
+
+.bp3-icon-console::before {
+  content: '';
+}
+
+.bp3-icon-contrast::before {
+  content: '';
+}
+
+.bp3-icon-control::before {
+  content: '';
+}
+
+.bp3-icon-credit-card::before {
+  content: '';
+}
+
+.bp3-icon-cross::before {
+  content: '✗';
+}
+
+.bp3-icon-crown::before {
+  content: '';
+}
+
+.bp3-icon-cube::before {
+  content: '';
+}
+
+.bp3-icon-cube-add::before {
+  content: '';
+}
+
+.bp3-icon-cube-remove::before {
+  content: '';
+}
+
+.bp3-icon-curved-range-chart::before {
+  content: '';
+}
+
+.bp3-icon-cut::before {
+  content: '';
+}
+
+.bp3-icon-dashboard::before {
+  content: '';
+}
+
+.bp3-icon-data-lineage::before {
+  content: '';
+}
+
+.bp3-icon-database::before {
+  content: '';
+}
+
+.bp3-icon-delete::before {
+  content: '';
+}
+
+.bp3-icon-delta::before {
+  content: 'Δ';
+}
+
+.bp3-icon-derive-column::before {
+  content: '';
+}
+
+.bp3-icon-desktop::before {
+  content: '';
+}
+
+.bp3-icon-diagram-tree::before {
+  content: '';
+}
+
+.bp3-icon-direction-left::before {
+  content: '';
+}
+
+.bp3-icon-direction-right::before {
+  content: '';
+}
+
+.bp3-icon-disable::before {
+  content: '';
+}
+
+.bp3-icon-document::before {
+  content: '';
+}
+
+.bp3-icon-document-open::before {
+  content: '';
+}
+
+.bp3-icon-document-share::before {
+  content: '';
+}
+
+.bp3-icon-dollar::before {
+  content: '$';
+}
+
+.bp3-icon-dot::before {
+  content: '•';
+}
+
+.bp3-icon-double-caret-horizontal::before {
+  content: '';
+}
+
+.bp3-icon-double-caret-vertical::before {
+  content: '';
+}
+
+.bp3-icon-double-chevron-down::before {
+  content: '';
+}
+
+.bp3-icon-double-chevron-left::before {
+  content: '';
+}
+
+.bp3-icon-double-chevron-right::before {
+  content: '';
+}
+
+.bp3-icon-double-chevron-up::before {
+  content: '';
+}
+
+.bp3-icon-doughnut-chart::before {
+  content: '';
+}
+
+.bp3-icon-download::before {
+  content: '';
+}
+
+.bp3-icon-drag-handle-horizontal::before {
+  content: '';
+}
+
+.bp3-icon-drag-handle-vertical::before {
+  content: '';
+}
+
+.bp3-icon-draw::before {
+  content: '';
+}
+
+.bp3-icon-drive-time::before {
+  content: '';
+}
+
+.bp3-icon-duplicate::before {
+  content: '';
+}
+
+.bp3-icon-edit::before {
+  content: '✎';
+}
+
+.bp3-icon-eject::before {
+  content: '⏏';
+}
+
+.bp3-icon-endorsed::before {
+  content: '';
+}
+
+.bp3-icon-envelope::before {
+  content: '✉';
+}
+
+.bp3-icon-equals::before {
+  content: '';
+}
+
+.bp3-icon-eraser::before {
+  content: '';
+}
+
+.bp3-icon-error::before {
+  content: '';
+}
+
+.bp3-icon-euro::before {
+  content: '€';
+}
+
+.bp3-icon-exchange::before {
+  content: '';
+}
+
+.bp3-icon-exclude-row::before {
+  content: '';
+}
+
+.bp3-icon-expand-all::before {
+  content: '';
+}
+
+.bp3-icon-export::before {
+  content: '';
+}
+
+.bp3-icon-eye-off::before {
+  content: '';
+}
+
+.bp3-icon-eye-on::before {
+  content: '';
+}
+
+.bp3-icon-eye-open::before {
+  content: '';
+}
+
+.bp3-icon-fast-backward::before {
+  content: '';
+}
+
+.bp3-icon-fast-forward::before {
+  content: '';
+}
+
+.bp3-icon-feed::before {
+  content: '';
+}
+
+.bp3-icon-feed-subscribed::before {
+  content: '';
+}
+
+.bp3-icon-film::before {
+  content: '';
+}
+
+.bp3-icon-filter::before {
+  content: '';
+}
+
+.bp3-icon-filter-keep::before {
+  content: '';
+}
+
+.bp3-icon-filter-list::before {
+  content: '';
+}
+
+.bp3-icon-filter-open::before {
+  content: '';
+}
+
+.bp3-icon-filter-remove::before {
+  content: '';
+}
+
+.bp3-icon-flag::before {
+  content: '⚑';
+}
+
+.bp3-icon-flame::before {
+  content: '';
+}
+
+.bp3-icon-flash::before {
+  content: '';
+}
+
+.bp3-icon-floppy-disk::before {
+  content: '';
+}
+
+.bp3-icon-flow-branch::before {
+  content: '';
+}
+
+.bp3-icon-flow-end::before {
+  content: '';
+}
+
+.bp3-icon-flow-linear::before {
+  content: '';
+}
+
+.bp3-icon-flow-review::before {
+  content: '';
+}
+
+.bp3-icon-flow-review-branch::before {
+  content: '';
+}
+
+.bp3-icon-flows::before {
+  content: '';
+}
+
+.bp3-icon-folder-close::before {
+  content: '';
+}
+
+.bp3-icon-folder-new::before {
+  content: '';
+}
+
+.bp3-icon-folder-open::before {
+  content: '';
+}
+
+.bp3-icon-folder-shared::before {
+  content: '';
+}
+
+.bp3-icon-folder-shared-open::before {
+  content: '';
+}
+
+.bp3-icon-follower::before {
+  content: '';
+}
+
+.bp3-icon-following::before {
+  content: '';
+}
+
+.bp3-icon-font::before {
+  content: '';
+}
+
+.bp3-icon-fork::before {
+  content: '';
+}
+
+.bp3-icon-form::before {
+  content: '';
+}
+
+.bp3-icon-full-circle::before {
+  content: '';
+}
+
+.bp3-icon-full-stacked-chart::before {
+  content: '';
+}
+
+.bp3-icon-fullscreen::before {
+  content: '';
+}
+
+.bp3-icon-function::before {
+  content: '';
+}
+
+.bp3-icon-gantt-chart::before {
+  content: '';
+}
+
+.bp3-icon-geolocation::before {
+  content: '';
+}
+
+.bp3-icon-geosearch::before {
+  content: '';
+}
+
+.bp3-icon-git-branch::before {
+  content: '';
+}
+
+.bp3-icon-git-commit::before {
+  content: '';
+}
+
+.bp3-icon-git-merge::before {
+  content: '';
+}
+
+.bp3-icon-git-new-branch::before {
+  content: '';
+}
+
+.bp3-icon-git-pull::before {
+  content: '';
+}
+
+.bp3-icon-git-push::before {
+  content: '';
+}
+
+.bp3-icon-git-repo::before {
+  content: '';
+}
+
+.bp3-icon-glass::before {
+  content: '';
+}
+
+.bp3-icon-globe::before {
+  content: '';
+}
+
+.bp3-icon-globe-network::before {
+  content: '';
+}
+
+.bp3-icon-graph::before {
+  content: '';
+}
+
+.bp3-icon-graph-remove::before {
+  content: '';
+}
+
+.bp3-icon-greater-than::before {
+  content: '';
+}
+
+.bp3-icon-greater-than-or-equal-to::before {
+  content: '';
+}
+
+.bp3-icon-grid::before {
+  content: '';
+}
+
+.bp3-icon-grid-view::before {
+  content: '';
+}
+
+.bp3-icon-group-objects::before {
+  content: '';
+}
+
+.bp3-icon-grouped-bar-chart::before {
+  content: '';
+}
+
+.bp3-icon-hand::before {
+  content: '';
+}
+
+.bp3-icon-hand-down::before {
+  content: '';
+}
+
+.bp3-icon-hand-left::before {
+  content: '';
+}
+
+.bp3-icon-hand-right::before {
+  content: '';
+}
+
+.bp3-icon-hand-up::before {
+  content: '';
+}
+
+.bp3-icon-header::before {
+  content: '';
+}
+
+.bp3-icon-header-one::before {
+  content: '';
+}
+
+.bp3-icon-header-two::before {
+  content: '';
+}
+
+.bp3-icon-headset::before {
+  content: '';
+}
+
+.bp3-icon-heart::before {
+  content: '♥';
+}
+
+.bp3-icon-heart-broken::before {
+  content: '';
+}
+
+.bp3-icon-heat-grid::before {
+  content: '';
+}
+
+.bp3-icon-heatmap::before {
+  content: '';
+}
+
+.bp3-icon-help::before {
+  content: '?';
+}
+
+.bp3-icon-helper-management::before {
+  content: '';
+}
+
+.bp3-icon-highlight::before {
+  content: '';
+}
+
+.bp3-icon-history::before {
+  content: '';
+}
+
+.bp3-icon-home::before {
+  content: '⌂';
+}
+
+.bp3-icon-horizontal-bar-chart::before {
+  content: '';
+}
+
+.bp3-icon-horizontal-bar-chart-asc::before {
+  content: '';
+}
+
+.bp3-icon-horizontal-bar-chart-desc::before {
+  content: '';
+}
+
+.bp3-icon-horizontal-distribution::before {
+  content: '';
+}
+
+.bp3-icon-id-number::before {
+  content: '';
+}
+
+.bp3-icon-image-rotate-left::before {
+  content: '';
+}
+
+.bp3-icon-image-rotate-right::before {
+  content: '';
+}
+
+.bp3-icon-import::before {
+  content: '';
+}
+
+.bp3-icon-inbox::before {
+  content: '';
+}
+
+.bp3-icon-inbox-filtered::before {
+  content: '';
+}
+
+.bp3-icon-inbox-geo::before {
+  content: '';
+}
+
+.bp3-icon-inbox-search::before {
+  content: '';
+}
+
+.bp3-icon-inbox-update::before {
+  content: '';
+}
+
+.bp3-icon-info-sign::before {
+  content: 'ℹ';
+}
+
+.bp3-icon-inheritance::before {
+  content: '';
+}
+
+.bp3-icon-inner-join::before {
+  content: '';
+}
+
+.bp3-icon-insert::before {
+  content: '';
+}
+
+.bp3-icon-intersection::before {
+  content: '';
+}
+
+.bp3-icon-ip-address::before {
+  content: '';
+}
+
+.bp3-icon-issue::before {
+  content: '';
+}
+
+.bp3-icon-issue-closed::before {
+  content: '';
+}
+
+.bp3-icon-issue-new::before {
+  content: '';
+}
+
+.bp3-icon-italic::before {
+  content: '';
+}
+
+.bp3-icon-join-table::before {
+  content: '';
+}
+
+.bp3-icon-key::before {
+  content: '';
+}
+
+.bp3-icon-key-backspace::before {
+  content: '';
+}
+
+.bp3-icon-key-command::before {
+  content: '';
+}
+
+.bp3-icon-key-control::before {
+  content: '';
+}
+
+.bp3-icon-key-delete::before {
+  content: '';
+}
+
+.bp3-icon-key-enter::before {
+  content: '';
+}
+
+.bp3-icon-key-escape::before {
+  content: '';
+}
+
+.bp3-icon-key-option::before {
+  content: '';
+}
+
+.bp3-icon-key-shift::before {
+  content: '';
+}
+
+.bp3-icon-key-tab::before {
+  content: '';
+}
+
+.bp3-icon-known-vehicle::before {
+  content: '';
+}
+
+.bp3-icon-label::before {
+  content: '';
+}
+
+.bp3-icon-layer::before {
+  content: '';
+}
+
+.bp3-icon-layers::before {
+  content: '';
+}
+
+.bp3-icon-layout::before {
+  content: '';
+}
+
+.bp3-icon-layout-auto::before {
+  content: '';
+}
+
+.bp3-icon-layout-balloon::before {
+  content: '';
+}
+
+.bp3-icon-layout-circle::before {
+  content: '';
+}
+
+.bp3-icon-layout-grid::before {
+  content: '';
+}
+
+.bp3-icon-layout-group-by::before {
+  content: '';
+}
+
+.bp3-icon-layout-hierarchy::before {
+  content: '';
+}
+
+.bp3-icon-layout-linear::before {
+  content: '';
+}
+
+.bp3-icon-layout-skew-grid::before {
+  content: '';
+}
+
+.bp3-icon-layout-sorted-clusters::before {
+  content: '';
+}
+
+.bp3-icon-learning::before {
+  content: '';
+}
+
+.bp3-icon-left-join::before {
+  content: '';
+}
+
+.bp3-icon-less-than::before {
+  content: '';
+}
+
+.bp3-icon-less-than-or-equal-to::before {
+  content: '';
+}
+
+.bp3-icon-lifesaver::before {
+  content: '';
+}
+
+.bp3-icon-lightbulb::before {
+  content: '';
+}
+
+.bp3-icon-link::before {
+  content: '';
+}
+
+.bp3-icon-list::before {
+  content: '☰';
+}
+
+.bp3-icon-list-columns::before {
+  content: '';
+}
+
+.bp3-icon-list-detail-view::before {
+  content: '';
+}
+
+.bp3-icon-locate::before {
+  content: '';
+}
+
+.bp3-icon-lock::before {
+  content: '';
+}
+
+.bp3-icon-log-in::before {
+  content: '';
+}
+
+.bp3-icon-log-out::before {
+  content: '';
+}
+
+.bp3-icon-manual::before {
+  content: '';
+}
+
+.bp3-icon-manually-entered-data::before {
+  content: '';
+}
+
+.bp3-icon-map::before {
+  content: '';
+}
+
+.bp3-icon-map-create::before {
+  content: '';
+}
+
+.bp3-icon-map-marker::before {
+  content: '';
+}
+
+.bp3-icon-maximize::before {
+  content: '';
+}
+
+.bp3-icon-media::before {
+  content: '';
+}
+
+.bp3-icon-menu::before {
+  content: '';
+}
+
+.bp3-icon-menu-closed::before {
+  content: '';
+}
+
+.bp3-icon-menu-open::before {
+  content: '';
+}
+
+.bp3-icon-merge-columns::before {
+  content: '';
+}
+
+.bp3-icon-merge-links::before {
+  content: '';
+}
+
+.bp3-icon-minimize::before {
+  content: '';
+}
+
+.bp3-icon-minus::before {
+  content: '−';
+}
+
+.bp3-icon-mobile-phone::before {
+  content: '';
+}
+
+.bp3-icon-mobile-video::before {
+  content: '';
+}
+
+.bp3-icon-moon::before {
+  content: '';
+}
+
+.bp3-icon-more::before {
+  content: '';
+}
+
+.bp3-icon-mountain::before {
+  content: '';
+}
+
+.bp3-icon-move::before {
+  content: '';
+}
+
+.bp3-icon-mugshot::before {
+  content: '';
+}
+
+.bp3-icon-multi-select::before {
+  content: '';
+}
+
+.bp3-icon-music::before {
+  content: '';
+}
+
+.bp3-icon-new-drawing::before {
+  content: '';
+}
+
+.bp3-icon-new-grid-item::before {
+  content: '';
+}
+
+.bp3-icon-new-layer::before {
+  content: '';
+}
+
+.bp3-icon-new-layers::before {
+  content: '';
+}
+
+.bp3-icon-new-link::before {
+  content: '';
+}
+
+.bp3-icon-new-object::before {
+  content: '';
+}
+
+.bp3-icon-new-person::before {
+  content: '';
+}
+
+.bp3-icon-new-prescription::before {
+  content: '';
+}
+
+.bp3-icon-new-text-box::before {
+  content: '';
+}
+
+.bp3-icon-ninja::before {
+  content: '';
+}
+
+.bp3-icon-not-equal-to::before {
+  content: '';
+}
+
+.bp3-icon-notifications::before {
+  content: '';
+}
+
+.bp3-icon-notifications-updated::before {
+  content: '';
+}
+
+.bp3-icon-numbered-list::before {
+  content: '';
+}
+
+.bp3-icon-numerical::before {
+  content: '';
+}
+
+.bp3-icon-office::before {
+  content: '';
+}
+
+.bp3-icon-offline::before {
+  content: '';
+}
+
+.bp3-icon-oil-field::before {
+  content: '';
+}
+
+.bp3-icon-one-column::before {
+  content: '';
+}
+
+.bp3-icon-outdated::before {
+  content: '';
+}
+
+.bp3-icon-page-layout::before {
+  content: '';
+}
+
+.bp3-icon-panel-stats::before {
+  content: '';
+}
+
+.bp3-icon-panel-table::before {
+  content: '';
+}
+
+.bp3-icon-paperclip::before {
+  content: '';
+}
+
+.bp3-icon-paragraph::before {
+  content: '';
+}
+
+.bp3-icon-path::before {
+  content: '';
+}
+
+.bp3-icon-path-search::before {
+  content: '';
+}
+
+.bp3-icon-pause::before {
+  content: '';
+}
+
+.bp3-icon-people::before {
+  content: '';
+}
+
+.bp3-icon-percentage::before {
+  content: '';
+}
+
+.bp3-icon-person::before {
+  content: '';
+}
+
+.bp3-icon-phone::before {
+  content: '☎';
+}
+
+.bp3-icon-pie-chart::before {
+  content: '';
+}
+
+.bp3-icon-pin::before {
+  content: '';
+}
+
+.bp3-icon-pivot::before {
+  content: '';
+}
+
+.bp3-icon-pivot-table::before {
+  content: '';
+}
+
+.bp3-icon-play::before {
+  content: '';
+}
+
+.bp3-icon-plus::before {
+  content: '+';
+}
+
+.bp3-icon-polygon-filter::before {
+  content: '';
+}
+
+.bp3-icon-power::before {
+  content: '';
+}
+
+.bp3-icon-predictive-analysis::before {
+  content: '';
+}
+
+.bp3-icon-prescription::before {
+  content: '';
+}
+
+.bp3-icon-presentation::before {
+  content: '';
+}
+
+.bp3-icon-print::before {
+  content: '⎙';
+}
+
+.bp3-icon-projects::before {
+  content: '';
+}
+
+.bp3-icon-properties::before {
+  content: '';
+}
+
+.bp3-icon-property::before {
+  content: '';
+}
+
+.bp3-icon-publish-function::before {
+  content: '';
+}
+
+.bp3-icon-pulse::before {
+  content: '';
+}
+
+.bp3-icon-random::before {
+  content: '';
+}
+
+.bp3-icon-record::before {
+  content: '';
+}
+
+.bp3-icon-redo::before {
+  content: '';
+}
+
+.bp3-icon-refresh::before {
+  content: '';
+}
+
+.bp3-icon-regression-chart::before {
+  content: '';
+}
+
+.bp3-icon-remove::before {
+  content: '';
+}
+
+.bp3-icon-remove-column::before {
+  content: '';
+}
+
+.bp3-icon-remove-column-left::before {
+  content: '';
+}
+
+.bp3-icon-remove-column-right::before {
+  content: '';
+}
+
+.bp3-icon-remove-row-bottom::before {
+  content: '';
+}
+
+.bp3-icon-remove-row-top::before {
+  content: '';
+}
+
+.bp3-icon-repeat::before {
+  content: '';
+}
+
+.bp3-icon-reset::before {
+  content: '';
+}
+
+.bp3-icon-resolve::before {
+  content: '';
+}
+
+.bp3-icon-rig::before {
+  content: '';
+}
+
+.bp3-icon-right-join::before {
+  content: '';
+}
+
+.bp3-icon-ring::before {
+  content: '';
+}
+
+.bp3-icon-rotate-document::before {
+  content: '';
+}
+
+.bp3-icon-rotate-page::before {
+  content: '';
+}
+
+.bp3-icon-satellite::before {
+  content: '';
+}
+
+.bp3-icon-saved::before {
+  content: '';
+}
+
+.bp3-icon-scatter-plot::before {
+  content: '';
+}
+
+.bp3-icon-search::before {
+  content: '';
+}
+
+.bp3-icon-search-around::before {
+  content: '';
+}
+
+.bp3-icon-search-template::before {
+  content: '';
+}
+
+.bp3-icon-search-text::before {
+  content: '';
+}
+
+.bp3-icon-segmented-control::before {
+  content: '';
+}
+
+.bp3-icon-select::before {
+  content: '';
+}
+
+.bp3-icon-selection::before {
+  content: '⦿';
+}
+
+.bp3-icon-send-to::before {
+  content: '';
+}
+
+.bp3-icon-send-to-graph::before {
+  content: '';
+}
+
+.bp3-icon-send-to-map::before {
+  content: '';
+}
+
+.bp3-icon-series-add::before {
+  content: '';
+}
+
+.bp3-icon-series-configuration::before {
+  content: '';
+}
+
+.bp3-icon-series-derived::before {
+  content: '';
+}
+
+.bp3-icon-series-filtered::before {
+  content: '';
+}
+
+.bp3-icon-series-search::before {
+  content: '';
+}
+
+.bp3-icon-settings::before {
+  content: '';
+}
+
+.bp3-icon-share::before {
+  content: '';
+}
+
+.bp3-icon-shield::before {
+  content: '';
+}
+
+.bp3-icon-shop::before {
+  content: '';
+}
+
+.bp3-icon-shopping-cart::before {
+  content: '';
+}
+
+.bp3-icon-signal-search::before {
+  content: '';
+}
+
+.bp3-icon-sim-card::before {
+  content: '';
+}
+
+.bp3-icon-slash::before {
+  content: '';
+}
+
+.bp3-icon-small-cross::before {
+  content: '';
+}
+
+.bp3-icon-small-minus::before {
+  content: '';
+}
+
+.bp3-icon-small-plus::before {
+  content: '';
+}
+
+.bp3-icon-small-tick::before {
+  content: '';
+}
+
+.bp3-icon-snowflake::before {
+  content: '';
+}
+
+.bp3-icon-social-media::before {
+  content: '';
+}
+
+.bp3-icon-sort::before {
+  content: '';
+}
+
+.bp3-icon-sort-alphabetical::before {
+  content: '';
+}
+
+.bp3-icon-sort-alphabetical-desc::before {
+  content: '';
+}
+
+.bp3-icon-sort-asc::before {
+  content: '';
+}
+
+.bp3-icon-sort-desc::before {
+  content: '';
+}
+
+.bp3-icon-sort-numerical::before {
+  content: '';
+}
+
+.bp3-icon-sort-numerical-desc::before {
+  content: '';
+}
+
+.bp3-icon-split-columns::before {
+  content: '';
+}
+
+.bp3-icon-square::before {
+  content: '';
+}
+
+.bp3-icon-stacked-chart::before {
+  content: '';
+}
+
+.bp3-icon-star::before {
+  content: '★';
+}
+
+.bp3-icon-star-empty::before {
+  content: '☆';
+}
+
+.bp3-icon-step-backward::before {
+  content: '';
+}
+
+.bp3-icon-step-chart::before {
+  content: '';
+}
+
+.bp3-icon-step-forward::before {
+  content: '';
+}
+
+.bp3-icon-stop::before {
+  content: '';
+}
+
+.bp3-icon-stopwatch::before {
+  content: '';
+}
+
+.bp3-icon-strikethrough::before {
+  content: '';
+}
+
+.bp3-icon-style::before {
+  content: '';
+}
+
+.bp3-icon-swap-horizontal::before {
+  content: '';
+}
+
+.bp3-icon-swap-vertical::before {
+  content: '';
+}
+
+.bp3-icon-symbol-circle::before {
+  content: '';
+}
+
+.bp3-icon-symbol-cross::before {
+  content: '';
+}
+
+.bp3-icon-symbol-diamond::before {
+  content: '';
+}
+
+.bp3-icon-symbol-square::before {
+  content: '';
+}
+
+.bp3-icon-symbol-triangle-down::before {
+  content: '';
+}
+
+.bp3-icon-symbol-triangle-up::before {
+  content: '';
+}
+
+.bp3-icon-tag::before {
+  content: '';
+}
+
+.bp3-icon-take-action::before {
+  content: '';
+}
+
+.bp3-icon-taxi::before {
+  content: '';
+}
+
+.bp3-icon-text-highlight::before {
+  content: '';
+}
+
+.bp3-icon-th::before {
+  content: '';
+}
+
+.bp3-icon-th-derived::before {
+  content: '';
+}
+
+.bp3-icon-th-disconnect::before {
+  content: '';
+}
+
+.bp3-icon-th-filtered::before {
+  content: '';
+}
+
+.bp3-icon-th-list::before {
+  content: '';
+}
+
+.bp3-icon-thumbs-down::before {
+  content: '';
+}
+
+.bp3-icon-thumbs-up::before {
+  content: '';
+}
+
+.bp3-icon-tick::before {
+  content: '✓';
+}
+
+.bp3-icon-tick-circle::before {
+  content: '';
+}
+
+.bp3-icon-time::before {
+  content: '⏲';
+}
+
+.bp3-icon-timeline-area-chart::before {
+  content: '';
+}
+
+.bp3-icon-timeline-bar-chart::before {
+  content: '';
+}
+
+.bp3-icon-timeline-events::before {
+  content: '';
+}
+
+.bp3-icon-timeline-line-chart::before {
+  content: '';
+}
+
+.bp3-icon-tint::before {
+  content: '';
+}
+
+.bp3-icon-torch::before {
+  content: '';
+}
+
+.bp3-icon-tractor::before {
+  content: '';
+}
+
+.bp3-icon-train::before {
+  content: '';
+}
+
+.bp3-icon-translate::before {
+  content: '';
+}
+
+.bp3-icon-trash::before {
+  content: '';
+}
+
+.bp3-icon-tree::before {
+  content: '';
+}
+
+.bp3-icon-trending-down::before {
+  content: '';
+}
+
+.bp3-icon-trending-up::before {
+  content: '';
+}
+
+.bp3-icon-truck::before {
+  content: '';
+}
+
+.bp3-icon-two-columns::before {
+  content: '';
+}
+
+.bp3-icon-unarchive::before {
+  content: '';
+}
+
+.bp3-icon-underline::before {
+  content: '⎁';
+}
+
+.bp3-icon-undo::before {
+  content: '⎌';
+}
+
+.bp3-icon-ungroup-objects::before {
+  content: '';
+}
+
+.bp3-icon-unknown-vehicle::before {
+  content: '';
+}
+
+.bp3-icon-unlock::before {
+  content: '';
+}
+
+.bp3-icon-unpin::before {
+  content: '';
+}
+
+.bp3-icon-unresolve::before {
+  content: '';
+}
+
+.bp3-icon-updated::before {
+  content: '';
+}
+
+.bp3-icon-upload::before {
+  content: '';
+}
+
+.bp3-icon-user::before {
+  content: '';
+}
+
+.bp3-icon-variable::before {
+  content: '';
+}
+
+.bp3-icon-vertical-bar-chart-asc::before {
+  content: '';
+}
+
+.bp3-icon-vertical-bar-chart-desc::before {
+  content: '';
+}
+
+.bp3-icon-vertical-distribution::before {
+  content: '';
+}
+
+.bp3-icon-video::before {
+  content: '';
+}
+
+.bp3-icon-volume-down::before {
+  content: '';
+}
+
+.bp3-icon-volume-off::before {
+  content: '';
+}
+
+.bp3-icon-volume-up::before {
+  content: '';
+}
+
+.bp3-icon-walk::before {
+  content: '';
+}
+
+.bp3-icon-warning-sign::before {
+  content: '';
+}
+
+.bp3-icon-waterfall-chart::before {
+  content: '';
+}
+
+.bp3-icon-widget::before {
+  content: '';
+}
+
+.bp3-icon-widget-button::before {
+  content: '';
+}
+
+.bp3-icon-widget-footer::before {
+  content: '';
+}
+
+.bp3-icon-widget-header::before {
+  content: '';
+}
+
+.bp3-icon-wrench::before {
+  content: '';
+}
+
+.bp3-icon-zoom-in::before {
+  content: '';
+}
+
+.bp3-icon-zoom-out::before {
+  content: '';
+}
+
+.bp3-icon-zoom-to-fit::before {
+  content: '';
+}
+.bp3-submenu > .bp3-popover-wrapper {
+  display: block;
+}
+
+.bp3-submenu .bp3-popover-target {
+  display: block;
+}
+
+.bp3-submenu.bp3-popover {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  padding: 0 5px;
+}
+.bp3-submenu.bp3-popover > .bp3-popover-content {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
+    0 8px 24px rgba(16, 22, 26, 0.2);
+}
+.bp3-dark .bp3-submenu.bp3-popover,
+.bp3-submenu.bp3-popover.bp3-dark {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-dark .bp3-submenu.bp3-popover > .bp3-popover-content,
+.bp3-submenu.bp3-popover.bp3-dark > .bp3-popover-content {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4),
+    0 8px 24px rgba(16, 22, 26, 0.4);
+}
+.bp3-menu {
+  margin: 0;
+  border-radius: 3px;
+  background: #ffffff;
+  min-width: 180px;
+  padding: 5px;
+  list-style: none;
+  text-align: left;
+  color: #182026;
+}
+
+.bp3-menu-divider {
+  display: block;
+  margin: 5px;
+  border-top: 1px solid rgba(16, 22, 26, 0.15);
+}
+.bp3-dark .bp3-menu-divider {
+  border-top-color: rgba(255, 255, 255, 0.15);
+}
+
+.bp3-menu-item {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  border-radius: 2px;
+  padding: 5px 7px;
+  text-decoration: none;
+  line-height: 20px;
+  color: inherit;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-menu-item > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-menu-item > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-menu-item::before,
+.bp3-menu-item > * {
+  margin-right: 7px;
+}
+.bp3-menu-item:empty::before,
+.bp3-menu-item > :last-child {
+  margin-right: 0;
+}
+.bp3-menu-item > .bp3-fill {
+  word-break: break-word;
+}
+.bp3-menu-item:hover,
+.bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item {
+  background-color: rgba(167, 182, 194, 0.3);
+  cursor: pointer;
+  text-decoration: none;
+}
+.bp3-menu-item.bp3-disabled {
+  background-color: inherit;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-dark .bp3-menu-item {
+  color: inherit;
+}
+.bp3-dark .bp3-menu-item:hover,
+.bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item,
+.bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-menu-item {
+  background-color: rgba(138, 155, 168, 0.15);
+  color: inherit;
+}
+.bp3-dark .bp3-menu-item.bp3-disabled {
+  background-color: inherit;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-menu-item.bp3-intent-primary {
+  color: #106ba3;
+}
+.bp3-menu-item.bp3-intent-primary .bp3-icon {
+  color: inherit;
+}
+.bp3-menu-item.bp3-intent-primary::before,
+.bp3-menu-item.bp3-intent-primary::after,
+.bp3-menu-item.bp3-intent-primary .bp3-menu-item-label {
+  color: #106ba3;
+}
+.bp3-menu-item.bp3-intent-primary:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item,
+.bp3-menu-item.bp3-intent-primary.bp3-active {
+  background-color: #137cbd;
+}
+.bp3-menu-item.bp3-intent-primary:active {
+  background-color: #106ba3;
+}
+.bp3-menu-item.bp3-intent-primary:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item,
+.bp3-menu-item.bp3-intent-primary:hover::before,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item::before,
+.bp3-menu-item.bp3-intent-primary:hover::after,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item::after,
+.bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-primary:active,
+.bp3-menu-item.bp3-intent-primary:active::before,
+.bp3-menu-item.bp3-intent-primary:active::after,
+.bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-primary.bp3-active,
+.bp3-menu-item.bp3-intent-primary.bp3-active::before,
+.bp3-menu-item.bp3-intent-primary.bp3-active::after,
+.bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
+.bp3-menu-item.bp3-intent-success {
+  color: #0d8050;
+}
+.bp3-menu-item.bp3-intent-success .bp3-icon {
+  color: inherit;
+}
+.bp3-menu-item.bp3-intent-success::before,
+.bp3-menu-item.bp3-intent-success::after,
+.bp3-menu-item.bp3-intent-success .bp3-menu-item-label {
+  color: #0d8050;
+}
+.bp3-menu-item.bp3-intent-success:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item,
+.bp3-menu-item.bp3-intent-success.bp3-active {
+  background-color: #0f9960;
+}
+.bp3-menu-item.bp3-intent-success:active {
+  background-color: #0d8050;
+}
+.bp3-menu-item.bp3-intent-success:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item,
+.bp3-menu-item.bp3-intent-success:hover::before,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item::before,
+.bp3-menu-item.bp3-intent-success:hover::after,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item::after,
+.bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-success:active,
+.bp3-menu-item.bp3-intent-success:active::before,
+.bp3-menu-item.bp3-intent-success:active::after,
+.bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-success.bp3-active,
+.bp3-menu-item.bp3-intent-success.bp3-active::before,
+.bp3-menu-item.bp3-intent-success.bp3-active::after,
+.bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
+.bp3-menu-item.bp3-intent-warning {
+  color: #bf7326;
+}
+.bp3-menu-item.bp3-intent-warning .bp3-icon {
+  color: inherit;
+}
+.bp3-menu-item.bp3-intent-warning::before,
+.bp3-menu-item.bp3-intent-warning::after,
+.bp3-menu-item.bp3-intent-warning .bp3-menu-item-label {
+  color: #bf7326;
+}
+.bp3-menu-item.bp3-intent-warning:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item,
+.bp3-menu-item.bp3-intent-warning.bp3-active {
+  background-color: #d9822b;
+}
+.bp3-menu-item.bp3-intent-warning:active {
+  background-color: #bf7326;
+}
+.bp3-menu-item.bp3-intent-warning:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item,
+.bp3-menu-item.bp3-intent-warning:hover::before,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item::before,
+.bp3-menu-item.bp3-intent-warning:hover::after,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item::after,
+.bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-warning:active,
+.bp3-menu-item.bp3-intent-warning:active::before,
+.bp3-menu-item.bp3-intent-warning:active::after,
+.bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-warning.bp3-active,
+.bp3-menu-item.bp3-intent-warning.bp3-active::before,
+.bp3-menu-item.bp3-intent-warning.bp3-active::after,
+.bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
+.bp3-menu-item.bp3-intent-danger {
+  color: #c23030;
+}
+.bp3-menu-item.bp3-intent-danger .bp3-icon {
+  color: inherit;
+}
+.bp3-menu-item.bp3-intent-danger::before,
+.bp3-menu-item.bp3-intent-danger::after,
+.bp3-menu-item.bp3-intent-danger .bp3-menu-item-label {
+  color: #c23030;
+}
+.bp3-menu-item.bp3-intent-danger:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item,
+.bp3-menu-item.bp3-intent-danger.bp3-active {
+  background-color: #db3737;
+}
+.bp3-menu-item.bp3-intent-danger:active {
+  background-color: #c23030;
+}
+.bp3-menu-item.bp3-intent-danger:hover,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item,
+.bp3-menu-item.bp3-intent-danger:hover::before,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item::before,
+.bp3-menu-item.bp3-intent-danger:hover::after,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item::after,
+.bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-danger:active,
+.bp3-menu-item.bp3-intent-danger:active::before,
+.bp3-menu-item.bp3-intent-danger:active::after,
+.bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label,
+.bp3-menu-item.bp3-intent-danger.bp3-active,
+.bp3-menu-item.bp3-intent-danger.bp3-active::before,
+.bp3-menu-item.bp3-intent-danger.bp3-active::after,
+.bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
+.bp3-menu-item::before {
+  line-height: 1;
+  font-family: 'Icons16', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin-right: 7px;
+}
+.bp3-menu-item::before,
+.bp3-menu-item > .bp3-icon {
+  margin-top: 2px;
+  color: #5c7080;
+}
+.bp3-menu-item .bp3-menu-item-label {
+  color: #5c7080;
+}
+.bp3-menu-item:hover,
+.bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item {
+  color: inherit;
+}
+.bp3-menu-item.bp3-active,
+.bp3-menu-item:active {
+  background-color: rgba(115, 134, 148, 0.3);
+}
+.bp3-menu-item.bp3-disabled {
+  outline: none !important;
+  background-color: inherit !important;
+  cursor: not-allowed !important;
+  color: rgba(92, 112, 128, 0.6) !important;
+}
+.bp3-menu-item.bp3-disabled::before,
+.bp3-menu-item.bp3-disabled > .bp3-icon,
+.bp3-menu-item.bp3-disabled .bp3-menu-item-label {
+  color: rgba(92, 112, 128, 0.6) !important;
+}
+.bp3-large .bp3-menu-item {
+  padding: 9px 7px;
+  line-height: 22px;
+  font-size: 16px;
+}
+.bp3-large .bp3-menu-item .bp3-icon {
+  margin-top: 3px;
+}
+.bp3-large .bp3-menu-item::before {
+  line-height: 1;
+  font-family: 'Icons20', sans-serif;
+  font-size: 20px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin-top: 1px;
+  margin-right: 10px;
+}
+
+button.bp3-menu-item {
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+.bp3-menu-header {
+  display: block;
+  margin: 5px;
+  border-top: 1px solid rgba(16, 22, 26, 0.15);
+  cursor: default;
+  padding-left: 2px;
+}
+.bp3-dark .bp3-menu-header {
+  border-top-color: rgba(255, 255, 255, 0.15);
+}
+.bp3-menu-header:first-of-type {
+  border-top: none;
+}
+.bp3-menu-header > h6 {
+  color: #182026;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  margin: 0;
+  padding: 10px 7px 0 1px;
+  line-height: 17px;
+}
+.bp3-dark .bp3-menu-header > h6 {
+  color: #f5f8fa;
+}
+.bp3-menu-header:first-of-type > h6 {
+  padding-top: 0;
+}
+.bp3-large .bp3-menu-header > h6 {
+  padding-top: 15px;
+  padding-bottom: 5px;
+  font-size: 18px;
+}
+.bp3-large .bp3-menu-header:first-of-type > h6 {
+  padding-top: 0;
+}
+
+.bp3-dark .bp3-menu {
+  background: #30404d;
+  color: #f5f8fa;
+}
+
+.bp3-dark .bp3-menu-item.bp3-intent-primary {
+  color: #48aff0;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-icon {
+  color: inherit;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-primary::before,
+.bp3-dark .bp3-menu-item.bp3-intent-primary::after,
+.bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label {
+  color: #48aff0;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-primary:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active {
+  background-color: #137cbd;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-primary:active {
+  background-color: #106ba3;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-primary:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-primary:hover::before,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item::before,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item::before,
+.bp3-dark .bp3-menu-item.bp3-intent-primary:hover::after,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item::after,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item::after,
+.bp3-dark .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-primary.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-primary:active,
+.bp3-dark .bp3-menu-item.bp3-intent-primary:active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-primary:active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active,
+.bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
+
+.bp3-dark .bp3-menu-item.bp3-intent-success {
+  color: #3dcc91;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-success .bp3-icon {
+  color: inherit;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-success::before,
+.bp3-dark .bp3-menu-item.bp3-intent-success::after,
+.bp3-dark .bp3-menu-item.bp3-intent-success .bp3-menu-item-label {
+  color: #3dcc91;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-success:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active {
+  background-color: #0f9960;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-success:active {
+  background-color: #0d8050;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-success:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-success:hover::before,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item::before,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item::before,
+.bp3-dark .bp3-menu-item.bp3-intent-success:hover::after,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item::after,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item::after,
+.bp3-dark .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-success.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-success:active,
+.bp3-dark .bp3-menu-item.bp3-intent-success:active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-success:active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active,
+.bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
+
+.bp3-dark .bp3-menu-item.bp3-intent-warning {
+  color: #ffb366;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-icon {
+  color: inherit;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-warning::before,
+.bp3-dark .bp3-menu-item.bp3-intent-warning::after,
+.bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label {
+  color: #ffb366;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-warning:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active {
+  background-color: #d9822b;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-warning:active {
+  background-color: #bf7326;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-warning:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-warning:hover::before,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item::before,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item::before,
+.bp3-dark .bp3-menu-item.bp3-intent-warning:hover::after,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item::after,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item::after,
+.bp3-dark .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-warning.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-warning:active,
+.bp3-dark .bp3-menu-item.bp3-intent-warning:active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-warning:active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active,
+.bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
+
+.bp3-dark .bp3-menu-item.bp3-intent-danger {
+  color: #ff7373;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-icon {
+  color: inherit;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-danger::before,
+.bp3-dark .bp3-menu-item.bp3-intent-danger::after,
+.bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label {
+  color: #ff7373;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-danger:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active {
+  background-color: #db3737;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-danger:active {
+  background-color: #c23030;
+}
+.bp3-dark .bp3-menu-item.bp3-intent-danger:hover,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item,
+.bp3-dark .bp3-menu-item.bp3-intent-danger:hover::before,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item::before,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item::before,
+.bp3-dark .bp3-menu-item.bp3-intent-danger:hover::after,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item::after,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item::after,
+.bp3-dark .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
+.bp3-dark
+  .bp3-submenu
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-submenu
+  .bp3-dark
+  .bp3-popover-target.bp3-popover-open
+  > .bp3-intent-danger.bp3-menu-item
+  .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-danger:active,
+.bp3-dark .bp3-menu-item.bp3-intent-danger:active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-danger:active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label,
+.bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active,
+.bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::before,
+.bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::after,
+.bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label {
+  color: #ffffff;
+}
 
 .bp3-dark .bp3-menu-item::before,
-.bp3-dark .bp3-menu-item > .bp3-icon{
-  color:#a7b6c2; }
+.bp3-dark .bp3-menu-item > .bp3-icon {
+  color: #a7b6c2;
+}
 
-.bp3-dark .bp3-menu-item .bp3-menu-item-label{
-  color:#a7b6c2; }
+.bp3-dark .bp3-menu-item .bp3-menu-item-label {
+  color: #a7b6c2;
+}
 
-.bp3-dark .bp3-menu-item.bp3-active, .bp3-dark .bp3-menu-item:active{
-  background-color:rgba(138, 155, 168, 0.3); }
+.bp3-dark .bp3-menu-item.bp3-active,
+.bp3-dark .bp3-menu-item:active {
+  background-color: rgba(138, 155, 168, 0.3);
+}
 
-.bp3-dark .bp3-menu-item.bp3-disabled{
-  color:rgba(167, 182, 194, 0.6) !important; }
-  .bp3-dark .bp3-menu-item.bp3-disabled::before,
-  .bp3-dark .bp3-menu-item.bp3-disabled > .bp3-icon,
-  .bp3-dark .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
-    color:rgba(167, 182, 194, 0.6) !important; }
+.bp3-dark .bp3-menu-item.bp3-disabled {
+  color: rgba(167, 182, 194, 0.6) !important;
+}
+.bp3-dark .bp3-menu-item.bp3-disabled::before,
+.bp3-dark .bp3-menu-item.bp3-disabled > .bp3-icon,
+.bp3-dark .bp3-menu-item.bp3-disabled .bp3-menu-item-label {
+  color: rgba(167, 182, 194, 0.6) !important;
+}
 
 .bp3-dark .bp3-menu-divider,
-.bp3-dark .bp3-menu-header{
-  border-color:rgba(255, 255, 255, 0.15); }
+.bp3-dark .bp3-menu-header {
+  border-color: rgba(255, 255, 255, 0.15);
+}
 
-.bp3-dark .bp3-menu-header > h6{
-  color:#f5f8fa; }
+.bp3-dark .bp3-menu-header > h6 {
+  color: #f5f8fa;
+}
 
-.bp3-label .bp3-menu{
-  margin-top:5px; }
-.bp3-navbar{
-  position:relative;
-  z-index:10;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  width:100%;
-  height:50px;
-  padding:0 15px; }
-  .bp3-navbar.bp3-dark,
-  .bp3-dark .bp3-navbar{
-    background-color:#394b59; }
-  .bp3-navbar.bp3-dark{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
-  .bp3-dark .bp3-navbar{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
-  .bp3-navbar.bp3-fixed-top{
-    position:fixed;
-    top:0;
-    right:0;
-    left:0; }
+.bp3-label .bp3-menu {
+  margin-top: 5px;
+}
+.bp3-navbar {
+  position: relative;
+  z-index: 10;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  background-color: #ffffff;
+  width: 100%;
+  height: 50px;
+  padding: 0 15px;
+}
+.bp3-navbar.bp3-dark,
+.bp3-dark .bp3-navbar {
+  background-color: #394b59;
+}
+.bp3-navbar.bp3-dark {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-navbar {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0),
+    0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-navbar.bp3-fixed-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+}
 
-.bp3-navbar-heading{
-  margin-right:15px;
-  font-size:16px; }
+.bp3-navbar-heading {
+  margin-right: 15px;
+  font-size: 16px;
+}
 
-.bp3-navbar-group{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  height:50px; }
-  .bp3-navbar-group.bp3-align-left{
-    float:left; }
-  .bp3-navbar-group.bp3-align-right{
-    float:right; }
+.bp3-navbar-group {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 50px;
+}
+.bp3-navbar-group.bp3-align-left {
+  float: left;
+}
+.bp3-navbar-group.bp3-align-right {
+  float: right;
+}
 
-.bp3-navbar-divider{
-  margin:0 10px;
-  border-left:1px solid rgba(16, 22, 26, 0.15);
-  height:20px; }
-  .bp3-dark .bp3-navbar-divider{
-    border-left-color:rgba(255, 255, 255, 0.15); }
-.bp3-non-ideal-state{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:vertical;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:column;
-          flex-direction:column;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
-  width:100%;
-  height:100%;
-  text-align:center; }
-  .bp3-non-ideal-state > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-non-ideal-state > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-non-ideal-state::before,
-  .bp3-non-ideal-state > *{
-    margin-bottom:20px; }
-  .bp3-non-ideal-state:empty::before,
-  .bp3-non-ideal-state > :last-child{
-    margin-bottom:0; }
-  .bp3-non-ideal-state > *{
-    max-width:400px; }
+.bp3-navbar-divider {
+  margin: 0 10px;
+  border-left: 1px solid rgba(16, 22, 26, 0.15);
+  height: 20px;
+}
+.bp3-dark .bp3-navbar-divider {
+  border-left-color: rgba(255, 255, 255, 0.15);
+}
+.bp3-non-ideal-state {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+}
+.bp3-non-ideal-state > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-non-ideal-state > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-non-ideal-state::before,
+.bp3-non-ideal-state > * {
+  margin-bottom: 20px;
+}
+.bp3-non-ideal-state:empty::before,
+.bp3-non-ideal-state > :last-child {
+  margin-bottom: 0;
+}
+.bp3-non-ideal-state > * {
+  max-width: 400px;
+}
 
-.bp3-non-ideal-state-visual{
-  color:rgba(92, 112, 128, 0.6);
-  font-size:60px; }
-  .bp3-dark .bp3-non-ideal-state-visual{
-    color:rgba(167, 182, 194, 0.6); }
+.bp3-non-ideal-state-visual {
+  color: rgba(92, 112, 128, 0.6);
+  font-size: 60px;
+}
+.bp3-dark .bp3-non-ideal-state-visual {
+  color: rgba(167, 182, 194, 0.6);
+}
 
-.bp3-overflow-list{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -ms-flex-wrap:nowrap;
-      flex-wrap:nowrap;
-  min-width:0; }
+.bp3-overflow-list {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  min-width: 0;
+}
 
-.bp3-overflow-list-spacer{
-  -ms-flex-negative:1;
-      flex-shrink:1;
-  width:1px; }
+.bp3-overflow-list-spacer {
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  width: 1px;
+}
 
-body.bp3-overlay-open{
-  overflow:hidden; }
+body.bp3-overlay-open {
+  overflow: hidden;
+}
 
-.bp3-overlay{
-  position:static;
-  top:0;
-  right:0;
-  bottom:0;
-  left:0;
-  z-index:20; }
-  .bp3-overlay:not(.bp3-overlay-open){
-    pointer-events:none; }
-  .bp3-overlay.bp3-overlay-container{
-    position:fixed;
-    overflow:hidden; }
-    .bp3-overlay.bp3-overlay-container.bp3-overlay-inline{
-      position:absolute; }
-  .bp3-overlay.bp3-overlay-scroll-container{
-    position:fixed;
-    overflow:auto; }
-    .bp3-overlay.bp3-overlay-scroll-container.bp3-overlay-inline{
-      position:absolute; }
-  .bp3-overlay.bp3-overlay-inline{
-    display:inline;
-    overflow:visible; }
+.bp3-overlay {
+  position: static;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 20;
+}
+.bp3-overlay:not(.bp3-overlay-open) {
+  pointer-events: none;
+}
+.bp3-overlay.bp3-overlay-container {
+  position: fixed;
+  overflow: hidden;
+}
+.bp3-overlay.bp3-overlay-container.bp3-overlay-inline {
+  position: absolute;
+}
+.bp3-overlay.bp3-overlay-scroll-container {
+  position: fixed;
+  overflow: auto;
+}
+.bp3-overlay.bp3-overlay-scroll-container.bp3-overlay-inline {
+  position: absolute;
+}
+.bp3-overlay.bp3-overlay-inline {
+  display: inline;
+  overflow: visible;
+}
 
-.bp3-overlay-content{
-  position:fixed;
-  z-index:20; }
-  .bp3-overlay-inline .bp3-overlay-content,
-  .bp3-overlay-scroll-container .bp3-overlay-content{
-    position:absolute; }
+.bp3-overlay-content {
+  position: fixed;
+  z-index: 20;
+}
+.bp3-overlay-inline .bp3-overlay-content,
+.bp3-overlay-scroll-container .bp3-overlay-content {
+  position: absolute;
+}
 
-.bp3-overlay-backdrop{
-  position:fixed;
-  top:0;
-  right:0;
-  bottom:0;
-  left:0;
-  opacity:1;
-  z-index:20;
-  background-color:rgba(16, 22, 26, 0.7);
-  overflow:auto;
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-overlay-backdrop.bp3-overlay-enter, .bp3-overlay-backdrop.bp3-overlay-appear{
-    opacity:0; }
-  .bp3-overlay-backdrop.bp3-overlay-enter-active, .bp3-overlay-backdrop.bp3-overlay-appear-active{
-    opacity:1;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-overlay-backdrop.bp3-overlay-exit{
-    opacity:1; }
-  .bp3-overlay-backdrop.bp3-overlay-exit-active{
-    opacity:0;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-overlay-backdrop:focus{
-    outline:none; }
-  .bp3-overlay-inline .bp3-overlay-backdrop{
-    position:absolute; }
-.bp3-panel-stack{
-  position:relative;
-  overflow:hidden; }
+.bp3-overlay-backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  opacity: 1;
+  z-index: 20;
+  background-color: rgba(16, 22, 26, 0.7);
+  overflow: auto;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-overlay-backdrop.bp3-overlay-enter,
+.bp3-overlay-backdrop.bp3-overlay-appear {
+  opacity: 0;
+}
+.bp3-overlay-backdrop.bp3-overlay-enter-active,
+.bp3-overlay-backdrop.bp3-overlay-appear-active {
+  opacity: 1;
+  -webkit-transition-property: opacity;
+  transition-property: opacity;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-overlay-backdrop.bp3-overlay-exit {
+  opacity: 1;
+}
+.bp3-overlay-backdrop.bp3-overlay-exit-active {
+  opacity: 0;
+  -webkit-transition-property: opacity;
+  transition-property: opacity;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-overlay-backdrop:focus {
+  outline: none;
+}
+.bp3-overlay-inline .bp3-overlay-backdrop {
+  position: absolute;
+}
+.bp3-panel-stack {
+  position: relative;
+  overflow: hidden;
+}
 
-.bp3-panel-stack-header{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -ms-flex-negative:0;
-      flex-shrink:0;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  z-index:1;
-  -webkit-box-shadow:0 1px rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px rgba(16, 22, 26, 0.15);
-  height:30px; }
-  .bp3-dark .bp3-panel-stack-header{
-    -webkit-box-shadow:0 1px rgba(255, 255, 255, 0.15);
-            box-shadow:0 1px rgba(255, 255, 255, 0.15); }
-  .bp3-panel-stack-header > span{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    -webkit-box-flex:1;
-        -ms-flex:1;
-            flex:1;
-    -webkit-box-align:stretch;
-        -ms-flex-align:stretch;
-            align-items:stretch; }
-  .bp3-panel-stack-header .bp3-heading{
-    margin:0 5px; }
+.bp3-panel-stack-header {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: 1;
+  -webkit-box-shadow: 0 1px rgba(16, 22, 26, 0.15);
+  box-shadow: 0 1px rgba(16, 22, 26, 0.15);
+  height: 30px;
+}
+.bp3-dark .bp3-panel-stack-header {
+  -webkit-box-shadow: 0 1px rgba(255, 255, 255, 0.15);
+  box-shadow: 0 1px rgba(255, 255, 255, 0.15);
+}
+.bp3-panel-stack-header > span {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+.bp3-panel-stack-header .bp3-heading {
+  margin: 0 5px;
+}
 
-.bp3-button.bp3-panel-stack-header-back{
-  margin-left:5px;
-  padding-left:0;
-  white-space:nowrap; }
-  .bp3-button.bp3-panel-stack-header-back .bp3-icon{
-    margin:0 2px; }
+.bp3-button.bp3-panel-stack-header-back {
+  margin-left: 5px;
+  padding-left: 0;
+  white-space: nowrap;
+}
+.bp3-button.bp3-panel-stack-header-back .bp3-icon {
+  margin: 0 2px;
+}
 
-.bp3-panel-stack-view{
-  position:absolute;
-  top:0;
-  right:0;
-  bottom:0;
-  left:0;
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:vertical;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:column;
-          flex-direction:column;
-  margin-right:-1px;
-  border-right:1px solid rgba(16, 22, 26, 0.15);
-  background-color:#ffffff;
-  overflow-y:auto; }
-  .bp3-dark .bp3-panel-stack-view{
-    background-color:#30404d; }
+.bp3-panel-stack-view {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-right: -1px;
+  border-right: 1px solid rgba(16, 22, 26, 0.15);
+  background-color: #ffffff;
+  overflow-y: auto;
+}
+.bp3-dark .bp3-panel-stack-view {
+  background-color: #30404d;
+}
 
-.bp3-panel-stack-push .bp3-panel-stack-enter, .bp3-panel-stack-push .bp3-panel-stack-appear{
-  -webkit-transform:translateX(100%);
-          transform:translateX(100%);
-  opacity:0; }
+.bp3-panel-stack-push .bp3-panel-stack-enter,
+.bp3-panel-stack-push .bp3-panel-stack-appear {
+  -webkit-transform: translateX(100%);
+  transform: translateX(100%);
+  opacity: 0;
+}
 
-.bp3-panel-stack-push .bp3-panel-stack-enter-active, .bp3-panel-stack-push .bp3-panel-stack-appear-active{
-  -webkit-transform:translate(0%);
-          transform:translate(0%);
-  opacity:1;
-  -webkit-transition-property:opacity, -webkit-transform;
-  transition-property:opacity, -webkit-transform;
-  transition-property:transform, opacity;
-  transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
-  -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+.bp3-panel-stack-push .bp3-panel-stack-enter-active,
+.bp3-panel-stack-push .bp3-panel-stack-appear-active {
+  -webkit-transform: translate(0%);
+  transform: translate(0%);
+  opacity: 1;
+  -webkit-transition-property: opacity, -webkit-transform;
+  transition-property: opacity, -webkit-transform;
+  transition-property: transform, opacity;
+  transition-property: transform, opacity, -webkit-transform;
+  -webkit-transition-duration: 400ms;
+  transition-duration: 400ms;
+  -webkit-transition-timing-function: ease;
+  transition-timing-function: ease;
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
 
-.bp3-panel-stack-push .bp3-panel-stack-exit{
-  -webkit-transform:translate(0%);
-          transform:translate(0%);
-  opacity:1; }
+.bp3-panel-stack-push .bp3-panel-stack-exit {
+  -webkit-transform: translate(0%);
+  transform: translate(0%);
+  opacity: 1;
+}
 
-.bp3-panel-stack-push .bp3-panel-stack-exit-active{
-  -webkit-transform:translateX(-50%);
-          transform:translateX(-50%);
-  opacity:0;
-  -webkit-transition-property:opacity, -webkit-transform;
-  transition-property:opacity, -webkit-transform;
-  transition-property:transform, opacity;
-  transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
-  -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+.bp3-panel-stack-push .bp3-panel-stack-exit-active {
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+  opacity: 0;
+  -webkit-transition-property: opacity, -webkit-transform;
+  transition-property: opacity, -webkit-transform;
+  transition-property: transform, opacity;
+  transition-property: transform, opacity, -webkit-transform;
+  -webkit-transition-duration: 400ms;
+  transition-duration: 400ms;
+  -webkit-transition-timing-function: ease;
+  transition-timing-function: ease;
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
 
-.bp3-panel-stack-pop .bp3-panel-stack-enter, .bp3-panel-stack-pop .bp3-panel-stack-appear{
-  -webkit-transform:translateX(-50%);
-          transform:translateX(-50%);
-  opacity:0; }
+.bp3-panel-stack-pop .bp3-panel-stack-enter,
+.bp3-panel-stack-pop .bp3-panel-stack-appear {
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+  opacity: 0;
+}
 
-.bp3-panel-stack-pop .bp3-panel-stack-enter-active, .bp3-panel-stack-pop .bp3-panel-stack-appear-active{
-  -webkit-transform:translate(0%);
-          transform:translate(0%);
-  opacity:1;
-  -webkit-transition-property:opacity, -webkit-transform;
-  transition-property:opacity, -webkit-transform;
-  transition-property:transform, opacity;
-  transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
-  -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+.bp3-panel-stack-pop .bp3-panel-stack-enter-active,
+.bp3-panel-stack-pop .bp3-panel-stack-appear-active {
+  -webkit-transform: translate(0%);
+  transform: translate(0%);
+  opacity: 1;
+  -webkit-transition-property: opacity, -webkit-transform;
+  transition-property: opacity, -webkit-transform;
+  transition-property: transform, opacity;
+  transition-property: transform, opacity, -webkit-transform;
+  -webkit-transition-duration: 400ms;
+  transition-duration: 400ms;
+  -webkit-transition-timing-function: ease;
+  transition-timing-function: ease;
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
 
-.bp3-panel-stack-pop .bp3-panel-stack-exit{
-  -webkit-transform:translate(0%);
-          transform:translate(0%);
-  opacity:1; }
+.bp3-panel-stack-pop .bp3-panel-stack-exit {
+  -webkit-transform: translate(0%);
+  transform: translate(0%);
+  opacity: 1;
+}
 
-.bp3-panel-stack-pop .bp3-panel-stack-exit-active{
-  -webkit-transform:translateX(100%);
-          transform:translateX(100%);
-  opacity:0;
-  -webkit-transition-property:opacity, -webkit-transform;
-  transition-property:opacity, -webkit-transform;
-  transition-property:transform, opacity;
-  transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
-  -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
-.bp3-popover{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-  -webkit-transform:scale(1);
-          transform:scale(1);
-  display:inline-block;
-  z-index:20;
-  border-radius:3px; }
-  .bp3-popover .bp3-popover-arrow{
-    position:absolute;
-    width:30px;
-    height:30px; }
-    .bp3-popover .bp3-popover-arrow::before{
-      margin:5px;
-      width:20px;
-      height:20px; }
-  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover{
-    margin-top:-17px;
-    margin-bottom:17px; }
-    .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow{
-      bottom:-11px; }
-      .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(-90deg);
-                transform:rotate(-90deg); }
-  .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-popover{
-    margin-left:17px; }
-    .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-popover > .bp3-popover-arrow{
-      left:-11px; }
-      .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-popover > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(0);
-                transform:rotate(0); }
-  .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-popover{
-    margin-top:17px; }
-    .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-popover > .bp3-popover-arrow{
-      top:-11px; }
-      .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-popover > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(90deg);
-                transform:rotate(90deg); }
-  .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover{
-    margin-right:17px;
-    margin-left:-17px; }
-    .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow{
-      right:-11px; }
-      .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(180deg);
-                transform:rotate(180deg); }
-  .bp3-tether-element-attached-middle > .bp3-popover > .bp3-popover-arrow{
-    top:50%;
-    -webkit-transform:translateY(-50%);
-            transform:translateY(-50%); }
-  .bp3-tether-element-attached-center > .bp3-popover > .bp3-popover-arrow{
-    right:50%;
-    -webkit-transform:translateX(50%);
-            transform:translateX(50%); }
-  .bp3-tether-element-attached-top.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow{
-    top:-0.3934px; }
-  .bp3-tether-element-attached-right.bp3-tether-target-attached-right > .bp3-popover > .bp3-popover-arrow{
-    right:-0.3934px; }
-  .bp3-tether-element-attached-left.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow{
-    left:-0.3934px; }
-  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-bottom > .bp3-popover > .bp3-popover-arrow{
-    bottom:-0.3934px; }
-  .bp3-tether-element-attached-top.bp3-tether-element-attached-left > .bp3-popover{
-    -webkit-transform-origin:top left;
-            transform-origin:top left; }
-  .bp3-tether-element-attached-top.bp3-tether-element-attached-center > .bp3-popover{
-    -webkit-transform-origin:top center;
-            transform-origin:top center; }
-  .bp3-tether-element-attached-top.bp3-tether-element-attached-right > .bp3-popover{
-    -webkit-transform-origin:top right;
-            transform-origin:top right; }
-  .bp3-tether-element-attached-middle.bp3-tether-element-attached-left > .bp3-popover{
-    -webkit-transform-origin:center left;
-            transform-origin:center left; }
-  .bp3-tether-element-attached-middle.bp3-tether-element-attached-center > .bp3-popover{
-    -webkit-transform-origin:center center;
-            transform-origin:center center; }
-  .bp3-tether-element-attached-middle.bp3-tether-element-attached-right > .bp3-popover{
-    -webkit-transform-origin:center right;
-            transform-origin:center right; }
-  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-left > .bp3-popover{
-    -webkit-transform-origin:bottom left;
-            transform-origin:bottom left; }
-  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-center > .bp3-popover{
-    -webkit-transform-origin:bottom center;
-            transform-origin:bottom center; }
-  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-right > .bp3-popover{
-    -webkit-transform-origin:bottom right;
-            transform-origin:bottom right; }
-  .bp3-popover .bp3-popover-content{
-    background:#ffffff;
-    color:inherit; }
-  .bp3-popover .bp3-popover-arrow::before{
-    -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2);
-            box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2); }
-  .bp3-popover .bp3-popover-arrow-border{
-    fill:#10161a;
-    fill-opacity:0.1; }
-  .bp3-popover .bp3-popover-arrow-fill{
-    fill:#ffffff; }
-  .bp3-popover-enter > .bp3-popover, .bp3-popover-appear > .bp3-popover{
-    -webkit-transform:scale(0.3);
-            transform:scale(0.3); }
-  .bp3-popover-enter-active > .bp3-popover, .bp3-popover-appear-active > .bp3-popover{
-    -webkit-transform:scale(1);
-            transform:scale(1);
-    -webkit-transition-property:-webkit-transform;
-    transition-property:-webkit-transform;
-    transition-property:transform;
-    transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
-    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-popover-exit > .bp3-popover{
-    -webkit-transform:scale(1);
-            transform:scale(1); }
-  .bp3-popover-exit-active > .bp3-popover{
-    -webkit-transform:scale(0.3);
-            transform:scale(0.3);
-    -webkit-transition-property:-webkit-transform;
-    transition-property:-webkit-transform;
-    transition-property:transform;
-    transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
-    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-popover .bp3-popover-content{
-    position:relative;
-    border-radius:3px; }
-  .bp3-popover.bp3-popover-content-sizing .bp3-popover-content{
-    max-width:350px;
-    padding:20px; }
-  .bp3-popover-target + .bp3-overlay .bp3-popover.bp3-popover-content-sizing{
-    width:350px; }
-  .bp3-popover.bp3-minimal{
-    margin:0 !important; }
-    .bp3-popover.bp3-minimal .bp3-popover-arrow{
-      display:none; }
-    .bp3-popover.bp3-minimal.bp3-popover{
-      -webkit-transform:scale(1);
-              transform:scale(1); }
-      .bp3-popover-enter > .bp3-popover.bp3-minimal.bp3-popover, .bp3-popover-appear > .bp3-popover.bp3-minimal.bp3-popover{
-        -webkit-transform:scale(1);
-                transform:scale(1); }
-      .bp3-popover-enter-active > .bp3-popover.bp3-minimal.bp3-popover, .bp3-popover-appear-active > .bp3-popover.bp3-minimal.bp3-popover{
-        -webkit-transform:scale(1);
-                transform:scale(1);
-        -webkit-transition-property:-webkit-transform;
-        transition-property:-webkit-transform;
-        transition-property:transform;
-        transition-property:transform, -webkit-transform;
-        -webkit-transition-duration:100ms;
-                transition-duration:100ms;
-        -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-        -webkit-transition-delay:0;
-                transition-delay:0; }
-      .bp3-popover-exit > .bp3-popover.bp3-minimal.bp3-popover{
-        -webkit-transform:scale(1);
-                transform:scale(1); }
-      .bp3-popover-exit-active > .bp3-popover.bp3-minimal.bp3-popover{
-        -webkit-transform:scale(1);
-                transform:scale(1);
-        -webkit-transition-property:-webkit-transform;
-        transition-property:-webkit-transform;
-        transition-property:transform;
-        transition-property:transform, -webkit-transform;
-        -webkit-transition-duration:100ms;
-                transition-duration:100ms;
-        -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-        -webkit-transition-delay:0;
-                transition-delay:0; }
-  .bp3-popover.bp3-dark,
-  .bp3-dark .bp3-popover{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
-    .bp3-popover.bp3-dark .bp3-popover-content,
-    .bp3-dark .bp3-popover .bp3-popover-content{
-      background:#30404d;
-      color:inherit; }
-    .bp3-popover.bp3-dark .bp3-popover-arrow::before,
-    .bp3-dark .bp3-popover .bp3-popover-arrow::before{
-      -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4);
-              box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4); }
-    .bp3-popover.bp3-dark .bp3-popover-arrow-border,
-    .bp3-dark .bp3-popover .bp3-popover-arrow-border{
-      fill:#10161a;
-      fill-opacity:0.2; }
-    .bp3-popover.bp3-dark .bp3-popover-arrow-fill,
-    .bp3-dark .bp3-popover .bp3-popover-arrow-fill{
-      fill:#30404d; }
+.bp3-panel-stack-pop .bp3-panel-stack-exit-active {
+  -webkit-transform: translateX(100%);
+  transform: translateX(100%);
+  opacity: 0;
+  -webkit-transition-property: opacity, -webkit-transform;
+  transition-property: opacity, -webkit-transform;
+  transition-property: transform, opacity;
+  transition-property: transform, opacity, -webkit-transform;
+  -webkit-transition-duration: 400ms;
+  transition-duration: 400ms;
+  -webkit-transition-timing-function: ease;
+  transition-timing-function: ease;
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-popover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
+    0 8px 24px rgba(16, 22, 26, 0.2);
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  display: inline-block;
+  z-index: 20;
+  border-radius: 3px;
+}
+.bp3-popover .bp3-popover-arrow {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+}
+.bp3-popover .bp3-popover-arrow::before {
+  margin: 5px;
+  width: 20px;
+  height: 20px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-top
+  > .bp3-popover {
+  margin-top: -17px;
+  margin-bottom: 17px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-top
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  bottom: -11px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-top
+  > .bp3-popover
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-right
+  > .bp3-popover {
+  margin-left: 17px;
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-right
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  left: -11px;
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-right
+  > .bp3-popover
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(0);
+  transform: rotate(0);
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-bottom
+  > .bp3-popover {
+  margin-top: 17px;
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-bottom
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  top: -11px;
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-bottom
+  > .bp3-popover
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-left
+  > .bp3-popover {
+  margin-right: 17px;
+  margin-left: -17px;
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-left
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  right: -11px;
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-left
+  > .bp3-popover
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+.bp3-tether-element-attached-middle > .bp3-popover > .bp3-popover-arrow {
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+.bp3-tether-element-attached-center > .bp3-popover > .bp3-popover-arrow {
+  right: 50%;
+  -webkit-transform: translateX(50%);
+  transform: translateX(50%);
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-top
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  top: -0.3934px;
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-right
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  right: -0.3934px;
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-left
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  left: -0.3934px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-bottom
+  > .bp3-popover
+  > .bp3-popover-arrow {
+  bottom: -0.3934px;
+}
+.bp3-tether-element-attached-top.bp3-tether-element-attached-left
+  > .bp3-popover {
+  -webkit-transform-origin: top left;
+  transform-origin: top left;
+}
+.bp3-tether-element-attached-top.bp3-tether-element-attached-center
+  > .bp3-popover {
+  -webkit-transform-origin: top center;
+  transform-origin: top center;
+}
+.bp3-tether-element-attached-top.bp3-tether-element-attached-right
+  > .bp3-popover {
+  -webkit-transform-origin: top right;
+  transform-origin: top right;
+}
+.bp3-tether-element-attached-middle.bp3-tether-element-attached-left
+  > .bp3-popover {
+  -webkit-transform-origin: center left;
+  transform-origin: center left;
+}
+.bp3-tether-element-attached-middle.bp3-tether-element-attached-center
+  > .bp3-popover {
+  -webkit-transform-origin: center center;
+  transform-origin: center center;
+}
+.bp3-tether-element-attached-middle.bp3-tether-element-attached-right
+  > .bp3-popover {
+  -webkit-transform-origin: center right;
+  transform-origin: center right;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-element-attached-left
+  > .bp3-popover {
+  -webkit-transform-origin: bottom left;
+  transform-origin: bottom left;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-element-attached-center
+  > .bp3-popover {
+  -webkit-transform-origin: bottom center;
+  transform-origin: bottom center;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-element-attached-right
+  > .bp3-popover {
+  -webkit-transform-origin: bottom right;
+  transform-origin: bottom right;
+}
+.bp3-popover .bp3-popover-content {
+  background: #ffffff;
+  color: inherit;
+}
+.bp3-popover .bp3-popover-arrow::before {
+  -webkit-box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.2);
+  box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.2);
+}
+.bp3-popover .bp3-popover-arrow-border {
+  fill: #10161a;
+  fill-opacity: 0.1;
+}
+.bp3-popover .bp3-popover-arrow-fill {
+  fill: #ffffff;
+}
+.bp3-popover-enter > .bp3-popover,
+.bp3-popover-appear > .bp3-popover {
+  -webkit-transform: scale(0.3);
+  transform: scale(0.3);
+}
+.bp3-popover-enter-active > .bp3-popover,
+.bp3-popover-appear-active > .bp3-popover {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-popover-exit > .bp3-popover {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+.bp3-popover-exit-active > .bp3-popover {
+  -webkit-transform: scale(0.3);
+  transform: scale(0.3);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-popover .bp3-popover-content {
+  position: relative;
+  border-radius: 3px;
+}
+.bp3-popover.bp3-popover-content-sizing .bp3-popover-content {
+  max-width: 350px;
+  padding: 20px;
+}
+.bp3-popover-target + .bp3-overlay .bp3-popover.bp3-popover-content-sizing {
+  width: 350px;
+}
+.bp3-popover.bp3-minimal {
+  margin: 0 !important;
+}
+.bp3-popover.bp3-minimal .bp3-popover-arrow {
+  display: none;
+}
+.bp3-popover.bp3-minimal.bp3-popover {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+.bp3-popover-enter > .bp3-popover.bp3-minimal.bp3-popover,
+.bp3-popover-appear > .bp3-popover.bp3-minimal.bp3-popover {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+.bp3-popover-enter-active > .bp3-popover.bp3-minimal.bp3-popover,
+.bp3-popover-appear-active > .bp3-popover.bp3-minimal.bp3-popover {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-popover-exit > .bp3-popover.bp3-minimal.bp3-popover {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+.bp3-popover-exit-active > .bp3-popover.bp3-minimal.bp3-popover {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-popover.bp3-dark,
+.bp3-dark .bp3-popover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4),
+    0 8px 24px rgba(16, 22, 26, 0.4);
+}
+.bp3-popover.bp3-dark .bp3-popover-content,
+.bp3-dark .bp3-popover .bp3-popover-content {
+  background: #30404d;
+  color: inherit;
+}
+.bp3-popover.bp3-dark .bp3-popover-arrow::before,
+.bp3-dark .bp3-popover .bp3-popover-arrow::before {
+  -webkit-box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.4);
+  box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.4);
+}
+.bp3-popover.bp3-dark .bp3-popover-arrow-border,
+.bp3-dark .bp3-popover .bp3-popover-arrow-border {
+  fill: #10161a;
+  fill-opacity: 0.2;
+}
+.bp3-popover.bp3-dark .bp3-popover-arrow-fill,
+.bp3-dark .bp3-popover .bp3-popover-arrow-fill {
+  fill: #30404d;
+}
 
-.bp3-popover-arrow::before{
-  display:block;
-  position:absolute;
-  -webkit-transform:rotate(45deg);
-          transform:rotate(45deg);
-  border-radius:2px;
-  content:""; }
+.bp3-popover-arrow::before {
+  display: block;
+  position: absolute;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+  border-radius: 2px;
+  content: '';
+}
 
-.bp3-tether-pinned .bp3-popover-arrow{
-  display:none; }
+.bp3-tether-pinned .bp3-popover-arrow {
+  display: none;
+}
 
-.bp3-popover-backdrop{
-  background:rgba(255, 255, 255, 0); }
+.bp3-popover-backdrop {
+  background: rgba(255, 255, 255, 0);
+}
 
-.bp3-transition-container{
-  opacity:1;
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  z-index:20; }
-  .bp3-transition-container.bp3-popover-enter, .bp3-transition-container.bp3-popover-appear{
-    opacity:0; }
-  .bp3-transition-container.bp3-popover-enter-active, .bp3-transition-container.bp3-popover-appear-active{
-    opacity:1;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-transition-container.bp3-popover-exit{
-    opacity:1; }
-  .bp3-transition-container.bp3-popover-exit-active{
-    opacity:0;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-transition-container:focus{
-    outline:none; }
-  .bp3-transition-container.bp3-popover-leave .bp3-popover-content{
-    pointer-events:none; }
-  .bp3-transition-container[data-x-out-of-boundaries]{
-    display:none; }
+.bp3-transition-container {
+  opacity: 1;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 20;
+}
+.bp3-transition-container.bp3-popover-enter,
+.bp3-transition-container.bp3-popover-appear {
+  opacity: 0;
+}
+.bp3-transition-container.bp3-popover-enter-active,
+.bp3-transition-container.bp3-popover-appear-active {
+  opacity: 1;
+  -webkit-transition-property: opacity;
+  transition-property: opacity;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-transition-container.bp3-popover-exit {
+  opacity: 1;
+}
+.bp3-transition-container.bp3-popover-exit-active {
+  opacity: 0;
+  -webkit-transition-property: opacity;
+  transition-property: opacity;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-transition-container:focus {
+  outline: none;
+}
+.bp3-transition-container.bp3-popover-leave .bp3-popover-content {
+  pointer-events: none;
+}
+.bp3-transition-container[data-x-out-of-boundaries] {
+  display: none;
+}
 
-span.bp3-popover-target{
-  display:inline-block; }
+span.bp3-popover-target {
+  display: inline-block;
+}
 
-.bp3-popover-wrapper.bp3-fill{
-  width:100%; }
+.bp3-popover-wrapper.bp3-fill {
+  width: 100%;
+}
 
-.bp3-portal{
-  position:absolute;
-  top:0;
-  right:0;
-  left:0; }
-@-webkit-keyframes linear-progress-bar-stripes{
-  from{
-    background-position:0 0; }
-  to{
-    background-position:30px 0; } }
-@keyframes linear-progress-bar-stripes{
-  from{
-    background-position:0 0; }
-  to{
-    background-position:30px 0; } }
+.bp3-portal {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+}
+@-webkit-keyframes linear-progress-bar-stripes {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 30px 0;
+  }
+}
+@keyframes linear-progress-bar-stripes {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 30px 0;
+  }
+}
 
-.bp3-progress-bar{
-  display:block;
-  position:relative;
-  border-radius:40px;
-  background:rgba(92, 112, 128, 0.2);
-  width:100%;
-  height:8px;
-  overflow:hidden; }
-  .bp3-progress-bar .bp3-progress-meter{
-    position:absolute;
-    border-radius:40px;
-    background:linear-gradient(-45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%);
-    background-color:rgba(92, 112, 128, 0.8);
-    background-size:30px 30px;
-    width:100%;
-    height:100%;
-    -webkit-transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-  .bp3-progress-bar:not(.bp3-no-animation):not(.bp3-no-stripes) .bp3-progress-meter{
-    animation:linear-progress-bar-stripes 300ms linear infinite reverse; }
-  .bp3-progress-bar.bp3-no-stripes .bp3-progress-meter{
-    background-image:none; }
+.bp3-progress-bar {
+  display: block;
+  position: relative;
+  border-radius: 40px;
+  background: rgba(92, 112, 128, 0.2);
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+}
+.bp3-progress-bar .bp3-progress-meter {
+  position: absolute;
+  border-radius: 40px;
+  background: linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%
+  );
+  background-color: rgba(92, 112, 128, 0.8);
+  background-size: 30px 30px;
+  width: 100%;
+  height: 100%;
+  -webkit-transition: width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-progress-bar:not(.bp3-no-animation):not(.bp3-no-stripes)
+  .bp3-progress-meter {
+  animation: linear-progress-bar-stripes 300ms linear infinite reverse;
+}
+.bp3-progress-bar.bp3-no-stripes .bp3-progress-meter {
+  background-image: none;
+}
 
-.bp3-dark .bp3-progress-bar{
-  background:rgba(16, 22, 26, 0.5); }
-  .bp3-dark .bp3-progress-bar .bp3-progress-meter{
-    background-color:#8a9ba8; }
+.bp3-dark .bp3-progress-bar {
+  background: rgba(16, 22, 26, 0.5);
+}
+.bp3-dark .bp3-progress-bar .bp3-progress-meter {
+  background-color: #8a9ba8;
+}
 
-.bp3-progress-bar.bp3-intent-primary .bp3-progress-meter{
-  background-color:#137cbd; }
+.bp3-progress-bar.bp3-intent-primary .bp3-progress-meter {
+  background-color: #137cbd;
+}
 
-.bp3-progress-bar.bp3-intent-success .bp3-progress-meter{
-  background-color:#0f9960; }
+.bp3-progress-bar.bp3-intent-success .bp3-progress-meter {
+  background-color: #0f9960;
+}
 
-.bp3-progress-bar.bp3-intent-warning .bp3-progress-meter{
-  background-color:#d9822b; }
+.bp3-progress-bar.bp3-intent-warning .bp3-progress-meter {
+  background-color: #d9822b;
+}
 
-.bp3-progress-bar.bp3-intent-danger .bp3-progress-meter{
-  background-color:#db3737; }
-@-webkit-keyframes skeleton-glow{
-  from{
-    border-color:rgba(206, 217, 224, 0.2);
-    background:rgba(206, 217, 224, 0.2); }
-  to{
-    border-color:rgba(92, 112, 128, 0.2);
-    background:rgba(92, 112, 128, 0.2); } }
-@keyframes skeleton-glow{
-  from{
-    border-color:rgba(206, 217, 224, 0.2);
-    background:rgba(206, 217, 224, 0.2); }
-  to{
-    border-color:rgba(92, 112, 128, 0.2);
-    background:rgba(92, 112, 128, 0.2); } }
-.bp3-skeleton{
-  border-color:rgba(206, 217, 224, 0.2) !important;
-  border-radius:2px;
-  -webkit-box-shadow:none !important;
-          box-shadow:none !important;
-  background:rgba(206, 217, 224, 0.2);
-  background-clip:padding-box !important;
-  cursor:default;
-  color:transparent !important;
-  -webkit-animation:1000ms linear infinite alternate skeleton-glow;
-          animation:1000ms linear infinite alternate skeleton-glow;
-  pointer-events:none;
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-skeleton::before, .bp3-skeleton::after,
-  .bp3-skeleton *{
-    visibility:hidden !important; }
-.bp3-slider{
-  width:100%;
-  min-width:150px;
-  height:40px;
-  position:relative;
-  outline:none;
-  cursor:default;
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-slider:hover{
-    cursor:pointer; }
-  .bp3-slider:active{
-    cursor:-webkit-grabbing;
-    cursor:grabbing; }
-  .bp3-slider.bp3-disabled{
-    opacity:0.5;
-    cursor:not-allowed; }
-  .bp3-slider.bp3-slider-unlabeled{
-    height:16px; }
+.bp3-progress-bar.bp3-intent-danger .bp3-progress-meter {
+  background-color: #db3737;
+}
+@-webkit-keyframes skeleton-glow {
+  from {
+    border-color: rgba(206, 217, 224, 0.2);
+    background: rgba(206, 217, 224, 0.2);
+  }
+  to {
+    border-color: rgba(92, 112, 128, 0.2);
+    background: rgba(92, 112, 128, 0.2);
+  }
+}
+@keyframes skeleton-glow {
+  from {
+    border-color: rgba(206, 217, 224, 0.2);
+    background: rgba(206, 217, 224, 0.2);
+  }
+  to {
+    border-color: rgba(92, 112, 128, 0.2);
+    background: rgba(92, 112, 128, 0.2);
+  }
+}
+.bp3-skeleton {
+  border-color: rgba(206, 217, 224, 0.2) !important;
+  border-radius: 2px;
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+  background: rgba(206, 217, 224, 0.2);
+  background-clip: padding-box !important;
+  cursor: default;
+  color: transparent !important;
+  -webkit-animation: 1000ms linear infinite alternate skeleton-glow;
+  animation: 1000ms linear infinite alternate skeleton-glow;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-skeleton::before,
+.bp3-skeleton::after,
+.bp3-skeleton * {
+  visibility: hidden !important;
+}
+.bp3-slider {
+  width: 100%;
+  min-width: 150px;
+  height: 40px;
+  position: relative;
+  outline: none;
+  cursor: default;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-slider:hover {
+  cursor: pointer;
+}
+.bp3-slider:active {
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
+.bp3-slider.bp3-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.bp3-slider.bp3-slider-unlabeled {
+  height: 16px;
+}
 
 .bp3-slider-track,
-.bp3-slider-progress{
-  top:5px;
-  right:0;
-  left:0;
-  height:6px;
-  position:absolute; }
+.bp3-slider-progress {
+  top: 5px;
+  right: 0;
+  left: 0;
+  height: 6px;
+  position: absolute;
+}
 
-.bp3-slider-track{
-  border-radius:3px;
-  overflow:hidden; }
+.bp3-slider-track {
+  border-radius: 3px;
+  overflow: hidden;
+}
 
-.bp3-slider-progress{
-  background:rgba(92, 112, 128, 0.2); }
-  .bp3-dark .bp3-slider-progress{
-    background:rgba(16, 22, 26, 0.5); }
-  .bp3-slider-progress.bp3-intent-primary{
-    background-color:#137cbd; }
-  .bp3-slider-progress.bp3-intent-success{
-    background-color:#0f9960; }
-  .bp3-slider-progress.bp3-intent-warning{
-    background-color:#d9822b; }
-  .bp3-slider-progress.bp3-intent-danger{
-    background-color:#db3737; }
+.bp3-slider-progress {
+  background: rgba(92, 112, 128, 0.2);
+}
+.bp3-dark .bp3-slider-progress {
+  background: rgba(16, 22, 26, 0.5);
+}
+.bp3-slider-progress.bp3-intent-primary {
+  background-color: #137cbd;
+}
+.bp3-slider-progress.bp3-intent-success {
+  background-color: #0f9960;
+}
+.bp3-slider-progress.bp3-intent-warning {
+  background-color: #d9822b;
+}
+.bp3-slider-progress.bp3-intent-danger {
+  background-color: #db3737;
+}
 
-.bp3-slider-handle{
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-  background-color:#f5f8fa;
-  background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
-  background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
-  color:#182026;
-  position:absolute;
-  top:0;
-  left:0;
-  border-radius:3px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-  cursor:pointer;
-  width:16px;
-  height:16px; }
-  .bp3-slider-handle:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-clip:padding-box;
-    background-color:#ebf1f5; }
-  .bp3-slider-handle:active, .bp3-slider-handle.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#d8e1e8;
-    background-image:none; }
-  .bp3-slider-handle:disabled, .bp3-slider-handle.bp3-disabled{
-    outline:none;
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background-color:rgba(206, 217, 224, 0.5);
-    background-image:none;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
-    .bp3-slider-handle:disabled.bp3-active, .bp3-slider-handle:disabled.bp3-active:hover, .bp3-slider-handle.bp3-disabled.bp3-active, .bp3-slider-handle.bp3-disabled.bp3-active:hover{
-      background:rgba(206, 217, 224, 0.7); }
-  .bp3-slider-handle:focus{
-    z-index:1; }
-  .bp3-slider-handle:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-clip:padding-box;
-    background-color:#ebf1f5;
-    z-index:2;
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-    cursor:-webkit-grab;
-    cursor:grab; }
-  .bp3-slider-handle.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#d8e1e8;
-    background-image:none;
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
-    cursor:-webkit-grabbing;
-    cursor:grabbing; }
-  .bp3-disabled .bp3-slider-handle{
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:#bfccd6;
-    pointer-events:none; }
-  .bp3-dark .bp3-slider-handle{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#394b59;
-    background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
-    background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
-    color:#f5f8fa; }
-    .bp3-dark .bp3-slider-handle:hover, .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
-      color:#f5f8fa; }
-    .bp3-dark .bp3-slider-handle:hover{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
-    .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background-color:#202b33;
-      background-image:none; }
-    .bp3-dark .bp3-slider-handle:disabled, .bp3-dark .bp3-slider-handle.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
-      background-color:rgba(57, 75, 89, 0.5);
-      background-image:none;
-      color:rgba(167, 182, 194, 0.6); }
-      .bp3-dark .bp3-slider-handle:disabled.bp3-active, .bp3-dark .bp3-slider-handle.bp3-disabled.bp3-active{
-        background:rgba(57, 75, 89, 0.7); }
-    .bp3-dark .bp3-slider-handle .bp3-button-spinner .bp3-spinner-head{
-      background:rgba(16, 22, 26, 0.5);
-      stroke:#8a9ba8; }
-    .bp3-dark .bp3-slider-handle, .bp3-dark .bp3-slider-handle:hover{
-      background-color:#394b59; }
-    .bp3-dark .bp3-slider-handle.bp3-active{
-      background-color:#293742; }
-  .bp3-dark .bp3-disabled .bp3-slider-handle{
-    border-color:#5c7080;
-    -webkit-box-shadow:none;
-            box-shadow:none;
-    background:#5c7080; }
-  .bp3-slider-handle .bp3-slider-label{
-    margin-left:8px;
-    border-radius:3px;
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-    background:#394b59;
-    color:#f5f8fa; }
-    .bp3-dark .bp3-slider-handle .bp3-slider-label{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-      background:#e1e8ed;
-      color:#394b59; }
-    .bp3-disabled .bp3-slider-handle .bp3-slider-label{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-  .bp3-slider-handle.bp3-start, .bp3-slider-handle.bp3-end{
-    width:8px; }
-  .bp3-slider-handle.bp3-start{
-    border-top-right-radius:0;
-    border-bottom-right-radius:0; }
-  .bp3-slider-handle.bp3-end{
-    margin-left:8px;
-    border-top-left-radius:0;
-    border-bottom-left-radius:0; }
-    .bp3-slider-handle.bp3-end .bp3-slider-label{
-      margin-left:0; }
+.bp3-slider-handle {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-color: #f5f8fa;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.8)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.8),
+    rgba(255, 255, 255, 0)
+  );
+  color: #182026;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+}
+.bp3-slider-handle:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-clip: padding-box;
+  background-color: #ebf1f5;
+}
+.bp3-slider-handle:active,
+.bp3-slider-handle.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #d8e1e8;
+  background-image: none;
+}
+.bp3-slider-handle:disabled,
+.bp3-slider-handle.bp3-disabled {
+  outline: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(206, 217, 224, 0.5);
+  background-image: none;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-slider-handle:disabled.bp3-active,
+.bp3-slider-handle:disabled.bp3-active:hover,
+.bp3-slider-handle.bp3-disabled.bp3-active,
+.bp3-slider-handle.bp3-disabled.bp3-active:hover {
+  background: rgba(206, 217, 224, 0.7);
+}
+.bp3-slider-handle:focus {
+  z-index: 1;
+}
+.bp3-slider-handle:hover {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  background-clip: padding-box;
+  background-color: #ebf1f5;
+  z-index: 2;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+  cursor: -webkit-grab;
+  cursor: grab;
+}
+.bp3-slider-handle.bp3-active {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #d8e1e8;
+  background-image: none;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 1px rgba(16, 22, 26, 0.1);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    inset 0 1px 1px rgba(16, 22, 26, 0.1);
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
+.bp3-disabled .bp3-slider-handle {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: #bfccd6;
+  pointer-events: none;
+}
+.bp3-dark .bp3-slider-handle {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #394b59;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(255, 255, 255, 0.05)),
+    to(rgba(255, 255, 255, 0))
+  );
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0)
+  );
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-slider-handle:hover,
+.bp3-dark .bp3-slider-handle:active,
+.bp3-dark .bp3-slider-handle.bp3-active {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-slider-handle:hover {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.4);
+  background-color: #30404d;
+}
+.bp3-dark .bp3-slider-handle:active,
+.bp3-dark .bp3-slider-handle.bp3-active {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6),
+    inset 0 1px 2px rgba(16, 22, 26, 0.2);
+  background-color: #202b33;
+  background-image: none;
+}
+.bp3-dark .bp3-slider-handle:disabled,
+.bp3-dark .bp3-slider-handle.bp3-disabled {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(57, 75, 89, 0.5);
+  background-image: none;
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-slider-handle:disabled.bp3-active,
+.bp3-dark .bp3-slider-handle.bp3-disabled.bp3-active {
+  background: rgba(57, 75, 89, 0.7);
+}
+.bp3-dark .bp3-slider-handle .bp3-button-spinner .bp3-spinner-head {
+  background: rgba(16, 22, 26, 0.5);
+  stroke: #8a9ba8;
+}
+.bp3-dark .bp3-slider-handle,
+.bp3-dark .bp3-slider-handle:hover {
+  background-color: #394b59;
+}
+.bp3-dark .bp3-slider-handle.bp3-active {
+  background-color: #293742;
+}
+.bp3-dark .bp3-disabled .bp3-slider-handle {
+  border-color: #5c7080;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: #5c7080;
+}
+.bp3-slider-handle .bp3-slider-label {
+  margin-left: 8px;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
+    0 8px 24px rgba(16, 22, 26, 0.2);
+  background: #394b59;
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-slider-handle .bp3-slider-label {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4),
+    0 8px 24px rgba(16, 22, 26, 0.4);
+  background: #e1e8ed;
+  color: #394b59;
+}
+.bp3-disabled .bp3-slider-handle .bp3-slider-label {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-slider-handle.bp3-start,
+.bp3-slider-handle.bp3-end {
+  width: 8px;
+}
+.bp3-slider-handle.bp3-start {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.bp3-slider-handle.bp3-end {
+  margin-left: 8px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.bp3-slider-handle.bp3-end .bp3-slider-label {
+  margin-left: 0;
+}
 
-.bp3-slider-label{
-  -webkit-transform:translate(-50%, 20px);
-          transform:translate(-50%, 20px);
-  display:inline-block;
-  position:absolute;
-  padding:2px 5px;
-  vertical-align:top;
-  line-height:1;
-  font-size:12px; }
+.bp3-slider-label {
+  -webkit-transform: translate(-50%, 20px);
+  transform: translate(-50%, 20px);
+  display: inline-block;
+  position: absolute;
+  padding: 2px 5px;
+  vertical-align: top;
+  line-height: 1;
+  font-size: 12px;
+}
 
-.bp3-slider.bp3-vertical{
-  width:40px;
-  min-width:40px;
-  height:150px; }
-  .bp3-slider.bp3-vertical .bp3-slider-track,
-  .bp3-slider.bp3-vertical .bp3-slider-progress{
-    top:0;
-    bottom:0;
-    left:5px;
-    width:6px;
-    height:auto; }
-  .bp3-slider.bp3-vertical .bp3-slider-progress{
-    top:auto; }
-  .bp3-slider.bp3-vertical .bp3-slider-label{
-    -webkit-transform:translate(20px, 50%);
-            transform:translate(20px, 50%); }
-  .bp3-slider.bp3-vertical .bp3-slider-handle{
-    top:auto; }
-    .bp3-slider.bp3-vertical .bp3-slider-handle .bp3-slider-label{
-      margin-top:-8px;
-      margin-left:0; }
-    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end, .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
-      margin-left:0;
-      width:16px;
-      height:8px; }
-    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
-      border-top-left-radius:0;
-      border-bottom-right-radius:3px; }
-      .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start .bp3-slider-label{
-        -webkit-transform:translate(20px);
-                transform:translate(20px); }
-    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end{
-      margin-bottom:8px;
-      border-top-left-radius:3px;
-      border-bottom-left-radius:0;
-      border-bottom-right-radius:0; }
+.bp3-slider.bp3-vertical {
+  width: 40px;
+  min-width: 40px;
+  height: 150px;
+}
+.bp3-slider.bp3-vertical .bp3-slider-track,
+.bp3-slider.bp3-vertical .bp3-slider-progress {
+  top: 0;
+  bottom: 0;
+  left: 5px;
+  width: 6px;
+  height: auto;
+}
+.bp3-slider.bp3-vertical .bp3-slider-progress {
+  top: auto;
+}
+.bp3-slider.bp3-vertical .bp3-slider-label {
+  -webkit-transform: translate(20px, 50%);
+  transform: translate(20px, 50%);
+}
+.bp3-slider.bp3-vertical .bp3-slider-handle {
+  top: auto;
+}
+.bp3-slider.bp3-vertical .bp3-slider-handle .bp3-slider-label {
+  margin-top: -8px;
+  margin-left: 0;
+}
+.bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end,
+.bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start {
+  margin-left: 0;
+  width: 16px;
+  height: 8px;
+}
+.bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start {
+  border-top-left-radius: 0;
+  border-bottom-right-radius: 3px;
+}
+.bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start .bp3-slider-label {
+  -webkit-transform: translate(20px);
+  transform: translate(20px);
+}
+.bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end {
+  margin-bottom: 8px;
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
 
-@-webkit-keyframes pt-spinner-animation{
-  from{
-    -webkit-transform:rotate(0deg);
-            transform:rotate(0deg); }
-  to{
-    -webkit-transform:rotate(360deg);
-            transform:rotate(360deg); } }
+@-webkit-keyframes pt-spinner-animation {
+  from {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
 
-@keyframes pt-spinner-animation{
-  from{
-    -webkit-transform:rotate(0deg);
-            transform:rotate(0deg); }
-  to{
-    -webkit-transform:rotate(360deg);
-            transform:rotate(360deg); } }
+@keyframes pt-spinner-animation {
+  from {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
 
-.bp3-spinner{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
-  overflow:visible;
-  vertical-align:middle; }
-  .bp3-spinner svg{
-    display:block; }
-  .bp3-spinner path{
-    fill-opacity:0; }
-  .bp3-spinner .bp3-spinner-head{
-    -webkit-transform-origin:center;
-            transform-origin:center;
-    -webkit-transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    stroke:rgba(92, 112, 128, 0.8);
-    stroke-linecap:round; }
-  .bp3-spinner .bp3-spinner-track{
-    stroke:rgba(92, 112, 128, 0.2); }
+.bp3-spinner {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  overflow: visible;
+  vertical-align: middle;
+}
+.bp3-spinner svg {
+  display: block;
+}
+.bp3-spinner path {
+  fill-opacity: 0;
+}
+.bp3-spinner .bp3-spinner-head {
+  -webkit-transform-origin: center;
+  transform-origin: center;
+  -webkit-transition: stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  stroke: rgba(92, 112, 128, 0.8);
+  stroke-linecap: round;
+}
+.bp3-spinner .bp3-spinner-track {
+  stroke: rgba(92, 112, 128, 0.2);
+}
 
-.bp3-spinner-animation{
-  -webkit-animation:pt-spinner-animation 500ms linear infinite;
-          animation:pt-spinner-animation 500ms linear infinite; }
-  .bp3-no-spin > .bp3-spinner-animation{
-    -webkit-animation:none;
-            animation:none; }
+.bp3-spinner-animation {
+  -webkit-animation: pt-spinner-animation 500ms linear infinite;
+  animation: pt-spinner-animation 500ms linear infinite;
+}
+.bp3-no-spin > .bp3-spinner-animation {
+  -webkit-animation: none;
+  animation: none;
+}
 
-.bp3-dark .bp3-spinner .bp3-spinner-head{
-  stroke:#8a9ba8; }
+.bp3-dark .bp3-spinner .bp3-spinner-head {
+  stroke: #8a9ba8;
+}
 
-.bp3-dark .bp3-spinner .bp3-spinner-track{
-  stroke:rgba(16, 22, 26, 0.5); }
+.bp3-dark .bp3-spinner .bp3-spinner-track {
+  stroke: rgba(16, 22, 26, 0.5);
+}
 
-.bp3-spinner.bp3-intent-primary .bp3-spinner-head{
-  stroke:#137cbd; }
+.bp3-spinner.bp3-intent-primary .bp3-spinner-head {
+  stroke: #137cbd;
+}
 
-.bp3-spinner.bp3-intent-success .bp3-spinner-head{
-  stroke:#0f9960; }
+.bp3-spinner.bp3-intent-success .bp3-spinner-head {
+  stroke: #0f9960;
+}
 
-.bp3-spinner.bp3-intent-warning .bp3-spinner-head{
-  stroke:#d9822b; }
+.bp3-spinner.bp3-intent-warning .bp3-spinner-head {
+  stroke: #d9822b;
+}
 
-.bp3-spinner.bp3-intent-danger .bp3-spinner-head{
-  stroke:#db3737; }
-.bp3-tabs.bp3-vertical{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex; }
-  .bp3-tabs.bp3-vertical > .bp3-tab-list{
-    -webkit-box-orient:vertical;
-    -webkit-box-direction:normal;
-        -ms-flex-direction:column;
-            flex-direction:column;
-    -webkit-box-align:start;
-        -ms-flex-align:start;
-            align-items:flex-start; }
-    .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab{
-      border-radius:3px;
-      width:100%;
-      padding:0 10px; }
-      .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab[aria-selected="true"]{
-        -webkit-box-shadow:none;
-                box-shadow:none;
-        background-color:rgba(19, 124, 189, 0.2); }
-    .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab-indicator-wrapper .bp3-tab-indicator{
-      top:0;
-      right:0;
-      bottom:0;
-      left:0;
-      border-radius:3px;
-      background-color:rgba(19, 124, 189, 0.2);
-      height:auto; }
-  .bp3-tabs.bp3-vertical > .bp3-tab-panel{
-    margin-top:0;
-    padding-left:20px; }
+.bp3-spinner.bp3-intent-danger .bp3-spinner-head {
+  stroke: #db3737;
+}
+.bp3-tabs.bp3-vertical {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.bp3-tabs.bp3-vertical > .bp3-tab-list {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+}
+.bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab {
+  border-radius: 3px;
+  width: 100%;
+  padding: 0 10px;
+}
+.bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab[aria-selected='true'] {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: rgba(19, 124, 189, 0.2);
+}
+.bp3-tabs.bp3-vertical
+  > .bp3-tab-list
+  .bp3-tab-indicator-wrapper
+  .bp3-tab-indicator {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: 3px;
+  background-color: rgba(19, 124, 189, 0.2);
+  height: auto;
+}
+.bp3-tabs.bp3-vertical > .bp3-tab-panel {
+  margin-top: 0;
+  padding-left: 20px;
+}
 
-.bp3-tab-list{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-flex:0;
-      -ms-flex:0 0 auto;
-          flex:0 0 auto;
-  -webkit-box-align:end;
-      -ms-flex-align:end;
-          align-items:flex-end;
-  position:relative;
-  margin:0;
-  border:none;
-  padding:0;
-  list-style:none; }
-  .bp3-tab-list > *:not(:last-child){
-    margin-right:20px; }
+.bp3-tab-list {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-align: end;
+  -ms-flex-align: end;
+  align-items: flex-end;
+  position: relative;
+  margin: 0;
+  border: none;
+  padding: 0;
+  list-style: none;
+}
+.bp3-tab-list > *:not(:last-child) {
+  margin-right: 20px;
+}
 
-.bp3-tab{
-  overflow:hidden;
-  text-overflow:ellipsis;
-  white-space:nowrap;
-  word-wrap:normal;
-  -webkit-box-flex:0;
-      -ms-flex:0 0 auto;
-          flex:0 0 auto;
-  position:relative;
-  cursor:pointer;
-  max-width:100%;
-  vertical-align:top;
-  line-height:30px;
-  color:#182026;
-  font-size:14px; }
-  .bp3-tab a{
-    display:block;
-    text-decoration:none;
-    color:inherit; }
-  .bp3-tab-indicator-wrapper ~ .bp3-tab{
-    -webkit-box-shadow:none !important;
-            box-shadow:none !important;
-    background-color:transparent !important; }
-  .bp3-tab[aria-disabled="true"]{
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-tab[aria-selected="true"]{
-    border-radius:0;
-    -webkit-box-shadow:inset 0 -3px 0 #106ba3;
-            box-shadow:inset 0 -3px 0 #106ba3; }
-  .bp3-tab[aria-selected="true"], .bp3-tab:not([aria-disabled="true"]):hover{
-    color:#106ba3; }
-  .bp3-tab:focus{
-    -moz-outline-radius:0; }
-  .bp3-large > .bp3-tab{
-    line-height:40px;
-    font-size:16px; }
+.bp3-tab {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  position: relative;
+  cursor: pointer;
+  max-width: 100%;
+  vertical-align: top;
+  line-height: 30px;
+  color: #182026;
+  font-size: 14px;
+}
+.bp3-tab a {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+.bp3-tab-indicator-wrapper ~ .bp3-tab {
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+  background-color: transparent !important;
+}
+.bp3-tab[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-tab[aria-selected='true'] {
+  border-radius: 0;
+  -webkit-box-shadow: inset 0 -3px 0 #106ba3;
+  box-shadow: inset 0 -3px 0 #106ba3;
+}
+.bp3-tab[aria-selected='true'],
+.bp3-tab:not([aria-disabled='true']):hover {
+  color: #106ba3;
+}
+.bp3-tab:focus {
+  -moz-outline-radius: 0;
+}
+.bp3-large > .bp3-tab {
+  line-height: 40px;
+  font-size: 16px;
+}
 
-.bp3-tab-panel{
-  margin-top:20px; }
-  .bp3-tab-panel[aria-hidden="true"]{
-    display:none; }
+.bp3-tab-panel {
+  margin-top: 20px;
+}
+.bp3-tab-panel[aria-hidden='true'] {
+  display: none;
+}
 
-.bp3-tab-indicator-wrapper{
-  position:absolute;
-  top:0;
-  left:0;
-  -webkit-transform:translateX(0), translateY(0);
-          transform:translateX(0), translateY(0);
-  -webkit-transition:height, width, -webkit-transform;
-  transition:height, width, -webkit-transform;
-  transition:height, transform, width;
-  transition:height, transform, width, -webkit-transform;
-  -webkit-transition-duration:200ms;
-          transition-duration:200ms;
-  -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-          transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-  pointer-events:none; }
-  .bp3-tab-indicator-wrapper .bp3-tab-indicator{
-    position:absolute;
-    right:0;
-    bottom:0;
-    left:0;
-    background-color:#106ba3;
-    height:3px; }
-  .bp3-tab-indicator-wrapper.bp3-no-animation{
-    -webkit-transition:none;
-    transition:none; }
+.bp3-tab-indicator-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transform: translateX(0), translateY(0);
+  transform: translateX(0), translateY(0);
+  -webkit-transition: height, width, -webkit-transform;
+  transition: height, width, -webkit-transform;
+  transition: height, transform, width;
+  transition: height, transform, width, -webkit-transform;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  pointer-events: none;
+}
+.bp3-tab-indicator-wrapper .bp3-tab-indicator {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #106ba3;
+  height: 3px;
+}
+.bp3-tab-indicator-wrapper.bp3-no-animation {
+  -webkit-transition: none;
+  transition: none;
+}
 
-.bp3-dark .bp3-tab{
-  color:#f5f8fa; }
-  .bp3-dark .bp3-tab[aria-disabled="true"]{
-    color:rgba(167, 182, 194, 0.6); }
-  .bp3-dark .bp3-tab[aria-selected="true"]{
-    -webkit-box-shadow:inset 0 -3px 0 #48aff0;
-            box-shadow:inset 0 -3px 0 #48aff0; }
-  .bp3-dark .bp3-tab[aria-selected="true"], .bp3-dark .bp3-tab:not([aria-disabled="true"]):hover{
-    color:#48aff0; }
+.bp3-dark .bp3-tab {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-tab[aria-disabled='true'] {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-tab[aria-selected='true'] {
+  -webkit-box-shadow: inset 0 -3px 0 #48aff0;
+  box-shadow: inset 0 -3px 0 #48aff0;
+}
+.bp3-dark .bp3-tab[aria-selected='true'],
+.bp3-dark .bp3-tab:not([aria-disabled='true']):hover {
+  color: #48aff0;
+}
 
-.bp3-dark .bp3-tab-indicator{
-  background-color:#48aff0; }
+.bp3-dark .bp3-tab-indicator {
+  background-color: #48aff0;
+}
 
-.bp3-flex-expander{
-  -webkit-box-flex:1;
-      -ms-flex:1 1;
-          flex:1 1; }
-.bp3-tag{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:row;
-          flex-direction:row;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  position:relative;
-  border:none;
-  border-radius:3px;
-  -webkit-box-shadow:none;
-          box-shadow:none;
-  background-color:#5c7080;
-  min-width:20px;
-  max-width:100%;
-  min-height:20px;
-  padding:2px 6px;
-  line-height:16px;
-  color:#f5f8fa;
-  font-size:12px; }
-  .bp3-tag.bp3-interactive{
-    cursor:pointer; }
-    .bp3-tag.bp3-interactive:hover{
-      background-color:rgba(92, 112, 128, 0.85); }
-    .bp3-tag.bp3-interactive.bp3-active, .bp3-tag.bp3-interactive:active{
-      background-color:rgba(92, 112, 128, 0.7); }
-  .bp3-tag > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-tag > .bp3-fill{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-tag::before,
-  .bp3-tag > *{
-    margin-right:4px; }
-  .bp3-tag:empty::before,
-  .bp3-tag > :last-child{
-    margin-right:0; }
-  .bp3-tag:focus{
-    outline:rgba(19, 124, 189, 0.6) auto 2px;
-    outline-offset:0;
-    -moz-outline-radius:6px; }
-  .bp3-tag.bp3-round{
-    border-radius:30px;
-    padding-right:8px;
-    padding-left:8px; }
-  .bp3-dark .bp3-tag{
-    background-color:#bfccd6;
-    color:#182026; }
-    .bp3-dark .bp3-tag.bp3-interactive{
-      cursor:pointer; }
-      .bp3-dark .bp3-tag.bp3-interactive:hover{
-        background-color:rgba(191, 204, 214, 0.85); }
-      .bp3-dark .bp3-tag.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-interactive:active{
-        background-color:rgba(191, 204, 214, 0.7); }
-    .bp3-dark .bp3-tag > .bp3-icon, .bp3-dark .bp3-tag .bp3-icon-standard, .bp3-dark .bp3-tag .bp3-icon-large{
-      fill:currentColor; }
-  .bp3-tag > .bp3-icon, .bp3-tag .bp3-icon-standard, .bp3-tag .bp3-icon-large{
-    fill:#ffffff; }
-  .bp3-tag.bp3-large,
-  .bp3-large .bp3-tag{
-    min-width:30px;
-    min-height:30px;
-    padding:0 10px;
-    line-height:20px;
-    font-size:14px; }
-    .bp3-tag.bp3-large::before,
-    .bp3-tag.bp3-large > *,
-    .bp3-large .bp3-tag::before,
-    .bp3-large .bp3-tag > *{
-      margin-right:7px; }
-    .bp3-tag.bp3-large:empty::before,
-    .bp3-tag.bp3-large > :last-child,
-    .bp3-large .bp3-tag:empty::before,
-    .bp3-large .bp3-tag > :last-child{
-      margin-right:0; }
-    .bp3-tag.bp3-large.bp3-round,
-    .bp3-large .bp3-tag.bp3-round{
-      padding-right:12px;
-      padding-left:12px; }
-  .bp3-tag.bp3-intent-primary{
-    background:#137cbd;
-    color:#ffffff; }
-    .bp3-tag.bp3-intent-primary.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-intent-primary.bp3-interactive:hover{
-        background-color:rgba(19, 124, 189, 0.85); }
-      .bp3-tag.bp3-intent-primary.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-primary.bp3-interactive:active{
-        background-color:rgba(19, 124, 189, 0.7); }
-  .bp3-tag.bp3-intent-success{
-    background:#0f9960;
-    color:#ffffff; }
-    .bp3-tag.bp3-intent-success.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-intent-success.bp3-interactive:hover{
-        background-color:rgba(15, 153, 96, 0.85); }
-      .bp3-tag.bp3-intent-success.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-success.bp3-interactive:active{
-        background-color:rgba(15, 153, 96, 0.7); }
-  .bp3-tag.bp3-intent-warning{
-    background:#d9822b;
-    color:#ffffff; }
-    .bp3-tag.bp3-intent-warning.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-intent-warning.bp3-interactive:hover{
-        background-color:rgba(217, 130, 43, 0.85); }
-      .bp3-tag.bp3-intent-warning.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-warning.bp3-interactive:active{
-        background-color:rgba(217, 130, 43, 0.7); }
-  .bp3-tag.bp3-intent-danger{
-    background:#db3737;
-    color:#ffffff; }
-    .bp3-tag.bp3-intent-danger.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-intent-danger.bp3-interactive:hover{
-        background-color:rgba(219, 55, 55, 0.85); }
-      .bp3-tag.bp3-intent-danger.bp3-interactive.bp3-active, .bp3-tag.bp3-intent-danger.bp3-interactive:active{
-        background-color:rgba(219, 55, 55, 0.7); }
-  .bp3-tag.bp3-fill{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    width:100%; }
-  .bp3-tag.bp3-minimal > .bp3-icon, .bp3-tag.bp3-minimal .bp3-icon-standard, .bp3-tag.bp3-minimal .bp3-icon-large{
-    fill:#5c7080; }
-  .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]){
-    background-color:rgba(138, 155, 168, 0.2);
-    color:#182026; }
-    .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:hover{
-        background-color:rgba(92, 112, 128, 0.3); }
-      .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive.bp3-active, .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:active{
-        background-color:rgba(92, 112, 128, 0.4); }
-    .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]){
-      color:#f5f8fa; }
-      .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive{
-        cursor:pointer; }
-        .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:hover{
-          background-color:rgba(191, 204, 214, 0.3); }
-        .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]).bp3-interactive:active{
-          background-color:rgba(191, 204, 214, 0.4); }
-      .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]) > .bp3-icon, .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]) .bp3-icon-standard, .bp3-dark .bp3-tag.bp3-minimal:not([class*="bp3-intent-"]) .bp3-icon-large{
-        fill:#a7b6c2; }
-  .bp3-tag.bp3-minimal.bp3-intent-primary{
-    background-color:rgba(19, 124, 189, 0.15);
-    color:#106ba3; }
-    .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:hover{
-        background-color:rgba(19, 124, 189, 0.25); }
-      .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:active{
-        background-color:rgba(19, 124, 189, 0.35); }
-    .bp3-tag.bp3-minimal.bp3-intent-primary > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-primary .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-primary .bp3-icon-large{
-      fill:#137cbd; }
-    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary{
-      background-color:rgba(19, 124, 189, 0.25);
-      color:#48aff0; }
-      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive{
-        cursor:pointer; }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:hover{
-          background-color:rgba(19, 124, 189, 0.35); }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:active{
-          background-color:rgba(19, 124, 189, 0.45); }
-  .bp3-tag.bp3-minimal.bp3-intent-success{
-    background-color:rgba(15, 153, 96, 0.15);
-    color:#0d8050; }
-    .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:hover{
-        background-color:rgba(15, 153, 96, 0.25); }
-      .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:active{
-        background-color:rgba(15, 153, 96, 0.35); }
-    .bp3-tag.bp3-minimal.bp3-intent-success > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-success .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-success .bp3-icon-large{
-      fill:#0f9960; }
-    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success{
-      background-color:rgba(15, 153, 96, 0.25);
-      color:#3dcc91; }
-      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive{
-        cursor:pointer; }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:hover{
-          background-color:rgba(15, 153, 96, 0.35); }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:active{
-          background-color:rgba(15, 153, 96, 0.45); }
-  .bp3-tag.bp3-minimal.bp3-intent-warning{
-    background-color:rgba(217, 130, 43, 0.15);
-    color:#bf7326; }
-    .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:hover{
-        background-color:rgba(217, 130, 43, 0.25); }
-      .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:active{
-        background-color:rgba(217, 130, 43, 0.35); }
-    .bp3-tag.bp3-minimal.bp3-intent-warning > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-warning .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-warning .bp3-icon-large{
-      fill:#d9822b; }
-    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning{
-      background-color:rgba(217, 130, 43, 0.25);
-      color:#ffb366; }
-      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive{
-        cursor:pointer; }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:hover{
-          background-color:rgba(217, 130, 43, 0.35); }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:active{
-          background-color:rgba(217, 130, 43, 0.45); }
-  .bp3-tag.bp3-minimal.bp3-intent-danger{
-    background-color:rgba(219, 55, 55, 0.15);
-    color:#c23030; }
-    .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive{
-      cursor:pointer; }
-      .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:hover{
-        background-color:rgba(219, 55, 55, 0.25); }
-      .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive.bp3-active, .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:active{
-        background-color:rgba(219, 55, 55, 0.35); }
-    .bp3-tag.bp3-minimal.bp3-intent-danger > .bp3-icon, .bp3-tag.bp3-minimal.bp3-intent-danger .bp3-icon-standard, .bp3-tag.bp3-minimal.bp3-intent-danger .bp3-icon-large{
-      fill:#db3737; }
-    .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger{
-      background-color:rgba(219, 55, 55, 0.25);
-      color:#ff7373; }
-      .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive{
-        cursor:pointer; }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:hover{
-          background-color:rgba(219, 55, 55, 0.35); }
-        .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive.bp3-active, .bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:active{
-          background-color:rgba(219, 55, 55, 0.45); }
+.bp3-flex-expander {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+}
+.bp3-tag {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  border-radius: 3px;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: #5c7080;
+  min-width: 20px;
+  max-width: 100%;
+  min-height: 20px;
+  padding: 2px 6px;
+  line-height: 16px;
+  color: #f5f8fa;
+  font-size: 12px;
+}
+.bp3-tag.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-interactive:hover {
+  background-color: rgba(92, 112, 128, 0.85);
+}
+.bp3-tag.bp3-interactive.bp3-active,
+.bp3-tag.bp3-interactive:active {
+  background-color: rgba(92, 112, 128, 0.7);
+}
+.bp3-tag > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-tag > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-tag::before,
+.bp3-tag > * {
+  margin-right: 4px;
+}
+.bp3-tag:empty::before,
+.bp3-tag > :last-child {
+  margin-right: 0;
+}
+.bp3-tag:focus {
+  outline: rgba(19, 124, 189, 0.6) auto 2px;
+  outline-offset: 0;
+  -moz-outline-radius: 6px;
+}
+.bp3-tag.bp3-round {
+  border-radius: 30px;
+  padding-right: 8px;
+  padding-left: 8px;
+}
+.bp3-dark .bp3-tag {
+  background-color: #bfccd6;
+  color: #182026;
+}
+.bp3-dark .bp3-tag.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-dark .bp3-tag.bp3-interactive:hover {
+  background-color: rgba(191, 204, 214, 0.85);
+}
+.bp3-dark .bp3-tag.bp3-interactive.bp3-active,
+.bp3-dark .bp3-tag.bp3-interactive:active {
+  background-color: rgba(191, 204, 214, 0.7);
+}
+.bp3-dark .bp3-tag > .bp3-icon,
+.bp3-dark .bp3-tag .bp3-icon-standard,
+.bp3-dark .bp3-tag .bp3-icon-large {
+  fill: currentColor;
+}
+.bp3-tag > .bp3-icon,
+.bp3-tag .bp3-icon-standard,
+.bp3-tag .bp3-icon-large {
+  fill: #ffffff;
+}
+.bp3-tag.bp3-large,
+.bp3-large .bp3-tag {
+  min-width: 30px;
+  min-height: 30px;
+  padding: 0 10px;
+  line-height: 20px;
+  font-size: 14px;
+}
+.bp3-tag.bp3-large::before,
+.bp3-tag.bp3-large > *,
+.bp3-large .bp3-tag::before,
+.bp3-large .bp3-tag > * {
+  margin-right: 7px;
+}
+.bp3-tag.bp3-large:empty::before,
+.bp3-tag.bp3-large > :last-child,
+.bp3-large .bp3-tag:empty::before,
+.bp3-large .bp3-tag > :last-child {
+  margin-right: 0;
+}
+.bp3-tag.bp3-large.bp3-round,
+.bp3-large .bp3-tag.bp3-round {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+.bp3-tag.bp3-intent-primary {
+  background: #137cbd;
+  color: #ffffff;
+}
+.bp3-tag.bp3-intent-primary.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-intent-primary.bp3-interactive:hover {
+  background-color: rgba(19, 124, 189, 0.85);
+}
+.bp3-tag.bp3-intent-primary.bp3-interactive.bp3-active,
+.bp3-tag.bp3-intent-primary.bp3-interactive:active {
+  background-color: rgba(19, 124, 189, 0.7);
+}
+.bp3-tag.bp3-intent-success {
+  background: #0f9960;
+  color: #ffffff;
+}
+.bp3-tag.bp3-intent-success.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-intent-success.bp3-interactive:hover {
+  background-color: rgba(15, 153, 96, 0.85);
+}
+.bp3-tag.bp3-intent-success.bp3-interactive.bp3-active,
+.bp3-tag.bp3-intent-success.bp3-interactive:active {
+  background-color: rgba(15, 153, 96, 0.7);
+}
+.bp3-tag.bp3-intent-warning {
+  background: #d9822b;
+  color: #ffffff;
+}
+.bp3-tag.bp3-intent-warning.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-intent-warning.bp3-interactive:hover {
+  background-color: rgba(217, 130, 43, 0.85);
+}
+.bp3-tag.bp3-intent-warning.bp3-interactive.bp3-active,
+.bp3-tag.bp3-intent-warning.bp3-interactive:active {
+  background-color: rgba(217, 130, 43, 0.7);
+}
+.bp3-tag.bp3-intent-danger {
+  background: #db3737;
+  color: #ffffff;
+}
+.bp3-tag.bp3-intent-danger.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-intent-danger.bp3-interactive:hover {
+  background-color: rgba(219, 55, 55, 0.85);
+}
+.bp3-tag.bp3-intent-danger.bp3-interactive.bp3-active,
+.bp3-tag.bp3-intent-danger.bp3-interactive:active {
+  background-color: rgba(219, 55, 55, 0.7);
+}
+.bp3-tag.bp3-fill {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+.bp3-tag.bp3-minimal > .bp3-icon,
+.bp3-tag.bp3-minimal .bp3-icon-standard,
+.bp3-tag.bp3-minimal .bp3-icon-large {
+  fill: #5c7080;
+}
+.bp3-tag.bp3-minimal:not([class*='bp3-intent-']) {
+  background-color: rgba(138, 155, 168, 0.2);
+  color: #182026;
+}
+.bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive:hover {
+  background-color: rgba(92, 112, 128, 0.3);
+}
+.bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive.bp3-active,
+.bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive:active {
+  background-color: rgba(92, 112, 128, 0.4);
+}
+.bp3-dark .bp3-tag.bp3-minimal:not([class*='bp3-intent-']) {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive {
+  cursor: pointer;
+}
+.bp3-dark
+  .bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive:hover {
+  background-color: rgba(191, 204, 214, 0.3);
+}
+.bp3-dark
+  .bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive.bp3-active,
+.bp3-dark
+  .bp3-tag.bp3-minimal:not([class*='bp3-intent-']).bp3-interactive:active {
+  background-color: rgba(191, 204, 214, 0.4);
+}
+.bp3-dark .bp3-tag.bp3-minimal:not([class*='bp3-intent-']) > .bp3-icon,
+.bp3-dark .bp3-tag.bp3-minimal:not([class*='bp3-intent-']) .bp3-icon-standard,
+.bp3-dark .bp3-tag.bp3-minimal:not([class*='bp3-intent-']) .bp3-icon-large {
+  fill: #a7b6c2;
+}
+.bp3-tag.bp3-minimal.bp3-intent-primary {
+  background-color: rgba(19, 124, 189, 0.15);
+  color: #106ba3;
+}
+.bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:hover {
+  background-color: rgba(19, 124, 189, 0.25);
+}
+.bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive.bp3-active,
+.bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:active {
+  background-color: rgba(19, 124, 189, 0.35);
+}
+.bp3-tag.bp3-minimal.bp3-intent-primary > .bp3-icon,
+.bp3-tag.bp3-minimal.bp3-intent-primary .bp3-icon-standard,
+.bp3-tag.bp3-minimal.bp3-intent-primary .bp3-icon-large {
+  fill: #137cbd;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary {
+  background-color: rgba(19, 124, 189, 0.25);
+  color: #48aff0;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:hover {
+  background-color: rgba(19, 124, 189, 0.35);
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive.bp3-active,
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-primary.bp3-interactive:active {
+  background-color: rgba(19, 124, 189, 0.45);
+}
+.bp3-tag.bp3-minimal.bp3-intent-success {
+  background-color: rgba(15, 153, 96, 0.15);
+  color: #0d8050;
+}
+.bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:hover {
+  background-color: rgba(15, 153, 96, 0.25);
+}
+.bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive.bp3-active,
+.bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:active {
+  background-color: rgba(15, 153, 96, 0.35);
+}
+.bp3-tag.bp3-minimal.bp3-intent-success > .bp3-icon,
+.bp3-tag.bp3-minimal.bp3-intent-success .bp3-icon-standard,
+.bp3-tag.bp3-minimal.bp3-intent-success .bp3-icon-large {
+  fill: #0f9960;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success {
+  background-color: rgba(15, 153, 96, 0.25);
+  color: #3dcc91;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:hover {
+  background-color: rgba(15, 153, 96, 0.35);
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive.bp3-active,
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-success.bp3-interactive:active {
+  background-color: rgba(15, 153, 96, 0.45);
+}
+.bp3-tag.bp3-minimal.bp3-intent-warning {
+  background-color: rgba(217, 130, 43, 0.15);
+  color: #bf7326;
+}
+.bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:hover {
+  background-color: rgba(217, 130, 43, 0.25);
+}
+.bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive.bp3-active,
+.bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:active {
+  background-color: rgba(217, 130, 43, 0.35);
+}
+.bp3-tag.bp3-minimal.bp3-intent-warning > .bp3-icon,
+.bp3-tag.bp3-minimal.bp3-intent-warning .bp3-icon-standard,
+.bp3-tag.bp3-minimal.bp3-intent-warning .bp3-icon-large {
+  fill: #d9822b;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning {
+  background-color: rgba(217, 130, 43, 0.25);
+  color: #ffb366;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:hover {
+  background-color: rgba(217, 130, 43, 0.35);
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive.bp3-active,
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-warning.bp3-interactive:active {
+  background-color: rgba(217, 130, 43, 0.45);
+}
+.bp3-tag.bp3-minimal.bp3-intent-danger {
+  background-color: rgba(219, 55, 55, 0.15);
+  color: #c23030;
+}
+.bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:hover {
+  background-color: rgba(219, 55, 55, 0.25);
+}
+.bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive.bp3-active,
+.bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:active {
+  background-color: rgba(219, 55, 55, 0.35);
+}
+.bp3-tag.bp3-minimal.bp3-intent-danger > .bp3-icon,
+.bp3-tag.bp3-minimal.bp3-intent-danger .bp3-icon-standard,
+.bp3-tag.bp3-minimal.bp3-intent-danger .bp3-icon-large {
+  fill: #db3737;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger {
+  background-color: rgba(219, 55, 55, 0.25);
+  color: #ff7373;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive {
+  cursor: pointer;
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:hover {
+  background-color: rgba(219, 55, 55, 0.35);
+}
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive.bp3-active,
+.bp3-dark .bp3-tag.bp3-minimal.bp3-intent-danger.bp3-interactive:active {
+  background-color: rgba(219, 55, 55, 0.45);
+}
 
-.bp3-tag-remove{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  opacity:0.5;
-  margin-top:-2px;
-  margin-right:-6px !important;
-  margin-bottom:-2px;
-  border:none;
-  background:none;
-  cursor:pointer;
-  padding:2px;
-  padding-left:0;
-  color:inherit; }
-  .bp3-tag-remove:hover{
-    opacity:0.8;
-    background:none;
-    text-decoration:none; }
-  .bp3-tag-remove:active{
-    opacity:1; }
-  .bp3-tag-remove:empty::before{
-    line-height:1;
-    font-family:"Icons16", sans-serif;
-    font-size:16px;
-    font-weight:400;
-    font-style:normal;
-    -moz-osx-font-smoothing:grayscale;
-    -webkit-font-smoothing:antialiased;
-    content:""; }
-  .bp3-large .bp3-tag-remove{
-    margin-right:-10px !important;
-    padding:5px;
-    padding-left:0; }
-    .bp3-large .bp3-tag-remove:empty::before{
-      line-height:1;
-      font-family:"Icons20", sans-serif;
-      font-size:20px;
-      font-weight:400;
-      font-style:normal; }
-.bp3-tag-input{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient:horizontal;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:row;
-          flex-direction:row;
-  -webkit-box-align:start;
-      -ms-flex-align:start;
-          align-items:flex-start;
-  cursor:text;
-  height:auto;
-  min-height:30px;
-  padding-right:0;
-  padding-left:5px;
-  line-height:inherit; }
-  .bp3-tag-input > *{
-    -webkit-box-flex:0;
-        -ms-flex-positive:0;
-            flex-grow:0;
-    -ms-flex-negative:0;
-        flex-shrink:0; }
-  .bp3-tag-input > .bp3-tag-input-values{
-    -webkit-box-flex:1;
-        -ms-flex-positive:1;
-            flex-grow:1;
-    -ms-flex-negative:1;
-        flex-shrink:1; }
-  .bp3-tag-input .bp3-tag-input-icon{
-    margin-top:7px;
-    margin-right:7px;
-    margin-left:2px;
-    color:#5c7080; }
-  .bp3-tag-input .bp3-tag-input-values{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    -webkit-box-orient:horizontal;
-    -webkit-box-direction:normal;
-        -ms-flex-direction:row;
-            flex-direction:row;
-    -ms-flex-wrap:wrap;
-        flex-wrap:wrap;
-    -webkit-box-align:center;
-        -ms-flex-align:center;
-            align-items:center;
-    -ms-flex-item-align:stretch;
-        align-self:stretch;
-    margin-top:5px;
-    margin-right:7px;
-    min-width:0; }
-    .bp3-tag-input .bp3-tag-input-values > *{
-      -webkit-box-flex:0;
-          -ms-flex-positive:0;
-              flex-grow:0;
-      -ms-flex-negative:0;
-          flex-shrink:0; }
-    .bp3-tag-input .bp3-tag-input-values > .bp3-fill{
-      -webkit-box-flex:1;
-          -ms-flex-positive:1;
-              flex-grow:1;
-      -ms-flex-negative:1;
-          flex-shrink:1; }
-    .bp3-tag-input .bp3-tag-input-values::before,
-    .bp3-tag-input .bp3-tag-input-values > *{
-      margin-right:5px; }
-    .bp3-tag-input .bp3-tag-input-values:empty::before,
-    .bp3-tag-input .bp3-tag-input-values > :last-child{
-      margin-right:0; }
-    .bp3-tag-input .bp3-tag-input-values:first-child .bp3-input-ghost:first-child{
-      padding-left:5px; }
-    .bp3-tag-input .bp3-tag-input-values > *{
-      margin-bottom:5px; }
-  .bp3-tag-input .bp3-tag{
-    overflow-wrap:break-word; }
-    .bp3-tag-input .bp3-tag.bp3-active{
-      outline:rgba(19, 124, 189, 0.6) auto 2px;
-      outline-offset:0;
-      -moz-outline-radius:6px; }
-  .bp3-tag-input .bp3-input-ghost{
-    -webkit-box-flex:1;
-        -ms-flex:1 1 auto;
-            flex:1 1 auto;
-    width:80px;
-    line-height:20px; }
-    .bp3-tag-input .bp3-input-ghost:disabled, .bp3-tag-input .bp3-input-ghost.bp3-disabled{
-      cursor:not-allowed; }
-  .bp3-tag-input .bp3-button,
-  .bp3-tag-input .bp3-spinner{
-    margin:3px;
-    margin-left:0; }
-  .bp3-tag-input .bp3-button{
-    min-width:24px;
-    min-height:24px;
-    padding:0 7px; }
-  .bp3-tag-input.bp3-large{
-    height:auto;
-    min-height:40px; }
-    .bp3-tag-input.bp3-large::before,
-    .bp3-tag-input.bp3-large > *{
-      margin-right:10px; }
-    .bp3-tag-input.bp3-large:empty::before,
-    .bp3-tag-input.bp3-large > :last-child{
-      margin-right:0; }
-    .bp3-tag-input.bp3-large .bp3-tag-input-icon{
-      margin-top:10px;
-      margin-left:5px; }
-    .bp3-tag-input.bp3-large .bp3-input-ghost{
-      line-height:30px; }
-    .bp3-tag-input.bp3-large .bp3-button{
-      min-width:30px;
-      min-height:30px;
-      padding:5px 10px;
-      margin:5px;
-      margin-left:0; }
-    .bp3-tag-input.bp3-large .bp3-spinner{
-      margin:8px;
-      margin-left:0; }
-  .bp3-tag-input.bp3-active{
-    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-    background-color:#ffffff; }
-    .bp3-tag-input.bp3-active.bp3-intent-primary{
-      -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-tag-input.bp3-active.bp3-intent-success{
-      -webkit-box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-tag-input.bp3-active.bp3-intent-warning{
-      -webkit-box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-    .bp3-tag-input.bp3-active.bp3-intent-danger{
-      -webkit-box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
-  .bp3-dark .bp3-tag-input .bp3-tag-input-icon, .bp3-tag-input.bp3-dark .bp3-tag-input-icon{
-    color:#a7b6c2; }
-  .bp3-dark .bp3-tag-input .bp3-input-ghost, .bp3-tag-input.bp3-dark .bp3-input-ghost{
-    color:#f5f8fa; }
-    .bp3-dark .bp3-tag-input .bp3-input-ghost::-webkit-input-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::-webkit-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-tag-input .bp3-input-ghost::-moz-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::-moz-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-tag-input .bp3-input-ghost:-ms-input-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost:-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-tag-input .bp3-input-ghost::-ms-input-placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::-ms-input-placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-    .bp3-dark .bp3-tag-input .bp3-input-ghost::placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::placeholder{
-      color:rgba(167, 182, 194, 0.6); }
-  .bp3-dark .bp3-tag-input.bp3-active, .bp3-tag-input.bp3-dark.bp3-active{
-    -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background-color:rgba(16, 22, 26, 0.3); }
-    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-primary, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-primary{
-      -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-success, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-success{
-      -webkit-box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-warning, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-warning{
-      -webkit-box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
-    .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-danger, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-danger{
-      -webkit-box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
+.bp3-tag-remove {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  opacity: 0.5;
+  margin-top: -2px;
+  margin-right: -6px !important;
+  margin-bottom: -2px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 2px;
+  padding-left: 0;
+  color: inherit;
+}
+.bp3-tag-remove:hover {
+  opacity: 0.8;
+  background: none;
+  text-decoration: none;
+}
+.bp3-tag-remove:active {
+  opacity: 1;
+}
+.bp3-tag-remove:empty::before {
+  line-height: 1;
+  font-family: 'Icons16', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  font-style: normal;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  content: '';
+}
+.bp3-large .bp3-tag-remove {
+  margin-right: -10px !important;
+  padding: 5px;
+  padding-left: 0;
+}
+.bp3-large .bp3-tag-remove:empty::before {
+  line-height: 1;
+  font-family: 'Icons20', sans-serif;
+  font-size: 20px;
+  font-weight: 400;
+  font-style: normal;
+}
+.bp3-tag-input {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  cursor: text;
+  height: auto;
+  min-height: 30px;
+  padding-right: 0;
+  padding-left: 5px;
+  line-height: inherit;
+}
+.bp3-tag-input > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-tag-input > .bp3-tag-input-values {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-tag-input .bp3-tag-input-icon {
+  margin-top: 7px;
+  margin-right: 7px;
+  margin-left: 2px;
+  color: #5c7080;
+}
+.bp3-tag-input .bp3-tag-input-values {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  margin-top: 5px;
+  margin-right: 7px;
+  min-width: 0;
+}
+.bp3-tag-input .bp3-tag-input-values > * {
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.bp3-tag-input .bp3-tag-input-values > .bp3-fill {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+.bp3-tag-input .bp3-tag-input-values::before,
+.bp3-tag-input .bp3-tag-input-values > * {
+  margin-right: 5px;
+}
+.bp3-tag-input .bp3-tag-input-values:empty::before,
+.bp3-tag-input .bp3-tag-input-values > :last-child {
+  margin-right: 0;
+}
+.bp3-tag-input .bp3-tag-input-values:first-child .bp3-input-ghost:first-child {
+  padding-left: 5px;
+}
+.bp3-tag-input .bp3-tag-input-values > * {
+  margin-bottom: 5px;
+}
+.bp3-tag-input .bp3-tag {
+  overflow-wrap: break-word;
+}
+.bp3-tag-input .bp3-tag.bp3-active {
+  outline: rgba(19, 124, 189, 0.6) auto 2px;
+  outline-offset: 0;
+  -moz-outline-radius: 6px;
+}
+.bp3-tag-input .bp3-input-ghost {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 80px;
+  line-height: 20px;
+}
+.bp3-tag-input .bp3-input-ghost:disabled,
+.bp3-tag-input .bp3-input-ghost.bp3-disabled {
+  cursor: not-allowed;
+}
+.bp3-tag-input .bp3-button,
+.bp3-tag-input .bp3-spinner {
+  margin: 3px;
+  margin-left: 0;
+}
+.bp3-tag-input .bp3-button {
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0 7px;
+}
+.bp3-tag-input.bp3-large {
+  height: auto;
+  min-height: 40px;
+}
+.bp3-tag-input.bp3-large::before,
+.bp3-tag-input.bp3-large > * {
+  margin-right: 10px;
+}
+.bp3-tag-input.bp3-large:empty::before,
+.bp3-tag-input.bp3-large > :last-child {
+  margin-right: 0;
+}
+.bp3-tag-input.bp3-large .bp3-tag-input-icon {
+  margin-top: 10px;
+  margin-left: 5px;
+}
+.bp3-tag-input.bp3-large .bp3-input-ghost {
+  line-height: 30px;
+}
+.bp3-tag-input.bp3-large .bp3-button {
+  min-width: 30px;
+  min-height: 30px;
+  padding: 5px 10px;
+  margin: 5px;
+  margin-left: 0;
+}
+.bp3-tag-input.bp3-large .bp3-spinner {
+  margin: 8px;
+  margin-left: 0;
+}
+.bp3-tag-input.bp3-active {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  background-color: #ffffff;
+}
+.bp3-tag-input.bp3-active.bp3-intent-primary {
+  -webkit-box-shadow: 0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-tag-input.bp3-active.bp3-intent-success {
+  -webkit-box-shadow: 0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-tag-input.bp3-active.bp3-intent-warning {
+  -webkit-box-shadow: 0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-tag-input.bp3-active.bp3-intent-danger {
+  -webkit-box-shadow: 0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+.bp3-dark .bp3-tag-input .bp3-tag-input-icon,
+.bp3-tag-input.bp3-dark .bp3-tag-input-icon {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-tag-input .bp3-input-ghost,
+.bp3-tag-input.bp3-dark .bp3-input-ghost {
+  color: #f5f8fa;
+}
+.bp3-dark .bp3-tag-input .bp3-input-ghost::-webkit-input-placeholder,
+.bp3-tag-input.bp3-dark .bp3-input-ghost::-webkit-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-tag-input .bp3-input-ghost::-moz-placeholder,
+.bp3-tag-input.bp3-dark .bp3-input-ghost::-moz-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-tag-input .bp3-input-ghost:-ms-input-placeholder,
+.bp3-tag-input.bp3-dark .bp3-input-ghost:-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-tag-input .bp3-input-ghost::-ms-input-placeholder,
+.bp3-tag-input.bp3-dark .bp3-input-ghost::-ms-input-placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-tag-input .bp3-input-ghost::placeholder,
+.bp3-tag-input.bp3-dark .bp3-input-ghost::placeholder {
+  color: rgba(167, 182, 194, 0.6);
+}
+.bp3-dark .bp3-tag-input.bp3-active,
+.bp3-tag-input.bp3-dark.bp3-active {
+  -webkit-box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #137cbd, 0 0 0 1px #137cbd,
+    0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3),
+    inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  background-color: rgba(16, 22, 26, 0.3);
+}
+.bp3-dark .bp3-tag-input.bp3-active.bp3-intent-primary,
+.bp3-tag-input.bp3-dark.bp3-active.bp3-intent-primary {
+  -webkit-box-shadow: 0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-tag-input.bp3-active.bp3-intent-success,
+.bp3-tag-input.bp3-dark.bp3-active.bp3-intent-success {
+  -webkit-box-shadow: 0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #0d8050, 0 0 0 3px rgba(13, 128, 80, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-tag-input.bp3-active.bp3-intent-warning,
+.bp3-tag-input.bp3-dark.bp3-active.bp3-intent-warning {
+  -webkit-box-shadow: 0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #bf7326, 0 0 0 3px rgba(191, 115, 38, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
+.bp3-dark .bp3-tag-input.bp3-active.bp3-intent-danger,
+.bp3-tag-input.bp3-dark.bp3-active.bp3-intent-danger {
+  -webkit-box-shadow: 0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3),
+    inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
+}
 
-.bp3-input-ghost{
-  border:none;
-  -webkit-box-shadow:none;
-          box-shadow:none;
-  background:none;
-  padding:0; }
-  .bp3-input-ghost::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input-ghost::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input-ghost:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input-ghost::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input-ghost::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
-  .bp3-input-ghost:focus{
-    outline:none !important; }
-.bp3-toast{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-align:start;
-      -ms-flex-align:start;
-          align-items:flex-start;
-  position:relative !important;
-  margin:20px 0 0;
-  border-radius:3px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  min-width:300px;
-  max-width:500px;
-  pointer-events:all; }
-  .bp3-toast.bp3-toast-enter, .bp3-toast.bp3-toast-appear{
-    -webkit-transform:translateY(-40px);
-            transform:translateY(-40px); }
-  .bp3-toast.bp3-toast-enter-active, .bp3-toast.bp3-toast-appear-active{
-    -webkit-transform:translateY(0);
-            transform:translateY(0);
-    -webkit-transition-property:-webkit-transform;
-    transition-property:-webkit-transform;
-    transition-property:transform;
-    transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
-    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-toast.bp3-toast-enter ~ .bp3-toast, .bp3-toast.bp3-toast-appear ~ .bp3-toast{
-    -webkit-transform:translateY(-40px);
-            transform:translateY(-40px); }
-  .bp3-toast.bp3-toast-enter-active ~ .bp3-toast, .bp3-toast.bp3-toast-appear-active ~ .bp3-toast{
-    -webkit-transform:translateY(0);
-            transform:translateY(0);
-    -webkit-transition-property:-webkit-transform;
-    transition-property:-webkit-transform;
-    transition-property:transform;
-    transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
-    -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-toast.bp3-toast-exit{
-    opacity:1;
-    -webkit-filter:blur(0);
-            filter:blur(0); }
-  .bp3-toast.bp3-toast-exit-active{
-    opacity:0;
-    -webkit-filter:blur(10px);
-            filter:blur(10px);
-    -webkit-transition-property:opacity, -webkit-filter;
-    transition-property:opacity, -webkit-filter;
-    transition-property:opacity, filter;
-    transition-property:opacity, filter, -webkit-filter;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-toast.bp3-toast-exit ~ .bp3-toast{
-    -webkit-transform:translateY(0);
-            transform:translateY(0); }
-  .bp3-toast.bp3-toast-exit-active ~ .bp3-toast{
-    -webkit-transform:translateY(-40px);
-            transform:translateY(-40px);
-    -webkit-transition-property:-webkit-transform;
-    transition-property:-webkit-transform;
-    transition-property:transform;
-    transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:50ms;
-            transition-delay:50ms; }
-  .bp3-toast .bp3-button-group{
-    -webkit-box-flex:0;
-        -ms-flex:0 0 auto;
-            flex:0 0 auto;
-    padding:5px;
-    padding-left:0; }
-  .bp3-toast > .bp3-icon{
-    margin:12px;
-    margin-right:0;
-    color:#5c7080; }
-  .bp3-toast.bp3-dark,
-  .bp3-dark .bp3-toast{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-    background-color:#394b59; }
-    .bp3-toast.bp3-dark > .bp3-icon,
-    .bp3-dark .bp3-toast > .bp3-icon{
-      color:#a7b6c2; }
-  .bp3-toast[class*="bp3-intent-"] a{
-    color:rgba(255, 255, 255, 0.7); }
-    .bp3-toast[class*="bp3-intent-"] a:hover{
-      color:#ffffff; }
-  .bp3-toast[class*="bp3-intent-"] > .bp3-icon{
-    color:#ffffff; }
-  .bp3-toast[class*="bp3-intent-"] .bp3-button, .bp3-toast[class*="bp3-intent-"] .bp3-button::before,
-  .bp3-toast[class*="bp3-intent-"] .bp3-button .bp3-icon, .bp3-toast[class*="bp3-intent-"] .bp3-button:active{
-    color:rgba(255, 255, 255, 0.7) !important; }
-  .bp3-toast[class*="bp3-intent-"] .bp3-button:focus{
-    outline-color:rgba(255, 255, 255, 0.5); }
-  .bp3-toast[class*="bp3-intent-"] .bp3-button:hover{
-    background-color:rgba(255, 255, 255, 0.15) !important;
-    color:#ffffff !important; }
-  .bp3-toast[class*="bp3-intent-"] .bp3-button:active{
-    background-color:rgba(255, 255, 255, 0.3) !important;
-    color:#ffffff !important; }
-  .bp3-toast[class*="bp3-intent-"] .bp3-button::after{
-    background:rgba(255, 255, 255, 0.3) !important; }
-  .bp3-toast.bp3-intent-primary{
-    background-color:#137cbd;
-    color:#ffffff; }
-  .bp3-toast.bp3-intent-success{
-    background-color:#0f9960;
-    color:#ffffff; }
-  .bp3-toast.bp3-intent-warning{
-    background-color:#d9822b;
-    color:#ffffff; }
-  .bp3-toast.bp3-intent-danger{
-    background-color:#db3737;
-    color:#ffffff; }
+.bp3-input-ghost {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: none;
+  padding: 0;
+}
+.bp3-input-ghost::-webkit-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input-ghost::-moz-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input-ghost:-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input-ghost::-ms-input-placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input-ghost::placeholder {
+  opacity: 1;
+  color: rgba(92, 112, 128, 0.6);
+}
+.bp3-input-ghost:focus {
+  outline: none !important;
+}
+.bp3-toast {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  position: relative !important;
+  margin: 20px 0 0;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
+    0 8px 24px rgba(16, 22, 26, 0.2);
+  background-color: #ffffff;
+  min-width: 300px;
+  max-width: 500px;
+  pointer-events: all;
+}
+.bp3-toast.bp3-toast-enter,
+.bp3-toast.bp3-toast-appear {
+  -webkit-transform: translateY(-40px);
+  transform: translateY(-40px);
+}
+.bp3-toast.bp3-toast-enter-active,
+.bp3-toast.bp3-toast-appear-active {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-toast.bp3-toast-enter ~ .bp3-toast,
+.bp3-toast.bp3-toast-appear ~ .bp3-toast {
+  -webkit-transform: translateY(-40px);
+  transform: translateY(-40px);
+}
+.bp3-toast.bp3-toast-enter-active ~ .bp3-toast,
+.bp3-toast.bp3-toast-appear-active ~ .bp3-toast {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-toast.bp3-toast-exit {
+  opacity: 1;
+  -webkit-filter: blur(0);
+  filter: blur(0);
+}
+.bp3-toast.bp3-toast-exit-active {
+  opacity: 0;
+  -webkit-filter: blur(10px);
+  filter: blur(10px);
+  -webkit-transition-property: opacity, -webkit-filter;
+  transition-property: opacity, -webkit-filter;
+  transition-property: opacity, filter;
+  transition-property: opacity, filter, -webkit-filter;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-toast.bp3-toast-exit ~ .bp3-toast {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+}
+.bp3-toast.bp3-toast-exit-active ~ .bp3-toast {
+  -webkit-transform: translateY(-40px);
+  transform: translateY(-40px);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 50ms;
+  transition-delay: 50ms;
+}
+.bp3-toast .bp3-button-group {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 5px;
+  padding-left: 0;
+}
+.bp3-toast > .bp3-icon {
+  margin: 12px;
+  margin-right: 0;
+  color: #5c7080;
+}
+.bp3-toast.bp3-dark,
+.bp3-dark .bp3-toast {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4),
+    0 8px 24px rgba(16, 22, 26, 0.4);
+  background-color: #394b59;
+}
+.bp3-toast.bp3-dark > .bp3-icon,
+.bp3-dark .bp3-toast > .bp3-icon {
+  color: #a7b6c2;
+}
+.bp3-toast[class*='bp3-intent-'] a {
+  color: rgba(255, 255, 255, 0.7);
+}
+.bp3-toast[class*='bp3-intent-'] a:hover {
+  color: #ffffff;
+}
+.bp3-toast[class*='bp3-intent-'] > .bp3-icon {
+  color: #ffffff;
+}
+.bp3-toast[class*='bp3-intent-'] .bp3-button,
+.bp3-toast[class*='bp3-intent-'] .bp3-button::before,
+.bp3-toast[class*='bp3-intent-'] .bp3-button .bp3-icon,
+.bp3-toast[class*='bp3-intent-'] .bp3-button:active {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+.bp3-toast[class*='bp3-intent-'] .bp3-button:focus {
+  outline-color: rgba(255, 255, 255, 0.5);
+}
+.bp3-toast[class*='bp3-intent-'] .bp3-button:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #ffffff !important;
+}
+.bp3-toast[class*='bp3-intent-'] .bp3-button:active {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  color: #ffffff !important;
+}
+.bp3-toast[class*='bp3-intent-'] .bp3-button::after {
+  background: rgba(255, 255, 255, 0.3) !important;
+}
+.bp3-toast.bp3-intent-primary {
+  background-color: #137cbd;
+  color: #ffffff;
+}
+.bp3-toast.bp3-intent-success {
+  background-color: #0f9960;
+  color: #ffffff;
+}
+.bp3-toast.bp3-intent-warning {
+  background-color: #d9822b;
+  color: #ffffff;
+}
+.bp3-toast.bp3-intent-danger {
+  background-color: #db3737;
+  color: #ffffff;
+}
 
-.bp3-toast-message{
-  -webkit-box-flex:1;
-      -ms-flex:1 1 auto;
-          flex:1 1 auto;
-  padding:11px;
-  word-break:break-word; }
+.bp3-toast-message {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  padding: 11px;
+  word-break: break-word;
+}
 
-.bp3-toast-container{
-  display:-webkit-box !important;
-  display:-ms-flexbox !important;
-  display:flex !important;
-  -webkit-box-orient:vertical;
-  -webkit-box-direction:normal;
-      -ms-flex-direction:column;
-          flex-direction:column;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  position:fixed;
-  right:0;
-  left:0;
-  z-index:40;
-  overflow:hidden;
-  padding:0 20px 20px;
-  pointer-events:none; }
-  .bp3-toast-container.bp3-toast-container-top{
-    top:0;
-    bottom:auto; }
-  .bp3-toast-container.bp3-toast-container-bottom{
-    -webkit-box-orient:vertical;
-    -webkit-box-direction:reverse;
-        -ms-flex-direction:column-reverse;
-            flex-direction:column-reverse;
-    top:auto;
-    bottom:0; }
-  .bp3-toast-container.bp3-toast-container-left{
-    -webkit-box-align:start;
-        -ms-flex-align:start;
-            align-items:flex-start; }
-  .bp3-toast-container.bp3-toast-container-right{
-    -webkit-box-align:end;
-        -ms-flex-align:end;
-            align-items:flex-end; }
+.bp3-toast-container {
+  display: -webkit-box !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: fixed;
+  right: 0;
+  left: 0;
+  z-index: 40;
+  overflow: hidden;
+  padding: 0 20px 20px;
+  pointer-events: none;
+}
+.bp3-toast-container.bp3-toast-container-top {
+  top: 0;
+  bottom: auto;
+}
+.bp3-toast-container.bp3-toast-container-bottom {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  top: auto;
+  bottom: 0;
+}
+.bp3-toast-container.bp3-toast-container-left {
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+}
+.bp3-toast-container.bp3-toast-container-right {
+  -webkit-box-align: end;
+  -ms-flex-align: end;
+  align-items: flex-end;
+}
 
-.bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active),
-.bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active) ~ .bp3-toast, .bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active),
-.bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active) ~ .bp3-toast,
-.bp3-toast-container-bottom .bp3-toast.bp3-toast-leave-active ~ .bp3-toast{
-  -webkit-transform:translateY(60px);
-          transform:translateY(60px); }
-.bp3-tooltip{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-  -webkit-transform:scale(1);
-          transform:scale(1); }
-  .bp3-tooltip .bp3-popover-arrow{
-    position:absolute;
-    width:22px;
-    height:22px; }
-    .bp3-tooltip .bp3-popover-arrow::before{
-      margin:4px;
-      width:14px;
-      height:14px; }
-  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip{
-    margin-top:-11px;
-    margin-bottom:11px; }
-    .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow{
-      bottom:-8px; }
-      .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(-90deg);
-                transform:rotate(-90deg); }
-  .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-tooltip{
-    margin-left:11px; }
-    .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-tooltip > .bp3-popover-arrow{
-      left:-8px; }
-      .bp3-tether-element-attached-left.bp3-tether-target-attached-right > .bp3-tooltip > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(0);
-                transform:rotate(0); }
-  .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-tooltip{
-    margin-top:11px; }
-    .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-tooltip > .bp3-popover-arrow{
-      top:-8px; }
-      .bp3-tether-element-attached-top.bp3-tether-target-attached-bottom > .bp3-tooltip > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(90deg);
-                transform:rotate(90deg); }
-  .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip{
-    margin-right:11px;
-    margin-left:-11px; }
-    .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow{
-      right:-8px; }
-      .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow svg{
-        -webkit-transform:rotate(180deg);
-                transform:rotate(180deg); }
-  .bp3-tether-element-attached-middle > .bp3-tooltip > .bp3-popover-arrow{
-    top:50%;
-    -webkit-transform:translateY(-50%);
-            transform:translateY(-50%); }
-  .bp3-tether-element-attached-center > .bp3-tooltip > .bp3-popover-arrow{
-    right:50%;
-    -webkit-transform:translateX(50%);
-            transform:translateX(50%); }
-  .bp3-tether-element-attached-top.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow{
-    top:-0.22183px; }
-  .bp3-tether-element-attached-right.bp3-tether-target-attached-right > .bp3-tooltip > .bp3-popover-arrow{
-    right:-0.22183px; }
-  .bp3-tether-element-attached-left.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow{
-    left:-0.22183px; }
-  .bp3-tether-element-attached-bottom.bp3-tether-target-attached-bottom > .bp3-tooltip > .bp3-popover-arrow{
-    bottom:-0.22183px; }
-  .bp3-tether-element-attached-top.bp3-tether-element-attached-left > .bp3-tooltip{
-    -webkit-transform-origin:top left;
-            transform-origin:top left; }
-  .bp3-tether-element-attached-top.bp3-tether-element-attached-center > .bp3-tooltip{
-    -webkit-transform-origin:top center;
-            transform-origin:top center; }
-  .bp3-tether-element-attached-top.bp3-tether-element-attached-right > .bp3-tooltip{
-    -webkit-transform-origin:top right;
-            transform-origin:top right; }
-  .bp3-tether-element-attached-middle.bp3-tether-element-attached-left > .bp3-tooltip{
-    -webkit-transform-origin:center left;
-            transform-origin:center left; }
-  .bp3-tether-element-attached-middle.bp3-tether-element-attached-center > .bp3-tooltip{
-    -webkit-transform-origin:center center;
-            transform-origin:center center; }
-  .bp3-tether-element-attached-middle.bp3-tether-element-attached-right > .bp3-tooltip{
-    -webkit-transform-origin:center right;
-            transform-origin:center right; }
-  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-left > .bp3-tooltip{
-    -webkit-transform-origin:bottom left;
-            transform-origin:bottom left; }
-  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-center > .bp3-tooltip{
-    -webkit-transform-origin:bottom center;
-            transform-origin:bottom center; }
-  .bp3-tether-element-attached-bottom.bp3-tether-element-attached-right > .bp3-tooltip{
-    -webkit-transform-origin:bottom right;
-            transform-origin:bottom right; }
-  .bp3-tooltip .bp3-popover-content{
-    background:#394b59;
-    color:#f5f8fa; }
-  .bp3-tooltip .bp3-popover-arrow::before{
-    -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2);
-            box-shadow:1px 1px 6px rgba(16, 22, 26, 0.2); }
-  .bp3-tooltip .bp3-popover-arrow-border{
-    fill:#10161a;
-    fill-opacity:0.1; }
-  .bp3-tooltip .bp3-popover-arrow-fill{
-    fill:#394b59; }
-  .bp3-popover-enter > .bp3-tooltip, .bp3-popover-appear > .bp3-tooltip{
-    -webkit-transform:scale(0.8);
-            transform:scale(0.8); }
-  .bp3-popover-enter-active > .bp3-tooltip, .bp3-popover-appear-active > .bp3-tooltip{
-    -webkit-transform:scale(1);
-            transform:scale(1);
-    -webkit-transition-property:-webkit-transform;
-    transition-property:-webkit-transform;
-    transition-property:transform;
-    transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-popover-exit > .bp3-tooltip{
-    -webkit-transform:scale(1);
-            transform:scale(1); }
-  .bp3-popover-exit-active > .bp3-tooltip{
-    -webkit-transform:scale(0.8);
-            transform:scale(0.8);
-    -webkit-transition-property:-webkit-transform;
-    transition-property:-webkit-transform;
-    transition-property:transform;
-    transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-tooltip .bp3-popover-content{
-    padding:10px 12px; }
-  .bp3-tooltip.bp3-dark,
-  .bp3-dark .bp3-tooltip{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
-    .bp3-tooltip.bp3-dark .bp3-popover-content,
-    .bp3-dark .bp3-tooltip .bp3-popover-content{
-      background:#e1e8ed;
-      color:#394b59; }
-    .bp3-tooltip.bp3-dark .bp3-popover-arrow::before,
-    .bp3-dark .bp3-tooltip .bp3-popover-arrow::before{
-      -webkit-box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4);
-              box-shadow:1px 1px 6px rgba(16, 22, 26, 0.4); }
-    .bp3-tooltip.bp3-dark .bp3-popover-arrow-border,
-    .bp3-dark .bp3-tooltip .bp3-popover-arrow-border{
-      fill:#10161a;
-      fill-opacity:0.2; }
-    .bp3-tooltip.bp3-dark .bp3-popover-arrow-fill,
-    .bp3-dark .bp3-tooltip .bp3-popover-arrow-fill{
-      fill:#e1e8ed; }
-  .bp3-tooltip.bp3-intent-primary .bp3-popover-content{
-    background:#137cbd;
-    color:#ffffff; }
-  .bp3-tooltip.bp3-intent-primary .bp3-popover-arrow-fill{
-    fill:#137cbd; }
-  .bp3-tooltip.bp3-intent-success .bp3-popover-content{
-    background:#0f9960;
-    color:#ffffff; }
-  .bp3-tooltip.bp3-intent-success .bp3-popover-arrow-fill{
-    fill:#0f9960; }
-  .bp3-tooltip.bp3-intent-warning .bp3-popover-content{
-    background:#d9822b;
-    color:#ffffff; }
-  .bp3-tooltip.bp3-intent-warning .bp3-popover-arrow-fill{
-    fill:#d9822b; }
-  .bp3-tooltip.bp3-intent-danger .bp3-popover-content{
-    background:#db3737;
-    color:#ffffff; }
-  .bp3-tooltip.bp3-intent-danger .bp3-popover-arrow-fill{
-    fill:#db3737; }
+.bp3-toast-container-bottom
+  .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active),
+.bp3-toast-container-bottom
+  .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active)
+  ~ .bp3-toast,
+.bp3-toast-container-bottom
+  .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active),
+.bp3-toast-container-bottom
+  .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active)
+  ~ .bp3-toast,
+.bp3-toast-container-bottom .bp3-toast.bp3-toast-leave-active ~ .bp3-toast {
+  -webkit-transform: translateY(60px);
+  transform: translateY(60px);
+}
+.bp3-tooltip {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
+    0 8px 24px rgba(16, 22, 26, 0.2);
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+.bp3-tooltip .bp3-popover-arrow {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+}
+.bp3-tooltip .bp3-popover-arrow::before {
+  margin: 4px;
+  width: 14px;
+  height: 14px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-top
+  > .bp3-tooltip {
+  margin-top: -11px;
+  margin-bottom: 11px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-top
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  bottom: -8px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-top
+  > .bp3-tooltip
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-right
+  > .bp3-tooltip {
+  margin-left: 11px;
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-right
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  left: -8px;
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-right
+  > .bp3-tooltip
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(0);
+  transform: rotate(0);
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-bottom
+  > .bp3-tooltip {
+  margin-top: 11px;
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-bottom
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  top: -8px;
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-bottom
+  > .bp3-tooltip
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-left
+  > .bp3-tooltip {
+  margin-right: 11px;
+  margin-left: -11px;
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-left
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  right: -8px;
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-left
+  > .bp3-tooltip
+  > .bp3-popover-arrow
+  svg {
+  -webkit-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+.bp3-tether-element-attached-middle > .bp3-tooltip > .bp3-popover-arrow {
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+.bp3-tether-element-attached-center > .bp3-tooltip > .bp3-popover-arrow {
+  right: 50%;
+  -webkit-transform: translateX(50%);
+  transform: translateX(50%);
+}
+.bp3-tether-element-attached-top.bp3-tether-target-attached-top
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  top: -0.22183px;
+}
+.bp3-tether-element-attached-right.bp3-tether-target-attached-right
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  right: -0.22183px;
+}
+.bp3-tether-element-attached-left.bp3-tether-target-attached-left
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  left: -0.22183px;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-target-attached-bottom
+  > .bp3-tooltip
+  > .bp3-popover-arrow {
+  bottom: -0.22183px;
+}
+.bp3-tether-element-attached-top.bp3-tether-element-attached-left
+  > .bp3-tooltip {
+  -webkit-transform-origin: top left;
+  transform-origin: top left;
+}
+.bp3-tether-element-attached-top.bp3-tether-element-attached-center
+  > .bp3-tooltip {
+  -webkit-transform-origin: top center;
+  transform-origin: top center;
+}
+.bp3-tether-element-attached-top.bp3-tether-element-attached-right
+  > .bp3-tooltip {
+  -webkit-transform-origin: top right;
+  transform-origin: top right;
+}
+.bp3-tether-element-attached-middle.bp3-tether-element-attached-left
+  > .bp3-tooltip {
+  -webkit-transform-origin: center left;
+  transform-origin: center left;
+}
+.bp3-tether-element-attached-middle.bp3-tether-element-attached-center
+  > .bp3-tooltip {
+  -webkit-transform-origin: center center;
+  transform-origin: center center;
+}
+.bp3-tether-element-attached-middle.bp3-tether-element-attached-right
+  > .bp3-tooltip {
+  -webkit-transform-origin: center right;
+  transform-origin: center right;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-element-attached-left
+  > .bp3-tooltip {
+  -webkit-transform-origin: bottom left;
+  transform-origin: bottom left;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-element-attached-center
+  > .bp3-tooltip {
+  -webkit-transform-origin: bottom center;
+  transform-origin: bottom center;
+}
+.bp3-tether-element-attached-bottom.bp3-tether-element-attached-right
+  > .bp3-tooltip {
+  -webkit-transform-origin: bottom right;
+  transform-origin: bottom right;
+}
+.bp3-tooltip .bp3-popover-content {
+  background: #394b59;
+  color: #f5f8fa;
+}
+.bp3-tooltip .bp3-popover-arrow::before {
+  -webkit-box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.2);
+  box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.2);
+}
+.bp3-tooltip .bp3-popover-arrow-border {
+  fill: #10161a;
+  fill-opacity: 0.1;
+}
+.bp3-tooltip .bp3-popover-arrow-fill {
+  fill: #394b59;
+}
+.bp3-popover-enter > .bp3-tooltip,
+.bp3-popover-appear > .bp3-tooltip {
+  -webkit-transform: scale(0.8);
+  transform: scale(0.8);
+}
+.bp3-popover-enter-active > .bp3-tooltip,
+.bp3-popover-appear-active > .bp3-tooltip {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-popover-exit > .bp3-tooltip {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+.bp3-popover-exit-active > .bp3-tooltip {
+  -webkit-transform: scale(0.8);
+  transform: scale(0.8);
+  -webkit-transition-property: -webkit-transform;
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-tooltip .bp3-popover-content {
+  padding: 10px 12px;
+}
+.bp3-tooltip.bp3-dark,
+.bp3-dark .bp3-tooltip {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4),
+    0 8px 24px rgba(16, 22, 26, 0.4);
+}
+.bp3-tooltip.bp3-dark .bp3-popover-content,
+.bp3-dark .bp3-tooltip .bp3-popover-content {
+  background: #e1e8ed;
+  color: #394b59;
+}
+.bp3-tooltip.bp3-dark .bp3-popover-arrow::before,
+.bp3-dark .bp3-tooltip .bp3-popover-arrow::before {
+  -webkit-box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.4);
+  box-shadow: 1px 1px 6px rgba(16, 22, 26, 0.4);
+}
+.bp3-tooltip.bp3-dark .bp3-popover-arrow-border,
+.bp3-dark .bp3-tooltip .bp3-popover-arrow-border {
+  fill: #10161a;
+  fill-opacity: 0.2;
+}
+.bp3-tooltip.bp3-dark .bp3-popover-arrow-fill,
+.bp3-dark .bp3-tooltip .bp3-popover-arrow-fill {
+  fill: #e1e8ed;
+}
+.bp3-tooltip.bp3-intent-primary .bp3-popover-content {
+  background: #137cbd;
+  color: #ffffff;
+}
+.bp3-tooltip.bp3-intent-primary .bp3-popover-arrow-fill {
+  fill: #137cbd;
+}
+.bp3-tooltip.bp3-intent-success .bp3-popover-content {
+  background: #0f9960;
+  color: #ffffff;
+}
+.bp3-tooltip.bp3-intent-success .bp3-popover-arrow-fill {
+  fill: #0f9960;
+}
+.bp3-tooltip.bp3-intent-warning .bp3-popover-content {
+  background: #d9822b;
+  color: #ffffff;
+}
+.bp3-tooltip.bp3-intent-warning .bp3-popover-arrow-fill {
+  fill: #d9822b;
+}
+.bp3-tooltip.bp3-intent-danger .bp3-popover-content {
+  background: #db3737;
+  color: #ffffff;
+}
+.bp3-tooltip.bp3-intent-danger .bp3-popover-arrow-fill {
+  fill: #db3737;
+}
 
-.bp3-tooltip-indicator{
-  border-bottom:dotted 1px;
-  cursor:help; }
-.bp3-tree .bp3-icon, .bp3-tree .bp3-icon-standard, .bp3-tree .bp3-icon-large{
-  color:#5c7080; }
-  .bp3-tree .bp3-icon.bp3-intent-primary, .bp3-tree .bp3-icon-standard.bp3-intent-primary, .bp3-tree .bp3-icon-large.bp3-intent-primary{
-    color:#137cbd; }
-  .bp3-tree .bp3-icon.bp3-intent-success, .bp3-tree .bp3-icon-standard.bp3-intent-success, .bp3-tree .bp3-icon-large.bp3-intent-success{
-    color:#0f9960; }
-  .bp3-tree .bp3-icon.bp3-intent-warning, .bp3-tree .bp3-icon-standard.bp3-intent-warning, .bp3-tree .bp3-icon-large.bp3-intent-warning{
-    color:#d9822b; }
-  .bp3-tree .bp3-icon.bp3-intent-danger, .bp3-tree .bp3-icon-standard.bp3-intent-danger, .bp3-tree .bp3-icon-large.bp3-intent-danger{
-    color:#db3737; }
+.bp3-tooltip-indicator {
+  border-bottom: dotted 1px;
+  cursor: help;
+}
+.bp3-tree .bp3-icon,
+.bp3-tree .bp3-icon-standard,
+.bp3-tree .bp3-icon-large {
+  color: #5c7080;
+}
+.bp3-tree .bp3-icon.bp3-intent-primary,
+.bp3-tree .bp3-icon-standard.bp3-intent-primary,
+.bp3-tree .bp3-icon-large.bp3-intent-primary {
+  color: #137cbd;
+}
+.bp3-tree .bp3-icon.bp3-intent-success,
+.bp3-tree .bp3-icon-standard.bp3-intent-success,
+.bp3-tree .bp3-icon-large.bp3-intent-success {
+  color: #0f9960;
+}
+.bp3-tree .bp3-icon.bp3-intent-warning,
+.bp3-tree .bp3-icon-standard.bp3-intent-warning,
+.bp3-tree .bp3-icon-large.bp3-intent-warning {
+  color: #d9822b;
+}
+.bp3-tree .bp3-icon.bp3-intent-danger,
+.bp3-tree .bp3-icon-standard.bp3-intent-danger,
+.bp3-tree .bp3-icon-large.bp3-intent-danger {
+  color: #db3737;
+}
 
-.bp3-tree-node-list{
-  margin:0;
-  padding-left:0;
-  list-style:none; }
+.bp3-tree-node-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
 
-.bp3-tree-root{
-  position:relative;
-  background-color:transparent;
-  cursor:default;
-  padding-left:0; }
+.bp3-tree-root {
+  position: relative;
+  background-color: transparent;
+  cursor: default;
+  padding-left: 0;
+}
 
-.bp3-tree-node-content-0{
-  padding-left:0px; }
+.bp3-tree-node-content-0 {
+  padding-left: 0px;
+}
 
-.bp3-tree-node-content-1{
-  padding-left:23px; }
+.bp3-tree-node-content-1 {
+  padding-left: 23px;
+}
 
-.bp3-tree-node-content-2{
-  padding-left:46px; }
+.bp3-tree-node-content-2 {
+  padding-left: 46px;
+}
 
-.bp3-tree-node-content-3{
-  padding-left:69px; }
+.bp3-tree-node-content-3 {
+  padding-left: 69px;
+}
 
-.bp3-tree-node-content-4{
-  padding-left:92px; }
+.bp3-tree-node-content-4 {
+  padding-left: 92px;
+}
 
-.bp3-tree-node-content-5{
-  padding-left:115px; }
+.bp3-tree-node-content-5 {
+  padding-left: 115px;
+}
 
-.bp3-tree-node-content-6{
-  padding-left:138px; }
+.bp3-tree-node-content-6 {
+  padding-left: 138px;
+}
 
-.bp3-tree-node-content-7{
-  padding-left:161px; }
+.bp3-tree-node-content-7 {
+  padding-left: 161px;
+}
 
-.bp3-tree-node-content-8{
-  padding-left:184px; }
+.bp3-tree-node-content-8 {
+  padding-left: 184px;
+}
 
-.bp3-tree-node-content-9{
-  padding-left:207px; }
+.bp3-tree-node-content-9 {
+  padding-left: 207px;
+}
 
-.bp3-tree-node-content-10{
-  padding-left:230px; }
+.bp3-tree-node-content-10 {
+  padding-left: 230px;
+}
 
-.bp3-tree-node-content-11{
-  padding-left:253px; }
+.bp3-tree-node-content-11 {
+  padding-left: 253px;
+}
 
-.bp3-tree-node-content-12{
-  padding-left:276px; }
+.bp3-tree-node-content-12 {
+  padding-left: 276px;
+}
 
-.bp3-tree-node-content-13{
-  padding-left:299px; }
+.bp3-tree-node-content-13 {
+  padding-left: 299px;
+}
 
-.bp3-tree-node-content-14{
-  padding-left:322px; }
+.bp3-tree-node-content-14 {
+  padding-left: 322px;
+}
 
-.bp3-tree-node-content-15{
-  padding-left:345px; }
+.bp3-tree-node-content-15 {
+  padding-left: 345px;
+}
 
-.bp3-tree-node-content-16{
-  padding-left:368px; }
+.bp3-tree-node-content-16 {
+  padding-left: 368px;
+}
 
-.bp3-tree-node-content-17{
-  padding-left:391px; }
+.bp3-tree-node-content-17 {
+  padding-left: 391px;
+}
 
-.bp3-tree-node-content-18{
-  padding-left:414px; }
+.bp3-tree-node-content-18 {
+  padding-left: 414px;
+}
 
-.bp3-tree-node-content-19{
-  padding-left:437px; }
+.bp3-tree-node-content-19 {
+  padding-left: 437px;
+}
 
-.bp3-tree-node-content-20{
-  padding-left:460px; }
+.bp3-tree-node-content-20 {
+  padding-left: 460px;
+}
 
-.bp3-tree-node-content{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  width:100%;
-  height:30px;
-  padding-right:5px; }
-  .bp3-tree-node-content:hover{
-    background-color:rgba(191, 204, 214, 0.4); }
+.bp3-tree-node-content {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  height: 30px;
+  padding-right: 5px;
+}
+.bp3-tree-node-content:hover {
+  background-color: rgba(191, 204, 214, 0.4);
+}
 
 .bp3-tree-node-caret,
-.bp3-tree-node-caret-none{
-  min-width:30px; }
+.bp3-tree-node-caret-none {
+  min-width: 30px;
+}
 
-.bp3-tree-node-caret{
-  color:#5c7080;
-  -webkit-transform:rotate(0deg);
-          transform:rotate(0deg);
-  cursor:pointer;
-  padding:7px;
-  -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
-  .bp3-tree-node-caret:hover{
-    color:#182026; }
-  .bp3-dark .bp3-tree-node-caret{
-    color:#a7b6c2; }
-    .bp3-dark .bp3-tree-node-caret:hover{
-      color:#f5f8fa; }
-  .bp3-tree-node-caret.bp3-tree-node-caret-open{
-    -webkit-transform:rotate(90deg);
-            transform:rotate(90deg); }
-  .bp3-tree-node-caret.bp3-icon-standard::before{
-    content:""; }
+.bp3-tree-node-caret {
+  color: #5c7080;
+  -webkit-transform: rotate(0deg);
+  transform: rotate(0deg);
+  cursor: pointer;
+  padding: 7px;
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition: transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9),
+    -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp3-tree-node-caret:hover {
+  color: #182026;
+}
+.bp3-dark .bp3-tree-node-caret {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-tree-node-caret:hover {
+  color: #f5f8fa;
+}
+.bp3-tree-node-caret.bp3-tree-node-caret-open {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+.bp3-tree-node-caret.bp3-icon-standard::before {
+  content: '';
+}
 
-.bp3-tree-node-icon{
-  position:relative;
-  margin-right:7px; }
+.bp3-tree-node-icon {
+  position: relative;
+  margin-right: 7px;
+}
 
-.bp3-tree-node-label{
-  overflow:hidden;
-  text-overflow:ellipsis;
-  white-space:nowrap;
-  word-wrap:normal;
-  -webkit-box-flex:1;
-      -ms-flex:1 1 auto;
-          flex:1 1 auto;
-  position:relative;
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-tree-node-label span{
-    display:inline; }
+.bp3-tree-node-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-tree-node-label span {
+  display: inline;
+}
 
-.bp3-tree-node-secondary-label{
-  padding:0 5px;
-  -webkit-user-select:none;
-     -moz-user-select:none;
-      -ms-user-select:none;
-          user-select:none; }
-  .bp3-tree-node-secondary-label .bp3-popover-wrapper,
-  .bp3-tree-node-secondary-label .bp3-popover-target{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
-    -webkit-box-align:center;
-        -ms-flex-align:center;
-            align-items:center; }
+.bp3-tree-node-secondary-label {
+  padding: 0 5px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.bp3-tree-node-secondary-label .bp3-popover-wrapper,
+.bp3-tree-node-secondary-label .bp3-popover-target {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
 
-.bp3-tree-node.bp3-disabled .bp3-tree-node-content{
-  background-color:inherit;
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+.bp3-tree-node.bp3-disabled .bp3-tree-node-content {
+  background-color: inherit;
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
 
 .bp3-tree-node.bp3-disabled .bp3-tree-node-caret,
-.bp3-tree-node.bp3-disabled .bp3-tree-node-icon{
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+.bp3-tree-node.bp3-disabled .bp3-tree-node-icon {
+  cursor: not-allowed;
+  color: rgba(92, 112, 128, 0.6);
+}
 
-.bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
-  background-color:#137cbd; }
-  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content,
-  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon, .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon-standard, .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon-large{
-    color:#ffffff; }
-  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-tree-node-caret::before{
-    color:rgba(255, 255, 255, 0.7); }
-  .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-tree-node-caret:hover::before{
-    color:#ffffff; }
+.bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content {
+  background-color: #137cbd;
+}
+.bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content,
+.bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon,
+.bp3-tree-node.bp3-tree-node-selected
+  > .bp3-tree-node-content
+  .bp3-icon-standard,
+.bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content .bp3-icon-large {
+  color: #ffffff;
+}
+.bp3-tree-node.bp3-tree-node-selected
+  > .bp3-tree-node-content
+  .bp3-tree-node-caret::before {
+  color: rgba(255, 255, 255, 0.7);
+}
+.bp3-tree-node.bp3-tree-node-selected
+  > .bp3-tree-node-content
+  .bp3-tree-node-caret:hover::before {
+  color: #ffffff;
+}
 
-.bp3-dark .bp3-tree-node-content:hover{
-  background-color:rgba(92, 112, 128, 0.3); }
+.bp3-dark .bp3-tree-node-content:hover {
+  background-color: rgba(92, 112, 128, 0.3);
+}
 
-.bp3-dark .bp3-tree .bp3-icon, .bp3-dark .bp3-tree .bp3-icon-standard, .bp3-dark .bp3-tree .bp3-icon-large{
-  color:#a7b6c2; }
-  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-primary, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-primary, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-primary{
-    color:#137cbd; }
-  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-success, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-success, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-success{
-    color:#0f9960; }
-  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-warning, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-warning, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-warning{
-    color:#d9822b; }
-  .bp3-dark .bp3-tree .bp3-icon.bp3-intent-danger, .bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-danger, .bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-danger{
-    color:#db3737; }
+.bp3-dark .bp3-tree .bp3-icon,
+.bp3-dark .bp3-tree .bp3-icon-standard,
+.bp3-dark .bp3-tree .bp3-icon-large {
+  color: #a7b6c2;
+}
+.bp3-dark .bp3-tree .bp3-icon.bp3-intent-primary,
+.bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-primary,
+.bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-primary {
+  color: #137cbd;
+}
+.bp3-dark .bp3-tree .bp3-icon.bp3-intent-success,
+.bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-success,
+.bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-success {
+  color: #0f9960;
+}
+.bp3-dark .bp3-tree .bp3-icon.bp3-intent-warning,
+.bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-warning,
+.bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-warning {
+  color: #d9822b;
+}
+.bp3-dark .bp3-tree .bp3-icon.bp3-intent-danger,
+.bp3-dark .bp3-tree .bp3-icon-standard.bp3-intent-danger,
+.bp3-dark .bp3-tree .bp3-icon-large.bp3-intent-danger {
+  color: #db3737;
+}
 
-.bp3-dark .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
-  background-color:#137cbd; }
+.bp3-dark .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content {
+  background-color: #137cbd;
+}
 /*!
 
 Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
 Licensed under the Apache License, Version 2.0.
 
 */
-.bp3-omnibar{
-  -webkit-filter:blur(0);
-          filter:blur(0);
-  opacity:1;
-  top:20vh;
-  left:calc(50% - 250px);
-  z-index:21;
-  border-radius:3px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  width:500px; }
-  .bp3-omnibar.bp3-overlay-enter, .bp3-omnibar.bp3-overlay-appear{
-    -webkit-filter:blur(20px);
-            filter:blur(20px);
-    opacity:0.2; }
-  .bp3-omnibar.bp3-overlay-enter-active, .bp3-omnibar.bp3-overlay-appear-active{
-    -webkit-filter:blur(0);
-            filter:blur(0);
-    opacity:1;
-    -webkit-transition-property:opacity, -webkit-filter;
-    transition-property:opacity, -webkit-filter;
-    transition-property:filter, opacity;
-    transition-property:filter, opacity, -webkit-filter;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-omnibar.bp3-overlay-exit{
-    -webkit-filter:blur(0);
-            filter:blur(0);
-    opacity:1; }
-  .bp3-omnibar.bp3-overlay-exit-active{
-    -webkit-filter:blur(20px);
-            filter:blur(20px);
-    opacity:0.2;
-    -webkit-transition-property:opacity, -webkit-filter;
-    transition-property:opacity, -webkit-filter;
-    transition-property:filter, opacity;
-    transition-property:filter, opacity, -webkit-filter;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
-    -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
-  .bp3-omnibar .bp3-input{
-    border-radius:0;
-    background-color:transparent; }
-    .bp3-omnibar .bp3-input, .bp3-omnibar .bp3-input:focus{
-      -webkit-box-shadow:none;
-              box-shadow:none; }
-  .bp3-omnibar .bp3-menu{
-    border-radius:0;
-    -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-            box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-    background-color:transparent;
-    max-height:calc(60vh - 40px);
-    overflow:auto; }
-    .bp3-omnibar .bp3-menu:empty{
-      display:none; }
-  .bp3-dark .bp3-omnibar, .bp3-omnibar.bp3-dark{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background-color:#30404d; }
+.bp3-omnibar {
+  -webkit-filter: blur(0);
+  filter: blur(0);
+  opacity: 1;
+  top: 20vh;
+  left: calc(50% - 250px);
+  z-index: 21;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1),
+    0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2),
+    0 18px 46px 6px rgba(16, 22, 26, 0.2);
+  background-color: #ffffff;
+  width: 500px;
+}
+.bp3-omnibar.bp3-overlay-enter,
+.bp3-omnibar.bp3-overlay-appear {
+  -webkit-filter: blur(20px);
+  filter: blur(20px);
+  opacity: 0.2;
+}
+.bp3-omnibar.bp3-overlay-enter-active,
+.bp3-omnibar.bp3-overlay-appear-active {
+  -webkit-filter: blur(0);
+  filter: blur(0);
+  opacity: 1;
+  -webkit-transition-property: opacity, -webkit-filter;
+  transition-property: opacity, -webkit-filter;
+  transition-property: filter, opacity;
+  transition-property: filter, opacity, -webkit-filter;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-omnibar.bp3-overlay-exit {
+  -webkit-filter: blur(0);
+  filter: blur(0);
+  opacity: 1;
+}
+.bp3-omnibar.bp3-overlay-exit-active {
+  -webkit-filter: blur(20px);
+  filter: blur(20px);
+  opacity: 0.2;
+  -webkit-transition-property: opacity, -webkit-filter;
+  transition-property: opacity, -webkit-filter;
+  transition-property: filter, opacity;
+  transition-property: filter, opacity, -webkit-filter;
+  -webkit-transition-duration: 200ms;
+  transition-duration: 200ms;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+}
+.bp3-omnibar .bp3-input {
+  border-radius: 0;
+  background-color: transparent;
+}
+.bp3-omnibar .bp3-input,
+.bp3-omnibar .bp3-input:focus {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.bp3-omnibar .bp3-menu {
+  border-radius: 0;
+  -webkit-box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.15);
+  box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.15);
+  background-color: transparent;
+  max-height: calc(60vh - 40px);
+  overflow: auto;
+}
+.bp3-omnibar .bp3-menu:empty {
+  display: none;
+}
+.bp3-dark .bp3-omnibar,
+.bp3-omnibar.bp3-dark {
+  -webkit-box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2),
+    0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4),
+    0 18px 46px 6px rgba(16, 22, 26, 0.4);
+  background-color: #30404d;
+}
 
-.bp3-omnibar-overlay .bp3-overlay-backdrop{
-  background-color:rgba(16, 22, 26, 0.2); }
+.bp3-omnibar-overlay .bp3-overlay-backdrop {
+  background-color: rgba(16, 22, 26, 0.2);
+}
 
-.bp3-select-popover .bp3-popover-content{
-  padding:5px; }
+.bp3-select-popover .bp3-popover-content {
+  padding: 5px;
+}
 
-.bp3-select-popover .bp3-input-group{
-  margin-bottom:0; }
+.bp3-select-popover .bp3-input-group {
+  margin-bottom: 0;
+}
 
-.bp3-select-popover .bp3-menu{
-  max-width:400px;
-  max-height:300px;
-  overflow:auto;
-  padding:0; }
-  .bp3-select-popover .bp3-menu:not(:first-child){
-    padding-top:5px; }
+.bp3-select-popover .bp3-menu {
+  max-width: 400px;
+  max-height: 300px;
+  overflow: auto;
+  padding: 0;
+}
+.bp3-select-popover .bp3-menu:not(:first-child) {
+  padding-top: 5px;
+}
 
-.bp3-multi-select{
-  min-width:150px; }
+.bp3-multi-select {
+  min-width: 150px;
+}
 
-.bp3-multi-select-popover .bp3-menu{
-  max-width:400px;
-  max-height:300px;
-  overflow:auto; }
+.bp3-multi-select-popover .bp3-menu {
+  max-width: 400px;
+  max-height: 300px;
+  overflow: auto;
+}
 
-.bp3-select-popover .bp3-popover-content{
-  padding:5px; }
+.bp3-select-popover .bp3-popover-content {
+  padding: 5px;
+}
 
-.bp3-select-popover .bp3-input-group{
-  margin-bottom:0; }
+.bp3-select-popover .bp3-input-group {
+  margin-bottom: 0;
+}
 
-.bp3-select-popover .bp3-menu{
-  max-width:400px;
-  max-height:300px;
-  overflow:auto;
-  padding:0; }
-  .bp3-select-popover .bp3-menu:not(:first-child){
-    padding-top:5px; }
+.bp3-select-popover .bp3-menu {
+  max-width: 400px;
+  max-height: 300px;
+  overflow: auto;
+  padding: 0;
+}
+.bp3-select-popover .bp3-menu:not(:first-child) {
+  padding-top: 5px;
+}
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
@@ -10653,8 +14501,8 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ body.p-mod-override-cursor *, /* </DEPRECATED> */
+/* <DEPRECATED> */
+body.p-mod-override-cursor *, /* </DEPRECATED> */
 body.lm-mod-override-cursor * {
   cursor: inherit !important;
 }
@@ -10746,7 +14594,8 @@ body.lm-mod-override-cursor * {
   padding: 0 4px; /* Horizontal padding of content */
 }
 
-.CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+.CodeMirror-scrollbar-filler,
+.CodeMirror-gutter-filler {
   background-color: white; /* The little square between H and V scrollbars */
 }
 
@@ -10757,7 +14606,8 @@ body.lm-mod-override-cursor * {
   background-color: #f7f7f7;
   white-space: nowrap;
 }
-.CodeMirror-linenumbers {}
+.CodeMirror-linenumbers {
+}
 .CodeMirror-linenumber {
   padding: 0 3px 0 5px;
   min-width: 20px;
@@ -10766,8 +14616,12 @@ body.lm-mod-override-cursor * {
   white-space: nowrap;
 }
 
-.CodeMirror-guttermarker { color: black; }
-.CodeMirror-guttermarker-subtle { color: #999; }
+.CodeMirror-guttermarker {
+  color: black;
+}
+.CodeMirror-guttermarker-subtle {
+  color: #999;
+}
 
 /* CURSOR */
 
@@ -10803,81 +14657,168 @@ body.lm-mod-override-cursor * {
   background-color: #7e7;
 }
 @-moz-keyframes blink {
-  0% {}
-  50% { background-color: transparent; }
-  100% {}
+  0% {
+  }
+  50% {
+    background-color: transparent;
+  }
+  100% {
+  }
 }
 @-webkit-keyframes blink {
-  0% {}
-  50% { background-color: transparent; }
-  100% {}
+  0% {
+  }
+  50% {
+    background-color: transparent;
+  }
+  100% {
+  }
 }
 @keyframes blink {
-  0% {}
-  50% { background-color: transparent; }
-  100% {}
+  0% {
+  }
+  50% {
+    background-color: transparent;
+  }
+  100% {
+  }
 }
 
 /* Can style cursor different in overwrite (non-insert) mode */
-.CodeMirror-overwrite .CodeMirror-cursor {}
+.CodeMirror-overwrite .CodeMirror-cursor {
+}
 
-.cm-tab { display: inline-block; text-decoration: inherit; }
+.cm-tab {
+  display: inline-block;
+  text-decoration: inherit;
+}
 
 .CodeMirror-rulers {
   position: absolute;
-  left: 0; right: 0; top: -50px; bottom: 0;
+  left: 0;
+  right: 0;
+  top: -50px;
+  bottom: 0;
   overflow: hidden;
 }
 .CodeMirror-ruler {
   border-left: 1px solid #ccc;
-  top: 0; bottom: 0;
+  top: 0;
+  bottom: 0;
   position: absolute;
 }
 
 /* DEFAULT THEME */
 
-.cm-s-default .cm-header {color: blue;}
-.cm-s-default .cm-quote {color: #090;}
-.cm-negative {color: #d44;}
-.cm-positive {color: #292;}
-.cm-header, .cm-strong {font-weight: bold;}
-.cm-em {font-style: italic;}
-.cm-link {text-decoration: underline;}
-.cm-strikethrough {text-decoration: line-through;}
+.cm-s-default .cm-header {
+  color: blue;
+}
+.cm-s-default .cm-quote {
+  color: #090;
+}
+.cm-negative {
+  color: #d44;
+}
+.cm-positive {
+  color: #292;
+}
+.cm-header,
+.cm-strong {
+  font-weight: bold;
+}
+.cm-em {
+  font-style: italic;
+}
+.cm-link {
+  text-decoration: underline;
+}
+.cm-strikethrough {
+  text-decoration: line-through;
+}
 
-.cm-s-default .cm-keyword {color: #708;}
-.cm-s-default .cm-atom {color: #219;}
-.cm-s-default .cm-number {color: #164;}
-.cm-s-default .cm-def {color: #00f;}
+.cm-s-default .cm-keyword {
+  color: #708;
+}
+.cm-s-default .cm-atom {
+  color: #219;
+}
+.cm-s-default .cm-number {
+  color: #164;
+}
+.cm-s-default .cm-def {
+  color: #00f;
+}
 .cm-s-default .cm-variable,
 .cm-s-default .cm-punctuation,
 .cm-s-default .cm-property,
-.cm-s-default .cm-operator {}
-.cm-s-default .cm-variable-2 {color: #05a;}
-.cm-s-default .cm-variable-3, .cm-s-default .cm-type {color: #085;}
-.cm-s-default .cm-comment {color: #a50;}
-.cm-s-default .cm-string {color: #a11;}
-.cm-s-default .cm-string-2 {color: #f50;}
-.cm-s-default .cm-meta {color: #555;}
-.cm-s-default .cm-qualifier {color: #555;}
-.cm-s-default .cm-builtin {color: #30a;}
-.cm-s-default .cm-bracket {color: #997;}
-.cm-s-default .cm-tag {color: #170;}
-.cm-s-default .cm-attribute {color: #00c;}
-.cm-s-default .cm-hr {color: #999;}
-.cm-s-default .cm-link {color: #00c;}
+.cm-s-default .cm-operator {
+}
+.cm-s-default .cm-variable-2 {
+  color: #05a;
+}
+.cm-s-default .cm-variable-3,
+.cm-s-default .cm-type {
+  color: #085;
+}
+.cm-s-default .cm-comment {
+  color: #a50;
+}
+.cm-s-default .cm-string {
+  color: #a11;
+}
+.cm-s-default .cm-string-2 {
+  color: #f50;
+}
+.cm-s-default .cm-meta {
+  color: #555;
+}
+.cm-s-default .cm-qualifier {
+  color: #555;
+}
+.cm-s-default .cm-builtin {
+  color: #30a;
+}
+.cm-s-default .cm-bracket {
+  color: #997;
+}
+.cm-s-default .cm-tag {
+  color: #170;
+}
+.cm-s-default .cm-attribute {
+  color: #00c;
+}
+.cm-s-default .cm-hr {
+  color: #999;
+}
+.cm-s-default .cm-link {
+  color: #00c;
+}
 
-.cm-s-default .cm-error {color: #f00;}
-.cm-invalidchar {color: #f00;}
+.cm-s-default .cm-error {
+  color: #f00;
+}
+.cm-invalidchar {
+  color: #f00;
+}
 
-.CodeMirror-composing { border-bottom: 2px solid; }
+.CodeMirror-composing {
+  border-bottom: 2px solid;
+}
 
 /* Default styles for common addons */
 
-div.CodeMirror span.CodeMirror-matchingbracket {color: #0b0;}
-div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
-.CodeMirror-matchingtag { background: rgba(255, 150, 0, .3); }
-.CodeMirror-activeline-background {background: #e8f2ff;}
+div.CodeMirror span.CodeMirror-matchingbracket {
+  color: #0b0;
+}
+div.CodeMirror span.CodeMirror-nonmatchingbracket {
+  color: #a22;
+}
+.CodeMirror-matchingtag {
+  background: rgba(255, 150, 0, 0.3);
+}
+.CodeMirror-activeline-background {
+  background: #e8f2ff;
+}
 
 /* STOP */
 
@@ -10894,7 +14835,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   overflow: scroll !important; /* Things will break if this is overridden */
   /* 30px is the magic margin used to hide the element's real scrollbars */
   /* See overflow: hidden in .CodeMirror */
-  margin-bottom: -30px; margin-right: -30px;
+  margin-bottom: -30px;
+  margin-right: -30px;
   padding-bottom: 30px;
   height: 100%;
   outline: none; /* Prevent dragging from highlighting the element */
@@ -10908,30 +14850,39 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
 /* The fake, visible scrollbars. Used to force redraw during scrolling
    before actual scrolling happens, thus preventing shaking and
    flickering artifacts. */
-.CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+.CodeMirror-vscrollbar,
+.CodeMirror-hscrollbar,
+.CodeMirror-scrollbar-filler,
+.CodeMirror-gutter-filler {
   position: absolute;
   z-index: 6;
   display: none;
 }
 .CodeMirror-vscrollbar {
-  right: 0; top: 0;
+  right: 0;
+  top: 0;
   overflow-x: hidden;
   overflow-y: scroll;
 }
 .CodeMirror-hscrollbar {
-  bottom: 0; left: 0;
+  bottom: 0;
+  left: 0;
   overflow-y: hidden;
   overflow-x: scroll;
 }
 .CodeMirror-scrollbar-filler {
-  right: 0; bottom: 0;
+  right: 0;
+  bottom: 0;
 }
 .CodeMirror-gutter-filler {
-  left: 0; bottom: 0;
+  left: 0;
+  bottom: 0;
 }
 
 .CodeMirror-gutters {
-  position: absolute; left: 0; top: 0;
+  position: absolute;
+  left: 0;
+  top: 0;
   min-height: 100%;
   z-index: 3;
 }
@@ -10950,7 +14901,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
 }
 .CodeMirror-gutter-background {
   position: absolute;
-  top: 0; bottom: 0;
+  top: 0;
+  bottom: 0;
   z-index: 4;
 }
 .CodeMirror-gutter-elt {
@@ -10958,8 +14910,12 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   cursor: default;
   z-index: 4;
 }
-.CodeMirror-gutter-wrapper ::selection { background-color: transparent }
-.CodeMirror-gutter-wrapper ::-moz-selection { background-color: transparent }
+.CodeMirror-gutter-wrapper ::selection {
+  background-color: transparent;
+}
+.CodeMirror-gutter-wrapper ::-moz-selection {
+  background-color: transparent;
+}
 
 .CodeMirror-lines {
   cursor: text;
@@ -10968,7 +14924,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
 .CodeMirror pre.CodeMirror-line,
 .CodeMirror pre.CodeMirror-line-like {
   /* Reset some styles that the rest of the page might have set */
-  -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0;
   border-width: 0;
   background: transparent;
   font-family: inherit;
@@ -10994,7 +14952,10 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
 
 .CodeMirror-linebackground {
   position: absolute;
-  left: 0; right: 0; top: 0; bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
   z-index: 0;
 }
 
@@ -11004,9 +14965,12 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   padding: 0.1px; /* Force widget margins to stay inside of the container */
 }
 
-.CodeMirror-widget {}
+.CodeMirror-widget {
+}
 
-.CodeMirror-rtl pre { direction: rtl; }
+.CodeMirror-rtl pre {
+  direction: rtl;
+}
 
 .CodeMirror-code {
   outline: none;
@@ -11034,7 +14998,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   position: absolute;
   pointer-events: none;
 }
-.CodeMirror-measure pre { position: static; }
+.CodeMirror-measure pre {
+  position: static;
+}
 
 div.CodeMirror-cursors {
   visibility: hidden;
@@ -11049,19 +15015,35 @@ div.CodeMirror-dragcursors {
   visibility: visible;
 }
 
-.CodeMirror-selected { background: #d9d9d9; }
-.CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
-.CodeMirror-crosshair { cursor: crosshair; }
-.CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #d7d4f0; }
-.CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #d7d4f0; }
+.CodeMirror-selected {
+  background: #d9d9d9;
+}
+.CodeMirror-focused .CodeMirror-selected {
+  background: #d7d4f0;
+}
+.CodeMirror-crosshair {
+  cursor: crosshair;
+}
+.CodeMirror-line::selection,
+.CodeMirror-line > span::selection,
+.CodeMirror-line > span > span::selection {
+  background: #d7d4f0;
+}
+.CodeMirror-line::-moz-selection,
+.CodeMirror-line > span::-moz-selection,
+.CodeMirror-line > span > span::-moz-selection {
+  background: #d7d4f0;
+}
 
 .cm-searching {
   background-color: #ffa;
-  background-color: rgba(255, 255, 0, .4);
+  background-color: rgba(255, 255, 0, 0.4);
 }
 
 /* Used to force a border model for a node */
-.cm-force-border { padding-right: .1px; }
+.cm-force-border {
+  padding-right: 0.1px;
+}
 
 @media print {
   /* Hide the cursor when printing */
@@ -11071,17 +15053,22 @@ div.CodeMirror-dragcursors {
 }
 
 /* See issue #2901 */
-.cm-tab-wrap-hack:after { content: ''; }
+.cm-tab-wrap-hack:after {
+  content: '';
+}
 
 /* Help users use markselection to safely style text background */
-span.CodeMirror-selectedtext { background: none; }
+span.CodeMirror-selectedtext {
+  background: none;
+}
 
 .CodeMirror-dialog {
   position: absolute;
-  left: 0; right: 0;
+  left: 0;
+  right: 0;
   background: inherit;
   z-index: 15;
-  padding: .1em .8em;
+  padding: 0.1em 0.8em;
   overflow: hidden;
   color: inherit;
 }
@@ -11111,23 +15098,24 @@ span.CodeMirror-selectedtext { background: none; }
 
 .CodeMirror-foldmarker {
   color: blue;
-  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
+  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px,
+    #b9f -1px 1px 2px;
   font-family: arial;
-  line-height: .3;
+  line-height: 0.3;
   cursor: pointer;
 }
 .CodeMirror-foldgutter {
-  width: .7em;
+  width: 0.7em;
 }
 .CodeMirror-foldgutter-open,
 .CodeMirror-foldgutter-folded {
   cursor: pointer;
 }
 .CodeMirror-foldgutter-open:after {
-  content: "\25BE";
+  content: '\25BE';
 }
 .CodeMirror-foldgutter-folded:after {
-  content: "\25B8";
+  content: '\25B8';
 }
 
 /*
@@ -11138,23 +15126,23 @@ span.CodeMirror-selectedtext { background: none; }
 
 .cm-s-material.CodeMirror {
   background-color: #263238;
-  color: #EEFFFF;
+  color: #eeffff;
 }
 
 .cm-s-material .CodeMirror-gutters {
   background: #263238;
-  color: #546E7A;
+  color: #546e7a;
   border: none;
 }
 
 .cm-s-material .CodeMirror-guttermarker,
 .cm-s-material .CodeMirror-guttermarker-subtle,
 .cm-s-material .CodeMirror-linenumber {
-  color: #546E7A;
+  color: #546e7a;
 }
 
 .cm-s-material .CodeMirror-cursor {
-  border-left: 1px solid #FFCC00;
+  border-left: 1px solid #ffcc00;
 }
 
 .cm-s-material div.CodeMirror-selected {
@@ -11166,14 +15154,14 @@ span.CodeMirror-selectedtext { background: none; }
 }
 
 .cm-s-material .CodeMirror-line::selection,
-.cm-s-material .CodeMirror-line>span::selection,
-.cm-s-material .CodeMirror-line>span>span::selection {
+.cm-s-material .CodeMirror-line > span::selection,
+.cm-s-material .CodeMirror-line > span > span::selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
 .cm-s-material .CodeMirror-line::-moz-selection,
-.cm-s-material .CodeMirror-line>span::-moz-selection,
-.cm-s-material .CodeMirror-line>span>span::-moz-selection {
+.cm-s-material .CodeMirror-line > span::-moz-selection,
+.cm-s-material .CodeMirror-line > span > span::-moz-selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
@@ -11182,15 +15170,15 @@ span.CodeMirror-selectedtext { background: none; }
 }
 
 .cm-s-material .cm-keyword {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material .cm-operator {
-  color: #89DDFF;
+  color: #89ddff;
 }
 
 .cm-s-material .cm-variable-2 {
-  color: #EEFFFF;
+  color: #eeffff;
 }
 
 .cm-s-material .cm-variable-3,
@@ -11199,23 +15187,23 @@ span.CodeMirror-selectedtext { background: none; }
 }
 
 .cm-s-material .cm-builtin {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material .cm-atom {
-  color: #F78C6C;
+  color: #f78c6c;
 }
 
 .cm-s-material .cm-number {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material .cm-def {
-  color: #82AAFF;
+  color: #82aaff;
 }
 
 .cm-s-material .cm-string {
-  color: #C3E88D;
+  color: #c3e88d;
 }
 
 .cm-s-material .cm-string-2 {
@@ -11223,7 +15211,7 @@ span.CodeMirror-selectedtext { background: none; }
 }
 
 .cm-s-material .cm-comment {
-  color: #546E7A;
+  color: #546e7a;
 }
 
 .cm-s-material .cm-variable {
@@ -11231,34 +15219,33 @@ span.CodeMirror-selectedtext { background: none; }
 }
 
 .cm-s-material .cm-tag {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material .cm-meta {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material .cm-attribute {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material .cm-property {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material .cm-qualifier {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
 .cm-s-material .cm-variable-3,
 .cm-s-material .cm-type {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
-
 .cm-s-material .cm-error {
-  color: rgba(255, 255, 255, 1.0);
-  background-color: #FF5370;
+  color: rgba(255, 255, 255, 1);
+  background-color: #ff5370;
 }
 
 .cm-s-material .CodeMirror-matchingbracket {
@@ -11275,66 +15262,197 @@ span.CodeMirror-selectedtext { background: none; }
  * From: https://github.com/wisenomad/zenburn-lighttable-theme/blob/master/zenburn.css
  */
 
-.cm-s-zenburn .CodeMirror-gutters { background: #3f3f3f !important; }
-.cm-s-zenburn .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: #999; }
-.cm-s-zenburn .CodeMirror-cursor { border-left: 1px solid white; }
-.cm-s-zenburn { background-color: #3f3f3f; color: #dcdccc; }
-.cm-s-zenburn span.cm-builtin { color: #dcdccc; font-weight: bold; }
-.cm-s-zenburn span.cm-comment { color: #7f9f7f; }
-.cm-s-zenburn span.cm-keyword { color: #f0dfaf; font-weight: bold; }
-.cm-s-zenburn span.cm-atom { color: #bfebbf; }
-.cm-s-zenburn span.cm-def { color: #dcdccc; }
-.cm-s-zenburn span.cm-variable { color: #dfaf8f; }
-.cm-s-zenburn span.cm-variable-2 { color: #dcdccc; }
-.cm-s-zenburn span.cm-string { color: #cc9393; }
-.cm-s-zenburn span.cm-string-2 { color: #cc9393; }
-.cm-s-zenburn span.cm-number { color: #dcdccc; }
-.cm-s-zenburn span.cm-tag { color: #93e0e3; }
-.cm-s-zenburn span.cm-property { color: #dfaf8f; }
-.cm-s-zenburn span.cm-attribute { color: #dfaf8f; }
-.cm-s-zenburn span.cm-qualifier { color: #7cb8bb; }
-.cm-s-zenburn span.cm-meta { color: #f0dfaf; }
-.cm-s-zenburn span.cm-header { color: #f0efd0; }
-.cm-s-zenburn span.cm-operator { color: #f0efd0; }
-.cm-s-zenburn span.CodeMirror-matchingbracket { box-sizing: border-box; background: transparent; border-bottom: 1px solid; }
-.cm-s-zenburn span.CodeMirror-nonmatchingbracket { border-bottom: 1px solid; background: none; }
-.cm-s-zenburn .CodeMirror-activeline { background: #000000; }
-.cm-s-zenburn .CodeMirror-activeline-background { background: #000000; }
-.cm-s-zenburn div.CodeMirror-selected { background: #545454; }
-.cm-s-zenburn .CodeMirror-focused div.CodeMirror-selected { background: #4f4f4f; }
+.cm-s-zenburn .CodeMirror-gutters {
+  background: #3f3f3f !important;
+}
+.cm-s-zenburn .CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded {
+  color: #999;
+}
+.cm-s-zenburn .CodeMirror-cursor {
+  border-left: 1px solid white;
+}
+.cm-s-zenburn {
+  background-color: #3f3f3f;
+  color: #dcdccc;
+}
+.cm-s-zenburn span.cm-builtin {
+  color: #dcdccc;
+  font-weight: bold;
+}
+.cm-s-zenburn span.cm-comment {
+  color: #7f9f7f;
+}
+.cm-s-zenburn span.cm-keyword {
+  color: #f0dfaf;
+  font-weight: bold;
+}
+.cm-s-zenburn span.cm-atom {
+  color: #bfebbf;
+}
+.cm-s-zenburn span.cm-def {
+  color: #dcdccc;
+}
+.cm-s-zenburn span.cm-variable {
+  color: #dfaf8f;
+}
+.cm-s-zenburn span.cm-variable-2 {
+  color: #dcdccc;
+}
+.cm-s-zenburn span.cm-string {
+  color: #cc9393;
+}
+.cm-s-zenburn span.cm-string-2 {
+  color: #cc9393;
+}
+.cm-s-zenburn span.cm-number {
+  color: #dcdccc;
+}
+.cm-s-zenburn span.cm-tag {
+  color: #93e0e3;
+}
+.cm-s-zenburn span.cm-property {
+  color: #dfaf8f;
+}
+.cm-s-zenburn span.cm-attribute {
+  color: #dfaf8f;
+}
+.cm-s-zenburn span.cm-qualifier {
+  color: #7cb8bb;
+}
+.cm-s-zenburn span.cm-meta {
+  color: #f0dfaf;
+}
+.cm-s-zenburn span.cm-header {
+  color: #f0efd0;
+}
+.cm-s-zenburn span.cm-operator {
+  color: #f0efd0;
+}
+.cm-s-zenburn span.CodeMirror-matchingbracket {
+  box-sizing: border-box;
+  background: transparent;
+  border-bottom: 1px solid;
+}
+.cm-s-zenburn span.CodeMirror-nonmatchingbracket {
+  border-bottom: 1px solid;
+  background: none;
+}
+.cm-s-zenburn .CodeMirror-activeline {
+  background: #000000;
+}
+.cm-s-zenburn .CodeMirror-activeline-background {
+  background: #000000;
+}
+.cm-s-zenburn div.CodeMirror-selected {
+  background: #545454;
+}
+.cm-s-zenburn .CodeMirror-focused div.CodeMirror-selected {
+  background: #4f4f4f;
+}
 
-.cm-s-abcdef.CodeMirror { background: #0f0f0f; color: #defdef; }
-.cm-s-abcdef div.CodeMirror-selected { background: #515151; }
-.cm-s-abcdef .CodeMirror-line::selection, .cm-s-abcdef .CodeMirror-line > span::selection, .cm-s-abcdef .CodeMirror-line > span > span::selection { background: rgba(56, 56, 56, 0.99); }
-.cm-s-abcdef .CodeMirror-line::-moz-selection, .cm-s-abcdef .CodeMirror-line > span::-moz-selection, .cm-s-abcdef .CodeMirror-line > span > span::-moz-selection { background: rgba(56, 56, 56, 0.99); }
-.cm-s-abcdef .CodeMirror-gutters { background: #555; border-right: 2px solid #314151; }
-.cm-s-abcdef .CodeMirror-guttermarker { color: #222; }
-.cm-s-abcdef .CodeMirror-guttermarker-subtle { color: azure; }
-.cm-s-abcdef .CodeMirror-linenumber { color: #FFFFFF; }
-.cm-s-abcdef .CodeMirror-cursor { border-left: 1px solid #00FF00; }
+.cm-s-abcdef.CodeMirror {
+  background: #0f0f0f;
+  color: #defdef;
+}
+.cm-s-abcdef div.CodeMirror-selected {
+  background: #515151;
+}
+.cm-s-abcdef .CodeMirror-line::selection,
+.cm-s-abcdef .CodeMirror-line > span::selection,
+.cm-s-abcdef .CodeMirror-line > span > span::selection {
+  background: rgba(56, 56, 56, 0.99);
+}
+.cm-s-abcdef .CodeMirror-line::-moz-selection,
+.cm-s-abcdef .CodeMirror-line > span::-moz-selection,
+.cm-s-abcdef .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(56, 56, 56, 0.99);
+}
+.cm-s-abcdef .CodeMirror-gutters {
+  background: #555;
+  border-right: 2px solid #314151;
+}
+.cm-s-abcdef .CodeMirror-guttermarker {
+  color: #222;
+}
+.cm-s-abcdef .CodeMirror-guttermarker-subtle {
+  color: azure;
+}
+.cm-s-abcdef .CodeMirror-linenumber {
+  color: #ffffff;
+}
+.cm-s-abcdef .CodeMirror-cursor {
+  border-left: 1px solid #00ff00;
+}
 
-.cm-s-abcdef span.cm-keyword { color: darkgoldenrod; font-weight: bold; }
-.cm-s-abcdef span.cm-atom { color: #77F; }
-.cm-s-abcdef span.cm-number { color: violet; }
-.cm-s-abcdef span.cm-def { color: #fffabc; }
-.cm-s-abcdef span.cm-variable { color: #abcdef; }
-.cm-s-abcdef span.cm-variable-2 { color: #cacbcc; }
-.cm-s-abcdef span.cm-variable-3, .cm-s-abcdef span.cm-type { color: #def; }
-.cm-s-abcdef span.cm-property { color: #fedcba; }
-.cm-s-abcdef span.cm-operator { color: #ff0; }
-.cm-s-abcdef span.cm-comment { color: #7a7b7c; font-style: italic;}
-.cm-s-abcdef span.cm-string { color: #2b4; }
-.cm-s-abcdef span.cm-meta { color: #C9F; }
-.cm-s-abcdef span.cm-qualifier { color: #FFF700; }
-.cm-s-abcdef span.cm-builtin { color: #30aabc; }
-.cm-s-abcdef span.cm-bracket { color: #8a8a8a; }
-.cm-s-abcdef span.cm-tag { color: #FFDD44; }
-.cm-s-abcdef span.cm-attribute { color: #DDFF00; }
-.cm-s-abcdef span.cm-error { color: #FF0000; }
-.cm-s-abcdef span.cm-header { color: aquamarine; font-weight: bold; }
-.cm-s-abcdef span.cm-link { color: blueviolet; }
+.cm-s-abcdef span.cm-keyword {
+  color: darkgoldenrod;
+  font-weight: bold;
+}
+.cm-s-abcdef span.cm-atom {
+  color: #77f;
+}
+.cm-s-abcdef span.cm-number {
+  color: violet;
+}
+.cm-s-abcdef span.cm-def {
+  color: #fffabc;
+}
+.cm-s-abcdef span.cm-variable {
+  color: #abcdef;
+}
+.cm-s-abcdef span.cm-variable-2 {
+  color: #cacbcc;
+}
+.cm-s-abcdef span.cm-variable-3,
+.cm-s-abcdef span.cm-type {
+  color: #def;
+}
+.cm-s-abcdef span.cm-property {
+  color: #fedcba;
+}
+.cm-s-abcdef span.cm-operator {
+  color: #ff0;
+}
+.cm-s-abcdef span.cm-comment {
+  color: #7a7b7c;
+  font-style: italic;
+}
+.cm-s-abcdef span.cm-string {
+  color: #2b4;
+}
+.cm-s-abcdef span.cm-meta {
+  color: #c9f;
+}
+.cm-s-abcdef span.cm-qualifier {
+  color: #fff700;
+}
+.cm-s-abcdef span.cm-builtin {
+  color: #30aabc;
+}
+.cm-s-abcdef span.cm-bracket {
+  color: #8a8a8a;
+}
+.cm-s-abcdef span.cm-tag {
+  color: #ffdd44;
+}
+.cm-s-abcdef span.cm-attribute {
+  color: #ddff00;
+}
+.cm-s-abcdef span.cm-error {
+  color: #ff0000;
+}
+.cm-s-abcdef span.cm-header {
+  color: aquamarine;
+  font-weight: bold;
+}
+.cm-s-abcdef span.cm-link {
+  color: blueviolet;
+}
 
-.cm-s-abcdef .CodeMirror-activeline-background { background: #314151; }
+.cm-s-abcdef .CodeMirror-activeline-background {
+  background: #314151;
+}
 
 /*
 
@@ -11346,34 +15464,91 @@ span.CodeMirror-selectedtext { background: none; }
 
 */
 
-.cm-s-base16-light.CodeMirror { background: #f5f5f5; color: #202020; }
-.cm-s-base16-light div.CodeMirror-selected { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-line::selection, .cm-s-base16-light .CodeMirror-line > span::selection, .cm-s-base16-light .CodeMirror-line > span > span::selection { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-line::-moz-selection, .cm-s-base16-light .CodeMirror-line > span::-moz-selection, .cm-s-base16-light .CodeMirror-line > span > span::-moz-selection { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-gutters { background: #f5f5f5; border-right: 0px; }
-.cm-s-base16-light .CodeMirror-guttermarker { color: #ac4142; }
-.cm-s-base16-light .CodeMirror-guttermarker-subtle { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-linenumber { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-cursor { border-left: 1px solid #505050; }
+.cm-s-base16-light.CodeMirror {
+  background: #f5f5f5;
+  color: #202020;
+}
+.cm-s-base16-light div.CodeMirror-selected {
+  background: #e0e0e0;
+}
+.cm-s-base16-light .CodeMirror-line::selection,
+.cm-s-base16-light .CodeMirror-line > span::selection,
+.cm-s-base16-light .CodeMirror-line > span > span::selection {
+  background: #e0e0e0;
+}
+.cm-s-base16-light .CodeMirror-line::-moz-selection,
+.cm-s-base16-light .CodeMirror-line > span::-moz-selection,
+.cm-s-base16-light .CodeMirror-line > span > span::-moz-selection {
+  background: #e0e0e0;
+}
+.cm-s-base16-light .CodeMirror-gutters {
+  background: #f5f5f5;
+  border-right: 0px;
+}
+.cm-s-base16-light .CodeMirror-guttermarker {
+  color: #ac4142;
+}
+.cm-s-base16-light .CodeMirror-guttermarker-subtle {
+  color: #b0b0b0;
+}
+.cm-s-base16-light .CodeMirror-linenumber {
+  color: #b0b0b0;
+}
+.cm-s-base16-light .CodeMirror-cursor {
+  border-left: 1px solid #505050;
+}
 
-.cm-s-base16-light span.cm-comment { color: #8f5536; }
-.cm-s-base16-light span.cm-atom { color: #aa759f; }
-.cm-s-base16-light span.cm-number { color: #aa759f; }
+.cm-s-base16-light span.cm-comment {
+  color: #8f5536;
+}
+.cm-s-base16-light span.cm-atom {
+  color: #aa759f;
+}
+.cm-s-base16-light span.cm-number {
+  color: #aa759f;
+}
 
-.cm-s-base16-light span.cm-property, .cm-s-base16-light span.cm-attribute { color: #90a959; }
-.cm-s-base16-light span.cm-keyword { color: #ac4142; }
-.cm-s-base16-light span.cm-string { color: #f4bf75; }
+.cm-s-base16-light span.cm-property,
+.cm-s-base16-light span.cm-attribute {
+  color: #90a959;
+}
+.cm-s-base16-light span.cm-keyword {
+  color: #ac4142;
+}
+.cm-s-base16-light span.cm-string {
+  color: #f4bf75;
+}
 
-.cm-s-base16-light span.cm-variable { color: #90a959; }
-.cm-s-base16-light span.cm-variable-2 { color: #6a9fb5; }
-.cm-s-base16-light span.cm-def { color: #d28445; }
-.cm-s-base16-light span.cm-bracket { color: #202020; }
-.cm-s-base16-light span.cm-tag { color: #ac4142; }
-.cm-s-base16-light span.cm-link { color: #aa759f; }
-.cm-s-base16-light span.cm-error { background: #ac4142; color: #505050; }
+.cm-s-base16-light span.cm-variable {
+  color: #90a959;
+}
+.cm-s-base16-light span.cm-variable-2 {
+  color: #6a9fb5;
+}
+.cm-s-base16-light span.cm-def {
+  color: #d28445;
+}
+.cm-s-base16-light span.cm-bracket {
+  color: #202020;
+}
+.cm-s-base16-light span.cm-tag {
+  color: #ac4142;
+}
+.cm-s-base16-light span.cm-link {
+  color: #aa759f;
+}
+.cm-s-base16-light span.cm-error {
+  background: #ac4142;
+  color: #505050;
+}
 
-.cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC; }
-.cm-s-base16-light .CodeMirror-matchingbracket { color: #f5f5f5 !important; background-color: #6A9FB5 !important}
+.cm-s-base16-light .CodeMirror-activeline-background {
+  background: #dddcdc;
+}
+.cm-s-base16-light .CodeMirror-matchingbracket {
+  color: #f5f5f5 !important;
+  background-color: #6a9fb5 !important;
+}
 
 /*
 
@@ -11385,34 +15560,91 @@ span.CodeMirror-selectedtext { background: none; }
 
 */
 
-.cm-s-base16-dark.CodeMirror { background: #151515; color: #e0e0e0; }
-.cm-s-base16-dark div.CodeMirror-selected { background: #303030; }
-.cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-gutters { background: #151515; border-right: 0px; }
-.cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
-.cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
-.cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
-.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0; }
+.cm-s-base16-dark.CodeMirror {
+  background: #151515;
+  color: #e0e0e0;
+}
+.cm-s-base16-dark div.CodeMirror-selected {
+  background: #303030;
+}
+.cm-s-base16-dark .CodeMirror-line::selection,
+.cm-s-base16-dark .CodeMirror-line > span::selection,
+.cm-s-base16-dark .CodeMirror-line > span > span::selection {
+  background: rgba(48, 48, 48, 0.99);
+}
+.cm-s-base16-dark .CodeMirror-line::-moz-selection,
+.cm-s-base16-dark .CodeMirror-line > span::-moz-selection,
+.cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(48, 48, 48, 0.99);
+}
+.cm-s-base16-dark .CodeMirror-gutters {
+  background: #151515;
+  border-right: 0px;
+}
+.cm-s-base16-dark .CodeMirror-guttermarker {
+  color: #ac4142;
+}
+.cm-s-base16-dark .CodeMirror-guttermarker-subtle {
+  color: #505050;
+}
+.cm-s-base16-dark .CodeMirror-linenumber {
+  color: #505050;
+}
+.cm-s-base16-dark .CodeMirror-cursor {
+  border-left: 1px solid #b0b0b0;
+}
 
-.cm-s-base16-dark span.cm-comment { color: #8f5536; }
-.cm-s-base16-dark span.cm-atom { color: #aa759f; }
-.cm-s-base16-dark span.cm-number { color: #aa759f; }
+.cm-s-base16-dark span.cm-comment {
+  color: #8f5536;
+}
+.cm-s-base16-dark span.cm-atom {
+  color: #aa759f;
+}
+.cm-s-base16-dark span.cm-number {
+  color: #aa759f;
+}
 
-.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute { color: #90a959; }
-.cm-s-base16-dark span.cm-keyword { color: #ac4142; }
-.cm-s-base16-dark span.cm-string { color: #f4bf75; }
+.cm-s-base16-dark span.cm-property,
+.cm-s-base16-dark span.cm-attribute {
+  color: #90a959;
+}
+.cm-s-base16-dark span.cm-keyword {
+  color: #ac4142;
+}
+.cm-s-base16-dark span.cm-string {
+  color: #f4bf75;
+}
 
-.cm-s-base16-dark span.cm-variable { color: #90a959; }
-.cm-s-base16-dark span.cm-variable-2 { color: #6a9fb5; }
-.cm-s-base16-dark span.cm-def { color: #d28445; }
-.cm-s-base16-dark span.cm-bracket { color: #e0e0e0; }
-.cm-s-base16-dark span.cm-tag { color: #ac4142; }
-.cm-s-base16-dark span.cm-link { color: #aa759f; }
-.cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
+.cm-s-base16-dark span.cm-variable {
+  color: #90a959;
+}
+.cm-s-base16-dark span.cm-variable-2 {
+  color: #6a9fb5;
+}
+.cm-s-base16-dark span.cm-def {
+  color: #d28445;
+}
+.cm-s-base16-dark span.cm-bracket {
+  color: #e0e0e0;
+}
+.cm-s-base16-dark span.cm-tag {
+  color: #ac4142;
+}
+.cm-s-base16-dark span.cm-link {
+  color: #aa759f;
+}
+.cm-s-base16-dark span.cm-error {
+  background: #ac4142;
+  color: #b0b0b0;
+}
 
-.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
-.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+.cm-s-base16-dark .CodeMirror-activeline-background {
+  background: #202020;
+}
+.cm-s-base16-dark .CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
+}
 
 /*
 
@@ -11423,37 +15655,92 @@ span.CodeMirror-selectedtext { background: none; }
 
 */
 
-
-.cm-s-dracula.CodeMirror, .cm-s-dracula .CodeMirror-gutters {
+.cm-s-dracula.CodeMirror,
+.cm-s-dracula .CodeMirror-gutters {
   background-color: #282a36 !important;
   color: #f8f8f2 !important;
   border: none;
 }
-.cm-s-dracula .CodeMirror-gutters { color: #282a36; }
-.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
-.cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-dracula .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula span.cm-comment { color: #6272a4; }
-.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 { color: #f1fa8c; }
-.cm-s-dracula span.cm-number { color: #bd93f9; }
-.cm-s-dracula span.cm-variable { color: #50fa7b; }
-.cm-s-dracula span.cm-variable-2 { color: white; }
-.cm-s-dracula span.cm-def { color: #50fa7b; }
-.cm-s-dracula span.cm-operator { color: #ff79c6; }
-.cm-s-dracula span.cm-keyword { color: #ff79c6; }
-.cm-s-dracula span.cm-atom { color: #bd93f9; }
-.cm-s-dracula span.cm-meta { color: #f8f8f2; }
-.cm-s-dracula span.cm-tag { color: #ff79c6; }
-.cm-s-dracula span.cm-attribute { color: #50fa7b; }
-.cm-s-dracula span.cm-qualifier { color: #50fa7b; }
-.cm-s-dracula span.cm-property { color: #66d9ef; }
-.cm-s-dracula span.cm-builtin { color: #50fa7b; }
-.cm-s-dracula span.cm-variable-3, .cm-s-dracula span.cm-type { color: #ffb86c; }
+.cm-s-dracula .CodeMirror-gutters {
+  color: #282a36;
+}
+.cm-s-dracula .CodeMirror-cursor {
+  border-left: solid thin #f8f8f0;
+}
+.cm-s-dracula .CodeMirror-linenumber {
+  color: #6d8a88;
+}
+.cm-s-dracula .CodeMirror-selected {
+  background: rgba(255, 255, 255, 0.1);
+}
+.cm-s-dracula .CodeMirror-line::selection,
+.cm-s-dracula .CodeMirror-line > span::selection,
+.cm-s-dracula .CodeMirror-line > span > span::selection {
+  background: rgba(255, 255, 255, 0.1);
+}
+.cm-s-dracula .CodeMirror-line::-moz-selection,
+.cm-s-dracula .CodeMirror-line > span::-moz-selection,
+.cm-s-dracula .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(255, 255, 255, 0.1);
+}
+.cm-s-dracula span.cm-comment {
+  color: #6272a4;
+}
+.cm-s-dracula span.cm-string,
+.cm-s-dracula span.cm-string-2 {
+  color: #f1fa8c;
+}
+.cm-s-dracula span.cm-number {
+  color: #bd93f9;
+}
+.cm-s-dracula span.cm-variable {
+  color: #50fa7b;
+}
+.cm-s-dracula span.cm-variable-2 {
+  color: white;
+}
+.cm-s-dracula span.cm-def {
+  color: #50fa7b;
+}
+.cm-s-dracula span.cm-operator {
+  color: #ff79c6;
+}
+.cm-s-dracula span.cm-keyword {
+  color: #ff79c6;
+}
+.cm-s-dracula span.cm-atom {
+  color: #bd93f9;
+}
+.cm-s-dracula span.cm-meta {
+  color: #f8f8f2;
+}
+.cm-s-dracula span.cm-tag {
+  color: #ff79c6;
+}
+.cm-s-dracula span.cm-attribute {
+  color: #50fa7b;
+}
+.cm-s-dracula span.cm-qualifier {
+  color: #50fa7b;
+}
+.cm-s-dracula span.cm-property {
+  color: #66d9ef;
+}
+.cm-s-dracula span.cm-builtin {
+  color: #50fa7b;
+}
+.cm-s-dracula span.cm-variable-3,
+.cm-s-dracula span.cm-type {
+  color: #ffb86c;
+}
 
-.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
-.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+.cm-s-dracula .CodeMirror-activeline-background {
+  background: rgba(255, 255, 255, 0.1);
+}
+.cm-s-dracula .CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
+}
 
 /*
 
@@ -11465,30 +15752,75 @@ span.CodeMirror-selectedtext { background: none; }
 
 */
 
-.cm-s-hopscotch.CodeMirror {background: #322931; color: #d5d3d5;}
-.cm-s-hopscotch div.CodeMirror-selected {background: #433b42 !important;}
-.cm-s-hopscotch .CodeMirror-gutters {background: #322931; border-right: 0px;}
-.cm-s-hopscotch .CodeMirror-linenumber {color: #797379;}
-.cm-s-hopscotch .CodeMirror-cursor {border-left: 1px solid #989498 !important;}
+.cm-s-hopscotch.CodeMirror {
+  background: #322931;
+  color: #d5d3d5;
+}
+.cm-s-hopscotch div.CodeMirror-selected {
+  background: #433b42 !important;
+}
+.cm-s-hopscotch .CodeMirror-gutters {
+  background: #322931;
+  border-right: 0px;
+}
+.cm-s-hopscotch .CodeMirror-linenumber {
+  color: #797379;
+}
+.cm-s-hopscotch .CodeMirror-cursor {
+  border-left: 1px solid #989498 !important;
+}
 
-.cm-s-hopscotch span.cm-comment {color: #b33508;}
-.cm-s-hopscotch span.cm-atom {color: #c85e7c;}
-.cm-s-hopscotch span.cm-number {color: #c85e7c;}
+.cm-s-hopscotch span.cm-comment {
+  color: #b33508;
+}
+.cm-s-hopscotch span.cm-atom {
+  color: #c85e7c;
+}
+.cm-s-hopscotch span.cm-number {
+  color: #c85e7c;
+}
 
-.cm-s-hopscotch span.cm-property, .cm-s-hopscotch span.cm-attribute {color: #8fc13e;}
-.cm-s-hopscotch span.cm-keyword {color: #dd464c;}
-.cm-s-hopscotch span.cm-string {color: #fdcc59;}
+.cm-s-hopscotch span.cm-property,
+.cm-s-hopscotch span.cm-attribute {
+  color: #8fc13e;
+}
+.cm-s-hopscotch span.cm-keyword {
+  color: #dd464c;
+}
+.cm-s-hopscotch span.cm-string {
+  color: #fdcc59;
+}
 
-.cm-s-hopscotch span.cm-variable {color: #8fc13e;}
-.cm-s-hopscotch span.cm-variable-2 {color: #1290bf;}
-.cm-s-hopscotch span.cm-def {color: #fd8b19;}
-.cm-s-hopscotch span.cm-error {background: #dd464c; color: #989498;}
-.cm-s-hopscotch span.cm-bracket {color: #d5d3d5;}
-.cm-s-hopscotch span.cm-tag {color: #dd464c;}
-.cm-s-hopscotch span.cm-link {color: #c85e7c;}
+.cm-s-hopscotch span.cm-variable {
+  color: #8fc13e;
+}
+.cm-s-hopscotch span.cm-variable-2 {
+  color: #1290bf;
+}
+.cm-s-hopscotch span.cm-def {
+  color: #fd8b19;
+}
+.cm-s-hopscotch span.cm-error {
+  background: #dd464c;
+  color: #989498;
+}
+.cm-s-hopscotch span.cm-bracket {
+  color: #d5d3d5;
+}
+.cm-s-hopscotch span.cm-tag {
+  color: #dd464c;
+}
+.cm-s-hopscotch span.cm-link {
+  color: #c85e7c;
+}
 
-.cm-s-hopscotch .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
-.cm-s-hopscotch .CodeMirror-activeline-background { background: #302020; }
+.cm-s-hopscotch .CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
+}
+.cm-s-hopscotch .CodeMirror-activeline-background {
+  background: #302020;
+}
 
 /****************************************************************/
 /*   Based on mbonaci's Brackets mbo theme                      */
@@ -11496,37 +15828,100 @@ span.CodeMirror-selectedtext { background: none; }
 /*   Create your own: http://tmtheme-editor.herokuapp.com       */
 /****************************************************************/
 
-.cm-s-mbo.CodeMirror { background: #2c2c2c; color: #ffffec; }
-.cm-s-mbo div.CodeMirror-selected { background: #716C62; }
-.cm-s-mbo .CodeMirror-line::selection, .cm-s-mbo .CodeMirror-line > span::selection, .cm-s-mbo .CodeMirror-line > span > span::selection { background: rgba(113, 108, 98, .99); }
-.cm-s-mbo .CodeMirror-line::-moz-selection, .cm-s-mbo .CodeMirror-line > span::-moz-selection, .cm-s-mbo .CodeMirror-line > span > span::-moz-selection { background: rgba(113, 108, 98, .99); }
-.cm-s-mbo .CodeMirror-gutters { background: #4e4e4e; border-right: 0px; }
-.cm-s-mbo .CodeMirror-guttermarker { color: white; }
-.cm-s-mbo .CodeMirror-guttermarker-subtle { color: grey; }
-.cm-s-mbo .CodeMirror-linenumber { color: #dadada; }
-.cm-s-mbo .CodeMirror-cursor { border-left: 1px solid #ffffec; }
+.cm-s-mbo.CodeMirror {
+  background: #2c2c2c;
+  color: #ffffec;
+}
+.cm-s-mbo div.CodeMirror-selected {
+  background: #716c62;
+}
+.cm-s-mbo .CodeMirror-line::selection,
+.cm-s-mbo .CodeMirror-line > span::selection,
+.cm-s-mbo .CodeMirror-line > span > span::selection {
+  background: rgba(113, 108, 98, 0.99);
+}
+.cm-s-mbo .CodeMirror-line::-moz-selection,
+.cm-s-mbo .CodeMirror-line > span::-moz-selection,
+.cm-s-mbo .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(113, 108, 98, 0.99);
+}
+.cm-s-mbo .CodeMirror-gutters {
+  background: #4e4e4e;
+  border-right: 0px;
+}
+.cm-s-mbo .CodeMirror-guttermarker {
+  color: white;
+}
+.cm-s-mbo .CodeMirror-guttermarker-subtle {
+  color: grey;
+}
+.cm-s-mbo .CodeMirror-linenumber {
+  color: #dadada;
+}
+.cm-s-mbo .CodeMirror-cursor {
+  border-left: 1px solid #ffffec;
+}
 
-.cm-s-mbo span.cm-comment { color: #95958a; }
-.cm-s-mbo span.cm-atom { color: #00a8c6; }
-.cm-s-mbo span.cm-number { color: #00a8c6; }
+.cm-s-mbo span.cm-comment {
+  color: #95958a;
+}
+.cm-s-mbo span.cm-atom {
+  color: #00a8c6;
+}
+.cm-s-mbo span.cm-number {
+  color: #00a8c6;
+}
 
-.cm-s-mbo span.cm-property, .cm-s-mbo span.cm-attribute { color: #9ddfe9; }
-.cm-s-mbo span.cm-keyword { color: #ffb928; }
-.cm-s-mbo span.cm-string { color: #ffcf6c; }
-.cm-s-mbo span.cm-string.cm-property { color: #ffffec; }
+.cm-s-mbo span.cm-property,
+.cm-s-mbo span.cm-attribute {
+  color: #9ddfe9;
+}
+.cm-s-mbo span.cm-keyword {
+  color: #ffb928;
+}
+.cm-s-mbo span.cm-string {
+  color: #ffcf6c;
+}
+.cm-s-mbo span.cm-string.cm-property {
+  color: #ffffec;
+}
 
-.cm-s-mbo span.cm-variable { color: #ffffec; }
-.cm-s-mbo span.cm-variable-2 { color: #00a8c6; }
-.cm-s-mbo span.cm-def { color: #ffffec; }
-.cm-s-mbo span.cm-bracket { color: #fffffc; font-weight: bold; }
-.cm-s-mbo span.cm-tag { color: #9ddfe9; }
-.cm-s-mbo span.cm-link { color: #f54b07; }
-.cm-s-mbo span.cm-error { border-bottom: #636363; color: #ffffec; }
-.cm-s-mbo span.cm-qualifier { color: #ffffec; }
+.cm-s-mbo span.cm-variable {
+  color: #ffffec;
+}
+.cm-s-mbo span.cm-variable-2 {
+  color: #00a8c6;
+}
+.cm-s-mbo span.cm-def {
+  color: #ffffec;
+}
+.cm-s-mbo span.cm-bracket {
+  color: #fffffc;
+  font-weight: bold;
+}
+.cm-s-mbo span.cm-tag {
+  color: #9ddfe9;
+}
+.cm-s-mbo span.cm-link {
+  color: #f54b07;
+}
+.cm-s-mbo span.cm-error {
+  border-bottom: #636363;
+  color: #ffffec;
+}
+.cm-s-mbo span.cm-qualifier {
+  color: #ffffec;
+}
 
-.cm-s-mbo .CodeMirror-activeline-background { background: #494b41; }
-.cm-s-mbo .CodeMirror-matchingbracket { color: #ffb928 !important; }
-.cm-s-mbo .CodeMirror-matchingtag { background: rgba(255, 255, 255, .37); }
+.cm-s-mbo .CodeMirror-activeline-background {
+  background: #494b41;
+}
+.cm-s-mbo .CodeMirror-matchingbracket {
+  color: #ffb928 !important;
+}
+.cm-s-mbo .CodeMirror-matchingtag {
+  background: rgba(255, 255, 255, 0.37);
+}
 
 /*
   MDN-LIKE Theme - Mozilla
@@ -11537,43 +15932,121 @@ span.CodeMirror-selectedtext { background: none; }
   The mdn-like theme is inspired on the displayed code examples at: https://developer.mozilla.org/en-US/docs/Web/CSS/animation
 
 */
-.cm-s-mdn-like.CodeMirror { color: #999; background-color: #fff; }
-.cm-s-mdn-like div.CodeMirror-selected { background: #cfc; }
-.cm-s-mdn-like .CodeMirror-line::selection, .cm-s-mdn-like .CodeMirror-line > span::selection, .cm-s-mdn-like .CodeMirror-line > span > span::selection { background: #cfc; }
-.cm-s-mdn-like .CodeMirror-line::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span > span::-moz-selection { background: #cfc; }
+.cm-s-mdn-like.CodeMirror {
+  color: #999;
+  background-color: #fff;
+}
+.cm-s-mdn-like div.CodeMirror-selected {
+  background: #cfc;
+}
+.cm-s-mdn-like .CodeMirror-line::selection,
+.cm-s-mdn-like .CodeMirror-line > span::selection,
+.cm-s-mdn-like .CodeMirror-line > span > span::selection {
+  background: #cfc;
+}
+.cm-s-mdn-like .CodeMirror-line::-moz-selection,
+.cm-s-mdn-like .CodeMirror-line > span::-moz-selection,
+.cm-s-mdn-like .CodeMirror-line > span > span::-moz-selection {
+  background: #cfc;
+}
 
-.cm-s-mdn-like .CodeMirror-gutters { background: #f8f8f8; border-left: 6px solid rgba(0,83,159,0.65); color: #333; }
-.cm-s-mdn-like .CodeMirror-linenumber { color: #aaa; padding-left: 8px; }
-.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
+.cm-s-mdn-like .CodeMirror-gutters {
+  background: #f8f8f8;
+  border-left: 6px solid rgba(0, 83, 159, 0.65);
+  color: #333;
+}
+.cm-s-mdn-like .CodeMirror-linenumber {
+  color: #aaa;
+  padding-left: 8px;
+}
+.cm-s-mdn-like .CodeMirror-cursor {
+  border-left: 2px solid #222;
+}
 
-.cm-s-mdn-like .cm-keyword { color: #6262FF; }
-.cm-s-mdn-like .cm-atom { color: #F90; }
-.cm-s-mdn-like .cm-number { color:  #ca7841; }
-.cm-s-mdn-like .cm-def { color: #8DA6CE; }
-.cm-s-mdn-like span.cm-variable-2, .cm-s-mdn-like span.cm-tag { color: #690; }
-.cm-s-mdn-like span.cm-variable-3, .cm-s-mdn-like span.cm-def, .cm-s-mdn-like span.cm-type { color: #07a; }
+.cm-s-mdn-like .cm-keyword {
+  color: #6262ff;
+}
+.cm-s-mdn-like .cm-atom {
+  color: #f90;
+}
+.cm-s-mdn-like .cm-number {
+  color: #ca7841;
+}
+.cm-s-mdn-like .cm-def {
+  color: #8da6ce;
+}
+.cm-s-mdn-like span.cm-variable-2,
+.cm-s-mdn-like span.cm-tag {
+  color: #690;
+}
+.cm-s-mdn-like span.cm-variable-3,
+.cm-s-mdn-like span.cm-def,
+.cm-s-mdn-like span.cm-type {
+  color: #07a;
+}
 
-.cm-s-mdn-like .cm-variable { color: #07a; }
-.cm-s-mdn-like .cm-property { color: #905; }
-.cm-s-mdn-like .cm-qualifier { color: #690; }
+.cm-s-mdn-like .cm-variable {
+  color: #07a;
+}
+.cm-s-mdn-like .cm-property {
+  color: #905;
+}
+.cm-s-mdn-like .cm-qualifier {
+  color: #690;
+}
 
-.cm-s-mdn-like .cm-operator { color: #cda869; }
-.cm-s-mdn-like .cm-comment { color:#777; font-weight:normal; }
-.cm-s-mdn-like .cm-string { color:#07a; font-style:italic; }
-.cm-s-mdn-like .cm-string-2 { color:#bd6b18; } /*?*/
-.cm-s-mdn-like .cm-meta { color: #000; } /*?*/
-.cm-s-mdn-like .cm-builtin { color: #9B7536; } /*?*/
-.cm-s-mdn-like .cm-tag { color: #997643; }
-.cm-s-mdn-like .cm-attribute { color: #d6bb6d; } /*?*/
-.cm-s-mdn-like .cm-header { color: #FF6400; }
-.cm-s-mdn-like .cm-hr { color: #AEAEAE; }
-.cm-s-mdn-like .cm-link { color:#ad9361; font-style:italic; text-decoration:none; }
-.cm-s-mdn-like .cm-error { border-bottom: 1px solid red; }
+.cm-s-mdn-like .cm-operator {
+  color: #cda869;
+}
+.cm-s-mdn-like .cm-comment {
+  color: #777;
+  font-weight: normal;
+}
+.cm-s-mdn-like .cm-string {
+  color: #07a;
+  font-style: italic;
+}
+.cm-s-mdn-like .cm-string-2 {
+  color: #bd6b18;
+} /*?*/
+.cm-s-mdn-like .cm-meta {
+  color: #000;
+} /*?*/
+.cm-s-mdn-like .cm-builtin {
+  color: #9b7536;
+} /*?*/
+.cm-s-mdn-like .cm-tag {
+  color: #997643;
+}
+.cm-s-mdn-like .cm-attribute {
+  color: #d6bb6d;
+} /*?*/
+.cm-s-mdn-like .cm-header {
+  color: #ff6400;
+}
+.cm-s-mdn-like .cm-hr {
+  color: #aeaeae;
+}
+.cm-s-mdn-like .cm-link {
+  color: #ad9361;
+  font-style: italic;
+  text-decoration: none;
+}
+.cm-s-mdn-like .cm-error {
+  border-bottom: 1px solid red;
+}
 
-div.cm-s-mdn-like .CodeMirror-activeline-background { background: #efefff; }
-div.cm-s-mdn-like span.CodeMirror-matchingbracket { outline:1px solid grey; color: inherit; }
+div.cm-s-mdn-like .CodeMirror-activeline-background {
+  background: #efefff;
+}
+div.cm-s-mdn-like span.CodeMirror-matchingbracket {
+  outline: 1px solid grey;
+  color: inherit;
+}
 
-.cm-s-mdn-like.CodeMirror { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFcAAAAyCAYAAAAp8UeFAAAHvklEQVR42s2b63bcNgyEQZCSHCdt2vd/0tWF7I+Q6XgMXiTtuvU5Pl57ZQKkKHzEAOtF5KeIJBGJ8uvL599FRFREZhFx8DeXv8trn68RuGaC8TRfo3SNp9dlDDHedyLyTUTeRWStXKPZrjtpZxaRw5hPqozRs1N8/enzIiQRWcCgy4MUA0f+XWliDhyL8Lfyvx7ei/Ae3iQFHyw7U/59pQVIMEEPEz0G7XiwdRjzSfC3UTtz9vchIntxvry5iMgfIhJoEflOz2CQr3F5h/HfeFe+GTdLaKcu9L8LTeQb/R/7GgbsfKedyNdoHsN31uRPWrfZ5wsj/NzzRQHuToIdU3ahwnsKPxXCjJITuOsi7XLc7SG/v5GdALs7wf8JjTFiB5+QvTEfRyGOfX3Lrx8wxyQi3sNq46O7QahQiCsRFgqddjBouVEHOKDgXAQHD9gJCr5sMKkEdjwsarG/ww3BMHBU7OBjXnzdyY7SfCxf5/z6ATccrwlKuwC/jhznnPF4CgVzhhVf4xp2EixcBActO75iZ8/fM9zAs2OMzKdslgXWJ9XG8PQoOAMA5fGcsvORgv0doBXyHrCwfLJAOwo71QLNkb8n2Pl6EWiR7OCibtkPaz4Kc/0NNAze2gju3zOwekALDaCFPI5vjPFmgGY5AZqyGEvH1x7QfIb8YtxMnA/b+QQ0aQDAwc6JMFg8CbQZ4qoYEEHbRwNojuK3EHwd7VALSgq+MNDKzfT58T8qdpADrgW0GmgcAS1lhzztJmkAzcPNOQbsWEALBDSlMKUG0Eq4CLAQWvEVQ9WU57gZJwZtgPO3r9oBTQ9WO8TjqXINx8R0EYpiZEUWOF3FxkbJkgU9B2f41YBrIj5ZfsQa0M5kTgiAAqM3ShXLgu8XMqcrQBvJ0CL5pnTsfMB13oB8athpAq2XOQmcGmoACCLydx7nToa23ATaSIY2ichfOdPTGxlasXMLaL0MLZAOwAKIM+y8CmicobGdCcbbK9DzN+yYGVoNNI5iUKTMyYOjPse4A8SM1MmcXgU0toOq1yO/v8FOxlASyc7TgeYaAMBJHcY1CcCwGI/TK4AmDbDyKYBBtFUkRwto8gygiQEaByFgJ00BH2M8JWwQS1nafDXQCidWyOI8AcjDCSjCLk8ngObuAm3JAHAdubAmOaK06V8MNEsKPJOhobSprwQa6gD7DclRQdqcwL4zxqgBrQcabUiBLclRDKAlWp+etPkBaNMA0AKlrHwTdEByZAA4GM+SNluSY6wAzcMNewxmgig5Ks0nkrSpBvSaQHMdKTBAnLojOdYyGpQ254602ZILPdTD1hdlggdIm74jbTp8vDwF5ZYUeLWGJpWsh6XNyXgcYwVoJQTEhhTYkxzZjiU5npU2TaB979TQehlaAVq4kaGpiPwwwLkYUuBbQwocyQTv1tA0+1UFWoJF3iv1oq+qoSk8EQdJmwHkziIF7oOZk14EGitibAdjLYYK78H5vZOhtWpoI0ATGHs0Q8OMb4Ey+2bU2UYztCtA0wFAs7TplGLRVQCcqaFdGSPCeTI1QNIC52iWNzof6Uib7xjEp07mNNoUYmVosVItHrHzRlLgBn9LFyRHaQCtVUMbtTNhoXWiTOO9k/V8BdAc1Oq0ArSQs6/5SU0hckNy9NnXqQY0PGYo5dWJ7nINaN6o958FWin27aBaWRka1r5myvLOAm0j30eBJqCxHLReVclxhxOEN2JfDWjxBtAC7MIH1fVaGdoOp4qJYDgKtKPSFNID2gSnGldrCqkFZ+5UeQXQBIRrSwocbdZYQT/2LwRahBPBXoHrB8nxaGROST62DKUbQOMMzZIC9abkuELfQzQALWTnDNAm8KHWFOJgJ5+SHIvTPcmx1xQyZRhNL5Qci689aXMEaN/uNIWkEwDAvFpOZmgsBaaGnbs1NPa1Jm32gBZAIh1pCtG7TSH4aE0y1uVY4uqoFPisGlpP2rSA5qTecWn5agK6BzSpgAyD+wFaqhnYoSZ1Vwr8CmlTQbrcO3ZaX0NAEyMbYaAlyquFoLKK3SPby9CeVUPThrSJmkCAE0CrKUQadi4DrdSlWhmah0YL9z9vClH59YGbHx1J8VZTyAjQepJjmXwAKTDQI3omc3p1U4gDUf6RfcdYfrUp5ClAi2J3Ba6UOXGo+K+bQrjjssitG2SJzshaLwMtXgRagUNpYYoVkMSBLM+9GGiJZMvduG6DRZ4qc04DMPtQQxOjEtACmhO7K1AbNbQDEggZyJwscFpAGwENhoBeUwh3bWolhe8BTYVKxQEWrSUn/uhcM5KhvUu/+eQu0Lzhi+VrK0PrZZNDQKs9cpYUuFYgMVpD4/NxenJTiMCNqdUEUf1qZWjppLT5qSkkUZbCwkbZMSuVnu80hfSkzRbQeqCZSAh6huR4VtoM2gHAlLf72smuWgE+VV7XpE25Ab2WFDgyhnSuKbs4GuGzCjR+tIoUuMFg3kgcWKLTwRqanJQ2W00hAsenfaApRC42hbCvK1SlE0HtE9BGgneJO+ELamitD1YjjOYnNYVcraGhtKkW0EqVVeDx733I2NH581k1NNxNLG0i0IJ8/NjVaOZ0tYZ2Vtr0Xv7tPV3hkWp9EFkgS/J0vosngTaSoaG06WHi+xObQkaAdlbanP8B2+2l0f90LmUAAAAASUVORK5CYII=); }
+.cm-s-mdn-like.CodeMirror {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFcAAAAyCAYAAAAp8UeFAAAHvklEQVR42s2b63bcNgyEQZCSHCdt2vd/0tWF7I+Q6XgMXiTtuvU5Pl57ZQKkKHzEAOtF5KeIJBGJ8uvL599FRFREZhFx8DeXv8trn68RuGaC8TRfo3SNp9dlDDHedyLyTUTeRWStXKPZrjtpZxaRw5hPqozRs1N8/enzIiQRWcCgy4MUA0f+XWliDhyL8Lfyvx7ei/Ae3iQFHyw7U/59pQVIMEEPEz0G7XiwdRjzSfC3UTtz9vchIntxvry5iMgfIhJoEflOz2CQr3F5h/HfeFe+GTdLaKcu9L8LTeQb/R/7GgbsfKedyNdoHsN31uRPWrfZ5wsj/NzzRQHuToIdU3ahwnsKPxXCjJITuOsi7XLc7SG/v5GdALs7wf8JjTFiB5+QvTEfRyGOfX3Lrx8wxyQi3sNq46O7QahQiCsRFgqddjBouVEHOKDgXAQHD9gJCr5sMKkEdjwsarG/ww3BMHBU7OBjXnzdyY7SfCxf5/z6ATccrwlKuwC/jhznnPF4CgVzhhVf4xp2EixcBActO75iZ8/fM9zAs2OMzKdslgXWJ9XG8PQoOAMA5fGcsvORgv0doBXyHrCwfLJAOwo71QLNkb8n2Pl6EWiR7OCibtkPaz4Kc/0NNAze2gju3zOwekALDaCFPI5vjPFmgGY5AZqyGEvH1x7QfIb8YtxMnA/b+QQ0aQDAwc6JMFg8CbQZ4qoYEEHbRwNojuK3EHwd7VALSgq+MNDKzfT58T8qdpADrgW0GmgcAS1lhzztJmkAzcPNOQbsWEALBDSlMKUG0Eq4CLAQWvEVQ9WU57gZJwZtgPO3r9oBTQ9WO8TjqXINx8R0EYpiZEUWOF3FxkbJkgU9B2f41YBrIj5ZfsQa0M5kTgiAAqM3ShXLgu8XMqcrQBvJ0CL5pnTsfMB13oB8athpAq2XOQmcGmoACCLydx7nToa23ATaSIY2ichfOdPTGxlasXMLaL0MLZAOwAKIM+y8CmicobGdCcbbK9DzN+yYGVoNNI5iUKTMyYOjPse4A8SM1MmcXgU0toOq1yO/v8FOxlASyc7TgeYaAMBJHcY1CcCwGI/TK4AmDbDyKYBBtFUkRwto8gygiQEaByFgJ00BH2M8JWwQS1nafDXQCidWyOI8AcjDCSjCLk8ngObuAm3JAHAdubAmOaK06V8MNEsKPJOhobSprwQa6gD7DclRQdqcwL4zxqgBrQcabUiBLclRDKAlWp+etPkBaNMA0AKlrHwTdEByZAA4GM+SNluSY6wAzcMNewxmgig5Ks0nkrSpBvSaQHMdKTBAnLojOdYyGpQ254602ZILPdTD1hdlggdIm74jbTp8vDwF5ZYUeLWGJpWsh6XNyXgcYwVoJQTEhhTYkxzZjiU5npU2TaB979TQehlaAVq4kaGpiPwwwLkYUuBbQwocyQTv1tA0+1UFWoJF3iv1oq+qoSk8EQdJmwHkziIF7oOZk14EGitibAdjLYYK78H5vZOhtWpoI0ATGHs0Q8OMb4Ey+2bU2UYztCtA0wFAs7TplGLRVQCcqaFdGSPCeTI1QNIC52iWNzof6Uib7xjEp07mNNoUYmVosVItHrHzRlLgBn9LFyRHaQCtVUMbtTNhoXWiTOO9k/V8BdAc1Oq0ArSQs6/5SU0hckNy9NnXqQY0PGYo5dWJ7nINaN6o958FWin27aBaWRka1r5myvLOAm0j30eBJqCxHLReVclxhxOEN2JfDWjxBtAC7MIH1fVaGdoOp4qJYDgKtKPSFNID2gSnGldrCqkFZ+5UeQXQBIRrSwocbdZYQT/2LwRahBPBXoHrB8nxaGROST62DKUbQOMMzZIC9abkuELfQzQALWTnDNAm8KHWFOJgJ5+SHIvTPcmx1xQyZRhNL5Qci689aXMEaN/uNIWkEwDAvFpOZmgsBaaGnbs1NPa1Jm32gBZAIh1pCtG7TSH4aE0y1uVY4uqoFPisGlpP2rSA5qTecWn5agK6BzSpgAyD+wFaqhnYoSZ1Vwr8CmlTQbrcO3ZaX0NAEyMbYaAlyquFoLKK3SPby9CeVUPThrSJmkCAE0CrKUQadi4DrdSlWhmah0YL9z9vClH59YGbHx1J8VZTyAjQepJjmXwAKTDQI3omc3p1U4gDUf6RfcdYfrUp5ClAi2J3Ba6UOXGo+K+bQrjjssitG2SJzshaLwMtXgRagUNpYYoVkMSBLM+9GGiJZMvduG6DRZ4qc04DMPtQQxOjEtACmhO7K1AbNbQDEggZyJwscFpAGwENhoBeUwh3bWolhe8BTYVKxQEWrSUn/uhcM5KhvUu/+eQu0Lzhi+VrK0PrZZNDQKs9cpYUuFYgMVpD4/NxenJTiMCNqdUEUf1qZWjppLT5qSkkUZbCwkbZMSuVnu80hfSkzRbQeqCZSAh6huR4VtoM2gHAlLf72smuWgE+VV7XpE25Ab2WFDgyhnSuKbs4GuGzCjR+tIoUuMFg3kgcWKLTwRqanJQ2W00hAsenfaApRC42hbCvK1SlE0HtE9BGgneJO+ELamitD1YjjOYnNYVcraGhtKkW0EqVVeDx733I2NH581k1NNxNLG0i0IJ8/NjVaOZ0tYZ2Vtr0Xv7tPV3hkWp9EFkgS/J0vosngTaSoaG06WHi+xObQkaAdlbanP8B2+2l0f90LmUAAAAASUVORK5CYII=);
+}
 
 /*
 
@@ -11584,41 +16057,95 @@ div.cm-s-mdn-like span.CodeMirror-matchingbracket { outline:1px solid grey; colo
 
 */
 
-
 .cm-s-seti.CodeMirror {
   background-color: #151718 !important;
-  color: #CFD2D1 !important;
+  color: #cfd2d1 !important;
   border: none;
 }
 .cm-s-seti .CodeMirror-gutters {
   color: #404b53;
-  background-color: #0E1112;
+  background-color: #0e1112;
   border: none;
 }
-.cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
-.cm-s-seti .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-seti.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti .CodeMirror-line::-moz-selection, .cm-s-seti .CodeMirror-line > span::-moz-selection, .cm-s-seti .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti span.cm-comment { color: #41535b; }
-.cm-s-seti span.cm-string, .cm-s-seti span.cm-string-2 { color: #55b5db; }
-.cm-s-seti span.cm-number { color: #cd3f45; }
-.cm-s-seti span.cm-variable { color: #55b5db; }
-.cm-s-seti span.cm-variable-2 { color: #a074c4; }
-.cm-s-seti span.cm-def { color: #55b5db; }
-.cm-s-seti span.cm-keyword { color: #ff79c6; }
-.cm-s-seti span.cm-operator { color: #9fca56; }
-.cm-s-seti span.cm-keyword { color: #e6cd69; }
-.cm-s-seti span.cm-atom { color: #cd3f45; }
-.cm-s-seti span.cm-meta { color: #55b5db; }
-.cm-s-seti span.cm-tag { color: #55b5db; }
-.cm-s-seti span.cm-attribute { color: #9fca56; }
-.cm-s-seti span.cm-qualifier { color: #9fca56; }
-.cm-s-seti span.cm-property { color: #a074c4; }
-.cm-s-seti span.cm-variable-3, .cm-s-seti span.cm-type { color: #9fca56; }
-.cm-s-seti span.cm-builtin { color: #9fca56; }
-.cm-s-seti .CodeMirror-activeline-background { background: #101213; }
-.cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+.cm-s-seti .CodeMirror-cursor {
+  border-left: solid thin #f8f8f0;
+}
+.cm-s-seti .CodeMirror-linenumber {
+  color: #6d8a88;
+}
+.cm-s-seti.CodeMirror-focused div.CodeMirror-selected {
+  background: rgba(255, 255, 255, 0.1);
+}
+.cm-s-seti .CodeMirror-line::selection,
+.cm-s-seti .CodeMirror-line > span::selection,
+.cm-s-seti .CodeMirror-line > span > span::selection {
+  background: rgba(255, 255, 255, 0.1);
+}
+.cm-s-seti .CodeMirror-line::-moz-selection,
+.cm-s-seti .CodeMirror-line > span::-moz-selection,
+.cm-s-seti .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(255, 255, 255, 0.1);
+}
+.cm-s-seti span.cm-comment {
+  color: #41535b;
+}
+.cm-s-seti span.cm-string,
+.cm-s-seti span.cm-string-2 {
+  color: #55b5db;
+}
+.cm-s-seti span.cm-number {
+  color: #cd3f45;
+}
+.cm-s-seti span.cm-variable {
+  color: #55b5db;
+}
+.cm-s-seti span.cm-variable-2 {
+  color: #a074c4;
+}
+.cm-s-seti span.cm-def {
+  color: #55b5db;
+}
+.cm-s-seti span.cm-keyword {
+  color: #ff79c6;
+}
+.cm-s-seti span.cm-operator {
+  color: #9fca56;
+}
+.cm-s-seti span.cm-keyword {
+  color: #e6cd69;
+}
+.cm-s-seti span.cm-atom {
+  color: #cd3f45;
+}
+.cm-s-seti span.cm-meta {
+  color: #55b5db;
+}
+.cm-s-seti span.cm-tag {
+  color: #55b5db;
+}
+.cm-s-seti span.cm-attribute {
+  color: #9fca56;
+}
+.cm-s-seti span.cm-qualifier {
+  color: #9fca56;
+}
+.cm-s-seti span.cm-property {
+  color: #a074c4;
+}
+.cm-s-seti span.cm-variable-3,
+.cm-s-seti span.cm-type {
+  color: #9fca56;
+}
+.cm-s-seti span.cm-builtin {
+  color: #9fca56;
+}
+.cm-s-seti .CodeMirror-activeline-background {
+  background: #101213;
+}
+.cm-s-seti .CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
+}
 
 /*
 Solarized theme for code-mirror
@@ -11630,22 +16157,54 @@ Solarized color palette
 http://ethanschoonover.com/solarized/img/solarized-palette.png
 */
 
-.solarized.base03 { color: #002b36; }
-.solarized.base02 { color: #073642; }
-.solarized.base01 { color: #586e75; }
-.solarized.base00 { color: #657b83; }
-.solarized.base0 { color: #839496; }
-.solarized.base1 { color: #93a1a1; }
-.solarized.base2 { color: #eee8d5; }
-.solarized.base3  { color: #fdf6e3; }
-.solarized.solar-yellow  { color: #b58900; }
-.solarized.solar-orange  { color: #cb4b16; }
-.solarized.solar-red { color: #dc322f; }
-.solarized.solar-magenta { color: #d33682; }
-.solarized.solar-violet  { color: #6c71c4; }
-.solarized.solar-blue { color: #268bd2; }
-.solarized.solar-cyan { color: #2aa198; }
-.solarized.solar-green { color: #859900; }
+.solarized.base03 {
+  color: #002b36;
+}
+.solarized.base02 {
+  color: #073642;
+}
+.solarized.base01 {
+  color: #586e75;
+}
+.solarized.base00 {
+  color: #657b83;
+}
+.solarized.base0 {
+  color: #839496;
+}
+.solarized.base1 {
+  color: #93a1a1;
+}
+.solarized.base2 {
+  color: #eee8d5;
+}
+.solarized.base3 {
+  color: #fdf6e3;
+}
+.solarized.solar-yellow {
+  color: #b58900;
+}
+.solarized.solar-orange {
+  color: #cb4b16;
+}
+.solarized.solar-red {
+  color: #dc322f;
+}
+.solarized.solar-magenta {
+  color: #d33682;
+}
+.solarized.solar-violet {
+  color: #6c71c4;
+}
+.solarized.solar-blue {
+  color: #268bd2;
+}
+.solarized.solar-cyan {
+  color: #2aa198;
+}
+.solarized.solar-green {
+  color: #859900;
+}
 
 /* Color scheme for code-mirror */
 
@@ -11669,41 +16228,92 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
   text-shadow: none;
 }
 
-.cm-s-solarized .cm-header { color: #586e75; }
-.cm-s-solarized .cm-quote { color: #93a1a1; }
+.cm-s-solarized .cm-header {
+  color: #586e75;
+}
+.cm-s-solarized .cm-quote {
+  color: #93a1a1;
+}
 
-.cm-s-solarized .cm-keyword { color: #cb4b16; }
-.cm-s-solarized .cm-atom { color: #d33682; }
-.cm-s-solarized .cm-number { color: #d33682; }
-.cm-s-solarized .cm-def { color: #2aa198; }
+.cm-s-solarized .cm-keyword {
+  color: #cb4b16;
+}
+.cm-s-solarized .cm-atom {
+  color: #d33682;
+}
+.cm-s-solarized .cm-number {
+  color: #d33682;
+}
+.cm-s-solarized .cm-def {
+  color: #2aa198;
+}
 
-.cm-s-solarized .cm-variable { color: #839496; }
-.cm-s-solarized .cm-variable-2 { color: #b58900; }
-.cm-s-solarized .cm-variable-3, .cm-s-solarized .cm-type { color: #6c71c4; }
+.cm-s-solarized .cm-variable {
+  color: #839496;
+}
+.cm-s-solarized .cm-variable-2 {
+  color: #b58900;
+}
+.cm-s-solarized .cm-variable-3,
+.cm-s-solarized .cm-type {
+  color: #6c71c4;
+}
 
-.cm-s-solarized .cm-property { color: #2aa198; }
-.cm-s-solarized .cm-operator { color: #6c71c4; }
+.cm-s-solarized .cm-property {
+  color: #2aa198;
+}
+.cm-s-solarized .cm-operator {
+  color: #6c71c4;
+}
 
-.cm-s-solarized .cm-comment { color: #586e75; font-style:italic; }
+.cm-s-solarized .cm-comment {
+  color: #586e75;
+  font-style: italic;
+}
 
-.cm-s-solarized .cm-string { color: #859900; }
-.cm-s-solarized .cm-string-2 { color: #b58900; }
+.cm-s-solarized .cm-string {
+  color: #859900;
+}
+.cm-s-solarized .cm-string-2 {
+  color: #b58900;
+}
 
-.cm-s-solarized .cm-meta { color: #859900; }
-.cm-s-solarized .cm-qualifier { color: #b58900; }
-.cm-s-solarized .cm-builtin { color: #d33682; }
-.cm-s-solarized .cm-bracket { color: #cb4b16; }
-.cm-s-solarized .CodeMirror-matchingbracket { color: #859900; }
-.cm-s-solarized .CodeMirror-nonmatchingbracket { color: #dc322f; }
-.cm-s-solarized .cm-tag { color: #93a1a1; }
-.cm-s-solarized .cm-attribute { color: #2aa198; }
+.cm-s-solarized .cm-meta {
+  color: #859900;
+}
+.cm-s-solarized .cm-qualifier {
+  color: #b58900;
+}
+.cm-s-solarized .cm-builtin {
+  color: #d33682;
+}
+.cm-s-solarized .cm-bracket {
+  color: #cb4b16;
+}
+.cm-s-solarized .CodeMirror-matchingbracket {
+  color: #859900;
+}
+.cm-s-solarized .CodeMirror-nonmatchingbracket {
+  color: #dc322f;
+}
+.cm-s-solarized .cm-tag {
+  color: #93a1a1;
+}
+.cm-s-solarized .cm-attribute {
+  color: #2aa198;
+}
 .cm-s-solarized .cm-hr {
   color: transparent;
   border-top: 1px solid #586e75;
   display: block;
 }
-.cm-s-solarized .cm-link { color: #93a1a1; cursor: pointer; }
-.cm-s-solarized .cm-special { color: #6c71c4; }
+.cm-s-solarized .cm-link {
+  color: #93a1a1;
+  cursor: pointer;
+}
+.cm-s-solarized .cm-special {
+  color: #6c71c4;
+}
 .cm-s-solarized .cm-em {
   color: #999;
   text-decoration: underline;
@@ -11715,17 +16325,33 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
   border-bottom: 1px dotted #dc322f;
 }
 
-.cm-s-solarized.cm-s-dark div.CodeMirror-selected { background: #073642; }
-.cm-s-solarized.cm-s-dark.CodeMirror ::selection { background: rgba(7, 54, 66, 0.99); }
-.cm-s-solarized.cm-s-dark .CodeMirror-line::-moz-selection, .cm-s-dark .CodeMirror-line > span::-moz-selection, .cm-s-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(7, 54, 66, 0.99); }
+.cm-s-solarized.cm-s-dark div.CodeMirror-selected {
+  background: #073642;
+}
+.cm-s-solarized.cm-s-dark.CodeMirror ::selection {
+  background: rgba(7, 54, 66, 0.99);
+}
+.cm-s-solarized.cm-s-dark .CodeMirror-line::-moz-selection,
+.cm-s-dark .CodeMirror-line > span::-moz-selection,
+.cm-s-dark .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(7, 54, 66, 0.99);
+}
 
-.cm-s-solarized.cm-s-light div.CodeMirror-selected { background: #eee8d5; }
-.cm-s-solarized.cm-s-light .CodeMirror-line::selection, .cm-s-light .CodeMirror-line > span::selection, .cm-s-light .CodeMirror-line > span > span::selection { background: #eee8d5; }
-.cm-s-solarized.cm-s-light .CodeMirror-line::-moz-selection, .cm-s-ligh .CodeMirror-line > span::-moz-selection, .cm-s-ligh .CodeMirror-line > span > span::-moz-selection { background: #eee8d5; }
+.cm-s-solarized.cm-s-light div.CodeMirror-selected {
+  background: #eee8d5;
+}
+.cm-s-solarized.cm-s-light .CodeMirror-line::selection,
+.cm-s-light .CodeMirror-line > span::selection,
+.cm-s-light .CodeMirror-line > span > span::selection {
+  background: #eee8d5;
+}
+.cm-s-solarized.cm-s-light .CodeMirror-line::-moz-selection,
+.cm-s-ligh .CodeMirror-line > span::-moz-selection,
+.cm-s-ligh .CodeMirror-line > span > span::-moz-selection {
+  background: #eee8d5;
+}
 
 /* Editor styling */
-
-
 
 /* Little shadow on the view-port of the buffer view */
 .cm-s-solarized.CodeMirror {
@@ -11764,22 +16390,38 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .CodeMirror-linenumber {
   padding: 0 5px;
 }
-.cm-s-solarized .CodeMirror-guttermarker-subtle { color: #586e75; }
-.cm-s-solarized.cm-s-dark .CodeMirror-guttermarker { color: #ddd; }
-.cm-s-solarized.cm-s-light .CodeMirror-guttermarker { color: #cb4b16; }
+.cm-s-solarized .CodeMirror-guttermarker-subtle {
+  color: #586e75;
+}
+.cm-s-solarized.cm-s-dark .CodeMirror-guttermarker {
+  color: #ddd;
+}
+.cm-s-solarized.cm-s-light .CodeMirror-guttermarker {
+  color: #cb4b16;
+}
 
 .cm-s-solarized .CodeMirror-gutter .CodeMirror-gutter-text {
   color: #586e75;
 }
 
 /* Cursor */
-.cm-s-solarized .CodeMirror-cursor { border-left: 1px solid #819090; }
+.cm-s-solarized .CodeMirror-cursor {
+  border-left: 1px solid #819090;
+}
 
 /* Fat cursor */
-.cm-s-solarized.cm-s-light.cm-fat-cursor .CodeMirror-cursor { background: #77ee77; }
-.cm-s-solarized.cm-s-light .cm-animate-fat-cursor { background-color: #77ee77; }
-.cm-s-solarized.cm-s-dark.cm-fat-cursor .CodeMirror-cursor { background: #586e75; }
-.cm-s-solarized.cm-s-dark .cm-animate-fat-cursor { background-color: #586e75; }
+.cm-s-solarized.cm-s-light.cm-fat-cursor .CodeMirror-cursor {
+  background: #77ee77;
+}
+.cm-s-solarized.cm-s-light .cm-animate-fat-cursor {
+  background-color: #77ee77;
+}
+.cm-s-solarized.cm-s-dark.cm-fat-cursor .CodeMirror-cursor {
+  background: #586e75;
+}
+.cm-s-solarized.cm-s-dark .cm-animate-fat-cursor {
+  background-color: #586e75;
+}
 
 /* Active line */
 .cm-s-solarized.cm-s-dark .CodeMirror-activeline-background {
@@ -11789,36 +16431,100 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
   background: rgba(0, 0, 0, 0.06);
 }
 
-.cm-s-the-matrix.CodeMirror { background: #000000; color: #00FF00; }
-.cm-s-the-matrix div.CodeMirror-selected { background: #2D2D2D; }
-.cm-s-the-matrix .CodeMirror-line::selection, .cm-s-the-matrix .CodeMirror-line > span::selection, .cm-s-the-matrix .CodeMirror-line > span > span::selection { background: rgba(45, 45, 45, 0.99); }
-.cm-s-the-matrix .CodeMirror-line::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span > span::-moz-selection { background: rgba(45, 45, 45, 0.99); }
-.cm-s-the-matrix .CodeMirror-gutters { background: #060; border-right: 2px solid #00FF00; }
-.cm-s-the-matrix .CodeMirror-guttermarker { color: #0f0; }
-.cm-s-the-matrix .CodeMirror-guttermarker-subtle { color: white; }
-.cm-s-the-matrix .CodeMirror-linenumber { color: #FFFFFF; }
-.cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00; }
+.cm-s-the-matrix.CodeMirror {
+  background: #000000;
+  color: #00ff00;
+}
+.cm-s-the-matrix div.CodeMirror-selected {
+  background: #2d2d2d;
+}
+.cm-s-the-matrix .CodeMirror-line::selection,
+.cm-s-the-matrix .CodeMirror-line > span::selection,
+.cm-s-the-matrix .CodeMirror-line > span > span::selection {
+  background: rgba(45, 45, 45, 0.99);
+}
+.cm-s-the-matrix .CodeMirror-line::-moz-selection,
+.cm-s-the-matrix .CodeMirror-line > span::-moz-selection,
+.cm-s-the-matrix .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(45, 45, 45, 0.99);
+}
+.cm-s-the-matrix .CodeMirror-gutters {
+  background: #060;
+  border-right: 2px solid #00ff00;
+}
+.cm-s-the-matrix .CodeMirror-guttermarker {
+  color: #0f0;
+}
+.cm-s-the-matrix .CodeMirror-guttermarker-subtle {
+  color: white;
+}
+.cm-s-the-matrix .CodeMirror-linenumber {
+  color: #ffffff;
+}
+.cm-s-the-matrix .CodeMirror-cursor {
+  border-left: 1px solid #00ff00;
+}
 
-.cm-s-the-matrix span.cm-keyword { color: #008803; font-weight: bold; }
-.cm-s-the-matrix span.cm-atom { color: #3FF; }
-.cm-s-the-matrix span.cm-number { color: #FFB94F; }
-.cm-s-the-matrix span.cm-def { color: #99C; }
-.cm-s-the-matrix span.cm-variable { color: #F6C; }
-.cm-s-the-matrix span.cm-variable-2 { color: #C6F; }
-.cm-s-the-matrix span.cm-variable-3, .cm-s-the-matrix span.cm-type { color: #96F; }
-.cm-s-the-matrix span.cm-property { color: #62FFA0; }
-.cm-s-the-matrix span.cm-operator { color: #999; }
-.cm-s-the-matrix span.cm-comment { color: #CCCCCC; }
-.cm-s-the-matrix span.cm-string { color: #39C; }
-.cm-s-the-matrix span.cm-meta { color: #C9F; }
-.cm-s-the-matrix span.cm-qualifier { color: #FFF700; }
-.cm-s-the-matrix span.cm-builtin { color: #30a; }
-.cm-s-the-matrix span.cm-bracket { color: #cc7; }
-.cm-s-the-matrix span.cm-tag { color: #FFBD40; }
-.cm-s-the-matrix span.cm-attribute { color: #FFF700; }
-.cm-s-the-matrix span.cm-error { color: #FF0000; }
+.cm-s-the-matrix span.cm-keyword {
+  color: #008803;
+  font-weight: bold;
+}
+.cm-s-the-matrix span.cm-atom {
+  color: #3ff;
+}
+.cm-s-the-matrix span.cm-number {
+  color: #ffb94f;
+}
+.cm-s-the-matrix span.cm-def {
+  color: #99c;
+}
+.cm-s-the-matrix span.cm-variable {
+  color: #f6c;
+}
+.cm-s-the-matrix span.cm-variable-2 {
+  color: #c6f;
+}
+.cm-s-the-matrix span.cm-variable-3,
+.cm-s-the-matrix span.cm-type {
+  color: #96f;
+}
+.cm-s-the-matrix span.cm-property {
+  color: #62ffa0;
+}
+.cm-s-the-matrix span.cm-operator {
+  color: #999;
+}
+.cm-s-the-matrix span.cm-comment {
+  color: #cccccc;
+}
+.cm-s-the-matrix span.cm-string {
+  color: #39c;
+}
+.cm-s-the-matrix span.cm-meta {
+  color: #c9f;
+}
+.cm-s-the-matrix span.cm-qualifier {
+  color: #fff700;
+}
+.cm-s-the-matrix span.cm-builtin {
+  color: #30a;
+}
+.cm-s-the-matrix span.cm-bracket {
+  color: #cc7;
+}
+.cm-s-the-matrix span.cm-tag {
+  color: #ffbd40;
+}
+.cm-s-the-matrix span.cm-attribute {
+  color: #fff700;
+}
+.cm-s-the-matrix span.cm-error {
+  color: #ff0000;
+}
 
-.cm-s-the-matrix .CodeMirror-activeline-background { background: #040; }
+.cm-s-the-matrix .CodeMirror-activeline-background {
+  background: #040;
+}
 
 /*
 Copyright (C) 2011 by MarkLogic Corporation
@@ -11842,27 +16548,71 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-.cm-s-xq-light span.cm-keyword { line-height: 1em; font-weight: bold; color: #5A5CAD; }
-.cm-s-xq-light span.cm-atom { color: #6C8CD5; }
-.cm-s-xq-light span.cm-number { color: #164; }
-.cm-s-xq-light span.cm-def { text-decoration:underline; }
-.cm-s-xq-light span.cm-variable { color: black; }
-.cm-s-xq-light span.cm-variable-2 { color:black; }
-.cm-s-xq-light span.cm-variable-3, .cm-s-xq-light span.cm-type { color: black; }
-.cm-s-xq-light span.cm-property {}
-.cm-s-xq-light span.cm-operator {}
-.cm-s-xq-light span.cm-comment { color: #0080FF; font-style: italic; }
-.cm-s-xq-light span.cm-string { color: red; }
-.cm-s-xq-light span.cm-meta { color: yellow; }
-.cm-s-xq-light span.cm-qualifier { color: grey; }
-.cm-s-xq-light span.cm-builtin { color: #7EA656; }
-.cm-s-xq-light span.cm-bracket { color: #cc7; }
-.cm-s-xq-light span.cm-tag { color: #3F7F7F; }
-.cm-s-xq-light span.cm-attribute { color: #7F007F; }
-.cm-s-xq-light span.cm-error { color: #f00; }
+.cm-s-xq-light span.cm-keyword {
+  line-height: 1em;
+  font-weight: bold;
+  color: #5a5cad;
+}
+.cm-s-xq-light span.cm-atom {
+  color: #6c8cd5;
+}
+.cm-s-xq-light span.cm-number {
+  color: #164;
+}
+.cm-s-xq-light span.cm-def {
+  text-decoration: underline;
+}
+.cm-s-xq-light span.cm-variable {
+  color: black;
+}
+.cm-s-xq-light span.cm-variable-2 {
+  color: black;
+}
+.cm-s-xq-light span.cm-variable-3,
+.cm-s-xq-light span.cm-type {
+  color: black;
+}
+.cm-s-xq-light span.cm-property {
+}
+.cm-s-xq-light span.cm-operator {
+}
+.cm-s-xq-light span.cm-comment {
+  color: #0080ff;
+  font-style: italic;
+}
+.cm-s-xq-light span.cm-string {
+  color: red;
+}
+.cm-s-xq-light span.cm-meta {
+  color: yellow;
+}
+.cm-s-xq-light span.cm-qualifier {
+  color: grey;
+}
+.cm-s-xq-light span.cm-builtin {
+  color: #7ea656;
+}
+.cm-s-xq-light span.cm-bracket {
+  color: #cc7;
+}
+.cm-s-xq-light span.cm-tag {
+  color: #3f7f7f;
+}
+.cm-s-xq-light span.cm-attribute {
+  color: #7f007f;
+}
+.cm-s-xq-light span.cm-error {
+  color: #f00;
+}
 
-.cm-s-xq-light .CodeMirror-activeline-background { background: #e8f2ff; }
-.cm-s-xq-light .CodeMirror-matchingbracket { outline:1px solid grey;color:black !important;background:yellow; }
+.cm-s-xq-light .CodeMirror-activeline-background {
+  background: #e8f2ff;
+}
+.cm-s-xq-light .CodeMirror-matchingbracket {
+  outline: 1px solid grey;
+  color: black !important;
+  background: yellow;
+}
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -13733,4 +18483,3 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-

--- a/share/jupyter/nbconvert/templates/presto/static/theme-dark.css
+++ b/share/jupyter/nbconvert/templates/presto/static/theme-dark.css
@@ -1,0 +1,405 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*
+The following CSS variables define the main, public API for styling JupyterLab.
+These variables should be used by all plugins wherever possible. In other
+words, plugins should not define custom colors, sizes, etc unless absolutely
+necessary. This enables users to change the visual theme of JupyterLab
+by changing these variables.
+
+Many variables appear in an ordered sequence (0,1,2,3). These sequences
+are designed to work well together, so for example, `--jp-border-color1` should
+be used with `--jp-layout-color1`. The numbers have the following meanings:
+
+* 0: super-primary, reserved for special emphasis
+* 1: primary, most important under normal situations
+* 2: secondary, next most important under normal situations
+* 3: tertiary, next most important under normal situations
+
+Throughout JupyterLab, we are mostly following principles from Google's
+Material Design when selecting colors. We are not, however, following
+all of MD as it is not optimized for dense, information rich UIs.
+*/
+
+:root {
+  /* Elevation
+   *
+   * We style box-shadows using Material Design's idea of elevation. These particular numbers are taken from here:
+   *
+   * https://github.com/material-components/material-components-web
+   * https://material-components-web.appspot.com/elevation.html
+   */
+
+  /* The dark theme shadows need a bit of work, but this will probably also require work on the core layout
+   * colors used in the theme as well. */
+  --jp-shadow-base-lightness: 32;
+  --jp-shadow-umbra-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.2
+  );
+  --jp-shadow-penumbra-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.14
+  );
+  --jp-shadow-ambient-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.12
+  );
+  --jp-elevation-z0: none;
+  --jp-elevation-z1: 0px 2px 1px -1px var(--jp-shadow-umbra-color),
+    0px 1px 1px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 3px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z2: 0px 3px 1px -2px var(--jp-shadow-umbra-color),
+    0px 2px 2px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 5px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z4: 0px 2px 4px -1px var(--jp-shadow-umbra-color),
+    0px 4px 5px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 10px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z6: 0px 3px 5px -1px var(--jp-shadow-umbra-color),
+    0px 6px 10px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 18px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z8: 0px 5px 5px -3px var(--jp-shadow-umbra-color),
+    0px 8px 10px 1px var(--jp-shadow-penumbra-color),
+    0px 3px 14px 2px var(--jp-shadow-ambient-color);
+  --jp-elevation-z12: 0px 7px 8px -4px var(--jp-shadow-umbra-color),
+    0px 12px 17px 2px var(--jp-shadow-penumbra-color),
+    0px 5px 22px 4px var(--jp-shadow-ambient-color);
+  --jp-elevation-z16: 0px 8px 10px -5px var(--jp-shadow-umbra-color),
+    0px 16px 24px 2px var(--jp-shadow-penumbra-color),
+    0px 6px 30px 5px var(--jp-shadow-ambient-color);
+  --jp-elevation-z20: 0px 10px 13px -6px var(--jp-shadow-umbra-color),
+    0px 20px 31px 3px var(--jp-shadow-penumbra-color),
+    0px 8px 38px 7px var(--jp-shadow-ambient-color);
+  --jp-elevation-z24: 0px 11px 15px -7px var(--jp-shadow-umbra-color),
+    0px 24px 38px 3px var(--jp-shadow-penumbra-color),
+    0px 9px 46px 8px var(--jp-shadow-ambient-color);
+
+  /* Borders
+   *
+   * The following variables, specify the visual styling of borders in JupyterLab.
+   */
+
+  --jp-border-width: 1px;
+  --jp-border-color0: var(--md-grey-700);
+  --jp-border-color1: var(--md-grey-700);
+  --jp-border-color2: var(--md-grey-800);
+  --jp-border-color3: var(--md-grey-900);
+  --jp-border-radius: 2px;
+
+  /* UI Fonts
+   *
+   * The UI font CSS variables are used for the typography all of the JupyterLab
+   * user interface elements that are not directly user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-ui-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
+   */
+
+  --jp-ui-font-scale-factor: 1.2;
+  --jp-ui-font-size0: 0.83333em;
+  --jp-ui-font-size1: 13px; /* Base font size */
+  --jp-ui-font-size2: 1.2em;
+  --jp-ui-font-size3: 1.44em;
+
+  --jp-ui-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+
+  /*
+   * Use these font colors against the corresponding main layout colors.
+   * In a light theme, these go from dark to light.
+   */
+
+  /* Defaults use Material Design specification */
+  --jp-ui-font-color0: rgba(255, 255, 255, 1);
+  --jp-ui-font-color1: rgba(255, 255, 255, 0.87);
+  --jp-ui-font-color2: rgba(255, 255, 255, 0.54);
+  --jp-ui-font-color3: rgba(255, 255, 255, 0.38);
+
+  /*
+   * Use these against the brand/accent/warn/error colors.
+   * These will typically go from light to darker, in both a dark and light theme.
+   */
+
+  --jp-ui-inverse-font-color0: rgba(0, 0, 0, 1);
+  --jp-ui-inverse-font-color1: rgba(0, 0, 0, 0.8);
+  --jp-ui-inverse-font-color2: rgba(0, 0, 0, 0.5);
+  --jp-ui-inverse-font-color3: rgba(0, 0, 0, 0.3);
+
+  /* Content Fonts
+   *
+   * Content font variables are used for typography of user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-content-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
+   */
+
+  --jp-content-line-height: 1.6;
+  --jp-content-font-scale-factor: 1.2;
+  --jp-content-font-size0: 0.83333em;
+  --jp-content-font-size1: 14px; /* Base font size */
+  --jp-content-font-size2: 1.2em;
+  --jp-content-font-size3: 1.44em;
+  --jp-content-font-size4: 1.728em;
+  --jp-content-font-size5: 2.0736em;
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-content-presentation-font-size1: 17px;
+
+  --jp-content-heading-line-height: 1;
+  --jp-content-heading-margin-top: 1.2em;
+  --jp-content-heading-margin-bottom: 0.8em;
+  --jp-content-heading-font-weight: 500;
+
+  /* Defaults use Material Design specification */
+  --jp-content-font-color0: rgba(255, 255, 255, 1);
+  --jp-content-font-color1: rgba(255, 255, 255, 1);
+  --jp-content-font-color2: rgba(255, 255, 255, 0.7);
+  --jp-content-font-color3: rgba(255, 255, 255, 0.5);
+
+  --jp-content-link-color: var(--md-blue-300);
+
+  --jp-content-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
+
+  /*
+   * Code Fonts
+   *
+   * Code font variables are used for typography of code and other monospaces content.
+   */
+
+  --jp-code-font-size: 13px;
+  --jp-code-line-height: 1.3077; /* 17px for 13px base */
+  --jp-code-padding: 5px; /* 5px for 13px base, codemirror highlighting needs integer px value */
+  --jp-code-font-family-default: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  --jp-code-font-family: var(--jp-code-font-family-default);
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-code-presentation-font-size: 16px;
+
+  /* may need to tweak cursor width if you change font size */
+  --jp-code-cursor-width0: 1.4px;
+  --jp-code-cursor-width1: 2px;
+  --jp-code-cursor-width2: 4px;
+
+  /* Layout
+   *
+   * The following are the main layout colors use in JupyterLab. In a light
+   * theme these would go from light to dark.
+   */
+
+  --jp-layout-color0: #111111;
+  --jp-layout-color1: var(--md-grey-900);
+  --jp-layout-color2: var(--md-grey-800);
+  --jp-layout-color3: var(--md-grey-700);
+  --jp-layout-color4: var(--md-grey-600);
+
+  /* Inverse Layout
+   *
+   * The following are the inverse layout colors use in JupyterLab. In a light
+   * theme these would go from dark to light.
+   */
+
+  --jp-inverse-layout-color0: white;
+  --jp-inverse-layout-color1: white;
+  --jp-inverse-layout-color2: var(--md-grey-200);
+  --jp-inverse-layout-color3: var(--md-grey-400);
+  --jp-inverse-layout-color4: var(--md-grey-600);
+
+  /* Brand/accent */
+
+  --jp-brand-color0: var(--md-blue-700);
+  --jp-brand-color1: var(--md-blue-500);
+  --jp-brand-color2: var(--md-blue-300);
+  --jp-brand-color3: var(--md-blue-100);
+  --jp-brand-color4: var(--md-blue-50);
+
+  --jp-accent-color0: var(--md-green-700);
+  --jp-accent-color1: var(--md-green-500);
+  --jp-accent-color2: var(--md-green-300);
+  --jp-accent-color3: var(--md-green-100);
+
+  /* State colors (warn, error, success, info) */
+
+  --jp-warn-color0: var(--md-orange-700);
+  --jp-warn-color1: var(--md-orange-500);
+  --jp-warn-color2: var(--md-orange-300);
+  --jp-warn-color3: var(--md-orange-100);
+
+  --jp-error-color0: var(--md-red-700);
+  --jp-error-color1: var(--md-red-500);
+  --jp-error-color2: var(--md-red-300);
+  --jp-error-color3: var(--md-red-100);
+
+  --jp-success-color0: var(--md-green-700);
+  --jp-success-color1: var(--md-green-500);
+  --jp-success-color2: var(--md-green-300);
+  --jp-success-color3: var(--md-green-100);
+
+  --jp-info-color0: var(--md-cyan-700);
+  --jp-info-color1: var(--md-cyan-500);
+  --jp-info-color2: var(--md-cyan-300);
+  --jp-info-color3: var(--md-cyan-100);
+
+  /* Cell specific styles */
+
+  --jp-cell-padding: 5px;
+
+  --jp-cell-collapser-width: 8px;
+  --jp-cell-collapser-min-height: 20px;
+  --jp-cell-collapser-not-active-hover-opacity: 0.6;
+
+  --jp-cell-editor-background: var(--jp-layout-color1);
+  --jp-cell-editor-border-color: var(--md-grey-700);
+  --jp-cell-editor-box-shadow: inset 0 0 2px var(--md-blue-300);
+  --jp-cell-editor-active-background: var(--jp-layout-color0);
+  --jp-cell-editor-active-border-color: var(--jp-brand-color1);
+
+  --jp-cell-prompt-width: 64px;
+  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
+  --jp-cell-prompt-letter-spacing: 0px;
+  --jp-cell-prompt-opacity: 1;
+  --jp-cell-prompt-not-active-opacity: 1;
+  --jp-cell-prompt-not-active-font-color: var(--md-grey-300);
+
+  /* A custom blend of MD grey and blue 600
+   * See https://meyerweb.com/eric/tools/color-blend/#546E7A:1E88E5:5:hex */
+  --jp-cell-inprompt-font-color: #307fc1;
+  /* A custom blend of MD grey and orange 600
+   * https://meyerweb.com/eric/tools/color-blend/#546E7A:F4511E:5:hex */
+  --jp-cell-outprompt-font-color: #bf5b3d;
+
+  /* Notebook specific styles */
+
+  --jp-notebook-padding: 10px;
+  --jp-notebook-select-background: var(--jp-layout-color1);
+  --jp-notebook-multiselected-color: rgba(33, 150, 243, 0.24);
+
+  /* The scroll padding is calculated to fill enough space at the bottom of the
+  notebook to show one single-line cell (with appropriate padding) at the top
+  when the notebook is scrolled all the way to the bottom. We also subtract one
+  pixel so that no scrollbar appears if we have just one single-line cell in the
+  notebook. This padding is to enable a 'scroll past end' feature in a notebook.
+  */
+  --jp-notebook-scroll-padding: calc(
+    100% - var(--jp-code-font-size) * var(--jp-code-line-height) -
+      var(--jp-code-padding) - var(--jp-cell-padding) - 1px
+  );
+
+  /* Rendermime styles */
+
+  --jp-rendermime-error-background: rgba(244, 67, 54, 0.28);
+  --jp-rendermime-table-row-background: var(--md-grey-900);
+  --jp-rendermime-table-row-hover-background: rgba(3, 169, 244, 0.2);
+
+  /* Dialog specific styles */
+
+  --jp-dialog-background: rgba(0, 0, 0, 0.6);
+
+  /* Console specific styles */
+
+  --jp-console-padding: 10px;
+
+  /* Toolbar specific styles */
+
+  --jp-toolbar-border-color: var(--jp-border-color2);
+  --jp-toolbar-micro-height: 8px;
+  --jp-toolbar-background: var(--jp-layout-color1);
+  --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.8);
+  --jp-toolbar-header-margin: 4px 4px 0px 4px;
+  --jp-toolbar-active-background: var(--jp-layout-color0);
+
+  /* Input field styles */
+
+  --jp-input-box-shadow: inset 0 0 2px var(--md-blue-300);
+  --jp-input-active-background: var(--jp-layout-color0);
+  --jp-input-hover-background: var(--jp-layout-color2);
+  --jp-input-background: var(--md-grey-800);
+  --jp-input-border-color: var(--jp-border-color1);
+  --jp-input-active-border-color: var(--jp-brand-color1);
+  --jp-input-active-box-shadow-color: rgba(19, 124, 189, 0.3);
+
+  /* General editor styles */
+
+  --jp-editor-selected-background: var(--jp-layout-color2);
+  --jp-editor-selected-focused-background: rgba(33, 150, 243, 0.24);
+  --jp-editor-cursor-color: var(--jp-ui-font-color0);
+
+  /* Code mirror specific styles */
+
+  --jp-mirror-editor-keyword-color: var(--md-green-500);
+  --jp-mirror-editor-atom-color: var(--md-blue-300);
+  --jp-mirror-editor-number-color: var(--md-green-400);
+  --jp-mirror-editor-def-color: var(--md-blue-600);
+  --jp-mirror-editor-variable-color: var(--md-grey-300);
+  --jp-mirror-editor-variable-2-color: var(--md-blue-400);
+  --jp-mirror-editor-variable-3-color: var(--md-green-600);
+  --jp-mirror-editor-punctuation-color: var(--md-blue-400);
+  --jp-mirror-editor-property-color: var(--md-blue-400);
+  --jp-mirror-editor-operator-color: #aa22ff;
+  --jp-mirror-editor-comment-color: #408080;
+  --jp-mirror-editor-string-color: #ff7070;
+  --jp-mirror-editor-string-2-color: var(--md-purple-300);
+  --jp-mirror-editor-meta-color: #aa22ff;
+  --jp-mirror-editor-qualifier-color: #555;
+  --jp-mirror-editor-builtin-color: var(--md-green-600);
+  --jp-mirror-editor-bracket-color: #997;
+  --jp-mirror-editor-tag-color: var(--md-green-700);
+  --jp-mirror-editor-attribute-color: var(--md-blue-700);
+  --jp-mirror-editor-header-color: var(--md-blue-500);
+  --jp-mirror-editor-quote-color: var(--md-green-300);
+  --jp-mirror-editor-link-color: var(--md-blue-700);
+  --jp-mirror-editor-error-color: #f00;
+  --jp-mirror-editor-hr-color: #999;
+
+  /* Vega extension styles */
+
+  --jp-vega-background: var(--md-grey-400);
+
+  /* Sidebar-related styles */
+
+  --jp-sidebar-min-width: 180px;
+
+  /* Search-related styles */
+
+  --jp-search-toggle-off-opacity: 0.6;
+  --jp-search-toggle-hover-opacity: 0.8;
+  --jp-search-toggle-on-opacity: 1;
+  --jp-search-selected-match-background-color: rgb(255, 225, 0);
+  --jp-search-selected-match-color: black;
+  --jp-search-unselected-match-background-color: var(
+    --jp-inverse-layout-color0
+  );
+  --jp-search-unselected-match-color: var(--jp-ui-inverse-font-color0);
+
+  /* scrollbar related styles. Supports every browser except Edge. */
+
+  /* colors based on JetBrain's Darcula theme */
+
+  --jp-scrollbar-background-color: #3f4244;
+  --jp-scrollbar-thumb-color: 88, 96, 97; /* need to specify thumb color as an RGB triplet */
+
+  --jp-scrollbar-endpad: 3px; /* the minimum gap between the thumb and the ends of a scrollbar */
+
+  /* hacks for setting the thumb shape. These do nothing in Firefox */
+
+  --jp-scrollbar-thumb-margin: 3.5px; /* the space in between the sides of the thumb and the track */
+  --jp-scrollbar-thumb-radius: 9px; /* set to a large-ish value for rounded endcaps on the thumb */
+
+  /* Icon colors that work well with light or dark backgrounds */
+  --jp-icon-contrast-color0: var(--md-purple-600);
+  --jp-icon-contrast-color1: var(--md-green-600);
+  --jp-icon-contrast-color2: var(--md-pink-600);
+  --jp-icon-contrast-color3: var(--md-blue-600);
+}

--- a/share/jupyter/nbconvert/templates/presto/static/theme-light.css
+++ b/share/jupyter/nbconvert/templates/presto/static/theme-light.css
@@ -1,0 +1,388 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*
+The following CSS variables define the main, public API for styling JupyterLab.
+These variables should be used by all plugins wherever possible. In other
+words, plugins should not define custom colors, sizes, etc unless absolutely
+necessary. This enables users to change the visual theme of JupyterLab
+by changing these variables.
+
+Many variables appear in an ordered sequence (0,1,2,3). These sequences
+are designed to work well together, so for example, `--jp-border-color1` should
+be used with `--jp-layout-color1`. The numbers have the following meanings:
+
+* 0: super-primary, reserved for special emphasis
+* 1: primary, most important under normal situations
+* 2: secondary, next most important under normal situations
+* 3: tertiary, next most important under normal situations
+
+Throughout JupyterLab, we are mostly following principles from Google's
+Material Design when selecting colors. We are not, however, following
+all of MD as it is not optimized for dense, information rich UIs.
+*/
+
+:root {
+  /* Elevation
+   *
+   * We style box-shadows using Material Design's idea of elevation. These particular numbers are taken from here:
+   *
+   * https://github.com/material-components/material-components-web
+   * https://material-components-web.appspot.com/elevation.html
+   */
+
+  --jp-shadow-base-lightness: 0;
+  --jp-shadow-umbra-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.2
+  );
+  --jp-shadow-penumbra-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.14
+  );
+  --jp-shadow-ambient-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.12
+  );
+  --jp-elevation-z0: none;
+  --jp-elevation-z1: 0px 2px 1px -1px var(--jp-shadow-umbra-color),
+    0px 1px 1px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 3px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z2: 0px 3px 1px -2px var(--jp-shadow-umbra-color),
+    0px 2px 2px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 5px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z4: 0px 2px 4px -1px var(--jp-shadow-umbra-color),
+    0px 4px 5px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 10px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z6: 0px 3px 5px -1px var(--jp-shadow-umbra-color),
+    0px 6px 10px 0px var(--jp-shadow-penumbra-color),
+    0px 1px 18px 0px var(--jp-shadow-ambient-color);
+  --jp-elevation-z8: 0px 5px 5px -3px var(--jp-shadow-umbra-color),
+    0px 8px 10px 1px var(--jp-shadow-penumbra-color),
+    0px 3px 14px 2px var(--jp-shadow-ambient-color);
+  --jp-elevation-z12: 0px 7px 8px -4px var(--jp-shadow-umbra-color),
+    0px 12px 17px 2px var(--jp-shadow-penumbra-color),
+    0px 5px 22px 4px var(--jp-shadow-ambient-color);
+  --jp-elevation-z16: 0px 8px 10px -5px var(--jp-shadow-umbra-color),
+    0px 16px 24px 2px var(--jp-shadow-penumbra-color),
+    0px 6px 30px 5px var(--jp-shadow-ambient-color);
+  --jp-elevation-z20: 0px 10px 13px -6px var(--jp-shadow-umbra-color),
+    0px 20px 31px 3px var(--jp-shadow-penumbra-color),
+    0px 8px 38px 7px var(--jp-shadow-ambient-color);
+  --jp-elevation-z24: 0px 11px 15px -7px var(--jp-shadow-umbra-color),
+    0px 24px 38px 3px var(--jp-shadow-penumbra-color),
+    0px 9px 46px 8px var(--jp-shadow-ambient-color);
+
+  /* Borders
+   *
+   * The following variables, specify the visual styling of borders in JupyterLab.
+   */
+
+  --jp-border-width: 1px;
+  --jp-border-color0: var(--md-grey-400);
+  --jp-border-color1: var(--md-grey-400);
+  --jp-border-color2: var(--md-grey-300);
+  --jp-border-color3: var(--md-grey-200);
+  --jp-border-radius: 2px;
+
+  /* UI Fonts
+   *
+   * The UI font CSS variables are used for the typography all of the JupyterLab
+   * user interface elements that are not directly user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-ui-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
+   */
+
+  --jp-ui-font-scale-factor: 1.2;
+  --jp-ui-font-size0: 0.83333em;
+  --jp-ui-font-size1: 13px; /* Base font size */
+  --jp-ui-font-size2: 1.2em;
+  --jp-ui-font-size3: 1.44em;
+
+  --jp-ui-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+
+  /*
+   * Use these font colors against the corresponding main layout colors.
+   * In a light theme, these go from dark to light.
+   */
+
+  /* Defaults use Material Design specification */
+  --jp-ui-font-color0: rgba(0, 0, 0, 1);
+  --jp-ui-font-color1: rgba(0, 0, 0, 0.87);
+  --jp-ui-font-color2: rgba(0, 0, 0, 0.54);
+  --jp-ui-font-color3: rgba(0, 0, 0, 0.38);
+
+  /*
+   * Use these against the brand/accent/warn/error colors.
+   * These will typically go from light to darker, in both a dark and light theme.
+   */
+
+  --jp-ui-inverse-font-color0: rgba(255, 255, 255, 1);
+  --jp-ui-inverse-font-color1: rgba(255, 255, 255, 1);
+  --jp-ui-inverse-font-color2: rgba(255, 255, 255, 0.7);
+  --jp-ui-inverse-font-color3: rgba(255, 255, 255, 0.5);
+
+  /* Content Fonts
+   *
+   * Content font variables are used for typography of user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-content-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
+   */
+
+  --jp-content-line-height: 1.6;
+  --jp-content-font-scale-factor: 1.2;
+  --jp-content-font-size0: 0.83333em;
+  --jp-content-font-size1: 14px; /* Base font size */
+  --jp-content-font-size2: 1.2em;
+  --jp-content-font-size3: 1.44em;
+  --jp-content-font-size4: 1.728em;
+  --jp-content-font-size5: 2.0736em;
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-content-presentation-font-size1: 17px;
+
+  --jp-content-heading-line-height: 1;
+  --jp-content-heading-margin-top: 1.2em;
+  --jp-content-heading-margin-bottom: 0.8em;
+  --jp-content-heading-font-weight: 500;
+
+  /* Defaults use Material Design specification */
+  --jp-content-font-color0: rgba(0, 0, 0, 1);
+  --jp-content-font-color1: rgba(0, 0, 0, 0.87);
+  --jp-content-font-color2: rgba(0, 0, 0, 0.54);
+  --jp-content-font-color3: rgba(0, 0, 0, 0.38);
+
+  --jp-content-link-color: var(--md-blue-700);
+
+  --jp-content-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
+
+  /*
+   * Code Fonts
+   *
+   * Code font variables are used for typography of code and other monospaces content.
+   */
+
+  --jp-code-font-size: 13px;
+  --jp-code-line-height: 1.3077; /* 17px for 13px base */
+  --jp-code-padding: 5px; /* 5px for 13px base, codemirror highlighting needs integer px value */
+  --jp-code-font-family-default: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  --jp-code-font-family: var(--jp-code-font-family-default);
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-code-presentation-font-size: 16px;
+
+  /* may need to tweak cursor width if you change font size */
+  --jp-code-cursor-width0: 1.4px;
+  --jp-code-cursor-width1: 2px;
+  --jp-code-cursor-width2: 4px;
+
+  /* Layout
+   *
+   * The following are the main layout colors use in JupyterLab. In a light
+   * theme these would go from light to dark.
+   */
+
+  --jp-layout-color0: white;
+  --jp-layout-color1: white;
+  --jp-layout-color2: var(--md-grey-200);
+  --jp-layout-color3: var(--md-grey-400);
+  --jp-layout-color4: var(--md-grey-600);
+
+  /* Inverse Layout
+   *
+   * The following are the inverse layout colors use in JupyterLab. In a light
+   * theme these would go from dark to light.
+   */
+
+  --jp-inverse-layout-color0: #111111;
+  --jp-inverse-layout-color1: var(--md-grey-900);
+  --jp-inverse-layout-color2: var(--md-grey-800);
+  --jp-inverse-layout-color3: var(--md-grey-700);
+  --jp-inverse-layout-color4: var(--md-grey-600);
+
+  /* Brand/accent */
+
+  --jp-brand-color0: var(--md-blue-700);
+  --jp-brand-color1: var(--md-blue-500);
+  --jp-brand-color2: var(--md-blue-300);
+  --jp-brand-color3: var(--md-blue-100);
+  --jp-brand-color4: var(--md-blue-50);
+
+  --jp-accent-color0: var(--md-green-700);
+  --jp-accent-color1: var(--md-green-500);
+  --jp-accent-color2: var(--md-green-300);
+  --jp-accent-color3: var(--md-green-100);
+
+  /* State colors (warn, error, success, info) */
+
+  --jp-warn-color0: var(--md-orange-700);
+  --jp-warn-color1: var(--md-orange-500);
+  --jp-warn-color2: var(--md-orange-300);
+  --jp-warn-color3: var(--md-orange-100);
+
+  --jp-error-color0: var(--md-red-700);
+  --jp-error-color1: var(--md-red-500);
+  --jp-error-color2: var(--md-red-300);
+  --jp-error-color3: var(--md-red-100);
+
+  --jp-success-color0: var(--md-green-700);
+  --jp-success-color1: var(--md-green-500);
+  --jp-success-color2: var(--md-green-300);
+  --jp-success-color3: var(--md-green-100);
+
+  --jp-info-color0: var(--md-cyan-700);
+  --jp-info-color1: var(--md-cyan-500);
+  --jp-info-color2: var(--md-cyan-300);
+  --jp-info-color3: var(--md-cyan-100);
+
+  /* Cell specific styles */
+
+  --jp-cell-padding: 5px;
+
+  --jp-cell-collapser-width: 8px;
+  --jp-cell-collapser-min-height: 20px;
+  --jp-cell-collapser-not-active-hover-opacity: 0.6;
+
+  --jp-cell-editor-background: var(--md-grey-100);
+  --jp-cell-editor-border-color: var(--md-grey-300);
+  --jp-cell-editor-box-shadow: inset 0 0 2px var(--md-blue-300);
+  --jp-cell-editor-active-background: var(--jp-layout-color0);
+  --jp-cell-editor-active-border-color: var(--jp-brand-color1);
+
+  --jp-cell-prompt-width: 64px;
+  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
+  --jp-cell-prompt-letter-spacing: 0px;
+  --jp-cell-prompt-opacity: 1;
+  --jp-cell-prompt-not-active-opacity: 0.5;
+  --jp-cell-prompt-not-active-font-color: var(--md-grey-700);
+  /* A custom blend of MD grey and blue 600
+   * See https://meyerweb.com/eric/tools/color-blend/#546E7A:1E88E5:5:hex */
+  --jp-cell-inprompt-font-color: #307fc1;
+  /* A custom blend of MD grey and orange 600
+   * https://meyerweb.com/eric/tools/color-blend/#546E7A:F4511E:5:hex */
+  --jp-cell-outprompt-font-color: #bf5b3d;
+
+  /* Notebook specific styles */
+
+  --jp-notebook-padding: 10px;
+  --jp-notebook-select-background: var(--jp-layout-color1);
+  --jp-notebook-multiselected-color: var(--md-blue-50);
+
+  /* The scroll padding is calculated to fill enough space at the bottom of the
+  notebook to show one single-line cell (with appropriate padding) at the top
+  when the notebook is scrolled all the way to the bottom. We also subtract one
+  pixel so that no scrollbar appears if we have just one single-line cell in the
+  notebook. This padding is to enable a 'scroll past end' feature in a notebook.
+  */
+  --jp-notebook-scroll-padding: calc(
+    100% - var(--jp-code-font-size) * var(--jp-code-line-height) -
+      var(--jp-code-padding) - var(--jp-cell-padding) - 1px
+  );
+
+  /* Rendermime styles */
+
+  --jp-rendermime-error-background: #fdd;
+  --jp-rendermime-table-row-background: var(--md-grey-100);
+  --jp-rendermime-table-row-hover-background: var(--md-light-blue-50);
+
+  /* Dialog specific styles */
+
+  --jp-dialog-background: rgba(0, 0, 0, 0.25);
+
+  /* Console specific styles */
+
+  --jp-console-padding: 10px;
+
+  /* Toolbar specific styles */
+
+  --jp-toolbar-border-color: var(--jp-border-color1);
+  --jp-toolbar-micro-height: 8px;
+  --jp-toolbar-background: var(--jp-layout-color1);
+  --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.24);
+  --jp-toolbar-header-margin: 4px 4px 0px 4px;
+  --jp-toolbar-active-background: var(--md-grey-300);
+
+  /* Input field styles */
+
+  --jp-input-box-shadow: inset 0 0 2px var(--md-blue-300);
+  --jp-input-active-background: var(--jp-layout-color1);
+  --jp-input-hover-background: var(--jp-layout-color1);
+  --jp-input-background: var(--md-grey-100);
+  --jp-input-border-color: var(--jp-border-color1);
+  --jp-input-active-border-color: var(--jp-brand-color1);
+  --jp-input-active-box-shadow-color: rgba(19, 124, 189, 0.3);
+
+  /* General editor styles */
+
+  --jp-editor-selected-background: #d9d9d9;
+  --jp-editor-selected-focused-background: #d7d4f0;
+  --jp-editor-cursor-color: var(--jp-ui-font-color0);
+
+  /* Code mirror specific styles */
+
+  --jp-mirror-editor-keyword-color: #008000;
+  --jp-mirror-editor-atom-color: #88f;
+  --jp-mirror-editor-number-color: #080;
+  --jp-mirror-editor-def-color: #00f;
+  --jp-mirror-editor-variable-color: var(--md-grey-900);
+  --jp-mirror-editor-variable-2-color: #05a;
+  --jp-mirror-editor-variable-3-color: #085;
+  --jp-mirror-editor-punctuation-color: #05a;
+  --jp-mirror-editor-property-color: #05a;
+  --jp-mirror-editor-operator-color: #aa22ff;
+  --jp-mirror-editor-comment-color: #408080;
+  --jp-mirror-editor-string-color: #ba2121;
+  --jp-mirror-editor-string-2-color: #708;
+  --jp-mirror-editor-meta-color: #aa22ff;
+  --jp-mirror-editor-qualifier-color: #555;
+  --jp-mirror-editor-builtin-color: #008000;
+  --jp-mirror-editor-bracket-color: #997;
+  --jp-mirror-editor-tag-color: #170;
+  --jp-mirror-editor-attribute-color: #00c;
+  --jp-mirror-editor-header-color: blue;
+  --jp-mirror-editor-quote-color: #090;
+  --jp-mirror-editor-link-color: #00c;
+  --jp-mirror-editor-error-color: #f00;
+  --jp-mirror-editor-hr-color: #999;
+
+  /* Vega extension styles */
+
+  --jp-vega-background: white;
+
+  /* Sidebar-related styles */
+
+  --jp-sidebar-min-width: 180px;
+
+  /* Search-related styles */
+
+  --jp-search-toggle-off-opacity: 0.5;
+  --jp-search-toggle-hover-opacity: 0.8;
+  --jp-search-toggle-on-opacity: 1;
+  --jp-search-selected-match-background-color: rgb(245, 200, 0);
+  --jp-search-selected-match-color: black;
+  --jp-search-unselected-match-background-color: var(
+    --jp-inverse-layout-color0
+  );
+  --jp-search-unselected-match-color: var(--jp-ui-inverse-font-color0);
+
+  /* Icon colors that work well with light or dark backgrounds */
+  --jp-icon-contrast-color0: var(--md-purple-600);
+  --jp-icon-contrast-color1: var(--md-green-600);
+  --jp-icon-contrast-color2: var(--md-pink-600);
+  --jp-icon-contrast-color3: var(--md-blue-600);
+}

--- a/share/jupyter/voila/templates/presto/index.html.j2
+++ b/share/jupyter/voila/templates/presto/index.html.j2
@@ -1,0 +1,151 @@
+{%- extends 'nbconvert/templates/lab/index.html.j2' -%}
+{% import "spinner.macro.html.j2" as spinner %}
+{% import "log.macro.html.j2" as log %}
+{% from 'voila_setup.macro.html.j2' import voila_setup with context %}
+
+{%- block html_head_js -%}
+{%- block html_head_js_logs -%}
+{{ log.js() }}
+{%- endblock html_head_js_logs -%}
+{%- endblock html_head_js -%}
+
+{%- block html_head_css -%}
+<link rel="stylesheet" href="https://unpkg.com/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
+{{ super() }}
+{{ spinner.css() }}
+  <style>
+    /*Hide empty cells*/
+    .jp-mod-noOutputs.jp-mod-noInput {
+      display: none;
+    }
+    
+    .pr-DashboardWidget {
+      position: absolute;
+      display: inline-flex;
+      align-items: flex-start;
+      justify-content: left;
+      overflow: hidden;
+    }
+
+    .jp-MarkdownOutput {
+      display: inline-block;
+      padding-right: 0;
+    }
+
+    .widget-dimensions {
+      position: absolute;
+      border: 1px solid black;
+      text-align: center;
+      width: 100px;
+    }
+  </style>
+{%- endblock html_head_css -%}
+
+{# this overrides the default behaviour of rendering static widgets #}
+{% block jupyter_widgets %}
+{% endblock jupyter_widgets %}
+
+{%- block body_header -%}
+{% if resources.theme == 'dark' %}
+<body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/">
+{% else %}
+<body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/">
+{% endif %}
+{{ spinner.html() }}
+<script>
+var voila_process = function(cell_index, cell_count) {
+  var el = document.getElementById("loading_text")
+  el.innerHTML = `Executing ${cell_index} of ${cell_count}`
+}
+var voila_heartbeat = function() {
+  console.log('Ok, voila is still executing...')
+}
+</script>
+<div id="rendered_cells" style="display: none">
+{%- endblock body_header -%}
+
+{%- block body_loop -%}
+  {# from this point on, the kernel is started #}
+  {%- with kernel_id = kernel_start(nb) -%}
+    <script id="jupyter-config-data" type="application/json">
+    {
+        "baseUrl": "{{resources.base_url}}",
+        "kernelId": "{{kernel_id}}"
+    }
+    </script>
+    {% set cell_count = nb.cells|length %}
+    {#
+    Voilà is using Jinja's Template.generate method to not render the whole template in one go.
+    The current implementation of Jinja will however not yield template snippets if we call a blocks' super()
+    Therefore it is important to have the cell loop in the template.
+    The issue for Jinja is: https://github.com/pallets/jinja/issues/1044
+    #}
+    {% set dashboardInfo = namespace(id=None, name=None, view=None) %}
+    {# If no id or name is provided the first embedded dashboard is used #}
+    {% set dashboardInfo.id = resources.presto.dashboardId or nb.metadata.presto.views.keys()|first %}
+    {% set dashboardInfo.name = resources.presto.dashboardName %}
+    {% set dashboardInfo.view = nb.metadata.presto.views[dashboardInfo.id] %}
+    {# If only a dashboard name is supplied #}
+    {% if dashboardInfo.view.name != dashboardInfo.name %}
+      {%- for id, view in nb.metadata.presto.views.items() if view.name == dashboardInfo.name -%}
+        {% set dashboardInfo.view = view %}
+        {% set dashboardInfo.id = id %}
+      {% endfor %}
+    {% endif %}
+
+    {% set cellHeight = dashboardInfo.view.cellHeight %}
+    {% set cellWidth = dashboardInfo.view.cellWidth %}
+    {% set dashboardHeight = dashboardInfo.view.dashboardHeight %}
+    {% set dashboardWidth = dashboardInfo.view.dashboardWidth %}
+
+    <div style="height: {{ dashboardHeight }}px; width: {{ dashboardWidth }}px;">
+      {%- for cell in cell_generator(nb, kernel_id) -%}
+        {% if 'presto' in cell.metadata and dashboardInfo.id in cell.metadata.presto.views and not cell.metadata.presto.views[dashboardInfo.id].hidden %}
+          {% set cellloop = loop %}
+          {%- block any_cell scoped -%}
+            {% set pos = cell.metadata.presto.views[dashboardInfo.id].pos %}
+            {% set snapToGrid = cell.metadata.presto.views[dashboardInfo.id].snapToGrid %}
+            {% set left = pos.left * cellWidth if snapToGrid else pos.left %}
+            {% set top = pos.top  * cellHeight if snapToGrid else pos.top %}
+            {% set width = pos.width * cellWidth if snapToGrid else pos.width %}
+            {% set height = pos.height * cellHeight if snapToGrid else pos.height %}
+
+            <div class="pr-DashboardWidget" style="top:{{top}}px;left:{{left}}px;width:{{width}}px;height:{{height}}px">
+              <script>
+                voila_process({{ cellloop.index }}, {{ cell_count }});
+              </script>
+                {{ super() }}
+            </div>
+            {% if resources.presto.showDimensions %}
+              </div>
+              <p class="widget-dimensions" style="top:{{top + height + 20}}px; left:{{left + (width / 2) - 50}}px;">
+                {{ width }} x {{ height }}
+              </p>
+            {% endif %}
+          {%- endblock any_cell -%}
+        {% endif %}
+      {%- endfor -%}
+    </div>
+
+    
+  {% endwith %}
+{%- endblock body_loop -%}
+
+{%- block body_footer -%}
+</div>
+<script type="text/javascript">
+  (function() {
+    // remove the loading element
+    var el = document.getElementById("loading")
+    el.parentNode.removeChild(el)
+    // show the cell output
+    el = document.getElementById("rendered_cells")
+    el.style.display = 'unset'
+  })();
+</script>
+{{ super() }}
+{%- endblock body_footer -%}
+
+{% block footer_js %}
+{{ voila_setup(resources.base_url, resources.nbextensions) }}
+{% endblock footer_js %}

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1,4 +1,8 @@
-import { NotebookPanel } from '@jupyterlab/notebook';
+import {
+  INotebookModel,
+  NotebookPanel,
+  StaticNotebook
+} from '@jupyterlab/notebook';
 
 import { CodeCell, MarkdownCell, Cell } from '@jupyterlab/cells';
 
@@ -11,25 +15,25 @@ import {
   CommandToolbarButton,
   IWidgetTracker,
   Toolbar,
-  ReactWidget
-  // MainAreaWidget,
+  ReactWidget,
+  InputDialog
 } from '@jupyterlab/apputils';
 
 import { CommandRegistry } from '@lumino/commands';
 
 import { Token } from '@lumino/coreutils';
 
-import { Widget } from '@lumino/widgets';
+import { Panel, Widget } from '@lumino/widgets';
 
 import { Message } from '@lumino/messaging';
 
 import { IDragEvent } from '@lumino/dragdrop';
 
-import { DashboardLayout } from './layout';
+import { DashboardLayout, NewDashboardLayout } from './layout';
 
-import { DashboardWidget } from './widget';
+import { DashboardWidget, OutputWidget } from './widget';
 
-import { Widgetstore, WidgetInfo } from './widgetstore';
+import { Widgetstore, WidgetInfo, WidgetPosition } from './widgetstore';
 
 import {
   addCellId,
@@ -47,7 +51,13 @@ import {
   IDocumentWidget
 } from '@jupyterlab/docregistry';
 
-import { IDashboardModel, DashboardModel } from './model';
+import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
+
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
+import { IObservableJSON } from '@jupyterlab/observables';
+
+import { IDashboardModel, DashboardModel, NewDashboardModel } from './model';
 
 import { CommandIDs } from './commands';
 
@@ -55,7 +65,11 @@ import { HTMLSelect } from '@jupyterlab/ui-components';
 
 import { UUID } from '@lumino/coreutils';
 
+import { DashboardIcons } from './icons';
+
 import * as dbformat from './dbformat';
+
+import { UndoManager, IUndoableAction } from './undo';
 
 // HTML element classes
 
@@ -118,7 +132,6 @@ export class Dashboard extends Widget {
     this.node.addEventListener('lm-dragleave', this, true);
     this.node.addEventListener('lm-dragover', this, true);
     this.node.addEventListener('lm-drop', this, true);
-    this.node.addEventListener('lm-dragend', this, true);
     this.node.addEventListener('scroll', this);
   }
 
@@ -506,7 +519,6 @@ export class DashboardDocument extends DocumentWidget<Dashboard> {
     });
 
     // Build the toolbar
-
     this.toolbar.addClass(TOOLBAR_CLASS);
 
     const commands = commandRegistry;
@@ -658,31 +670,654 @@ export namespace DashboardDocumentFactory {
   }
 }
 
-/**
- * CURRENTLY UNUSED
- *
- * Opens a visual HTMLElement in fullscreen.
- *
- * @param node- the element to open in fullscreen.
- */
-export function openfullscreen(node: HTMLElement): void {
-  // Trigger fullscreen
-  const docElmWithBrowsersFullScreenFunctions = node as HTMLElement & {
-    mozRequestFullScreen(): Promise<void>;
-    webkitRequestFullscreen(): Promise<void>;
-    msRequestFullscreen(): Promise<void>;
-  };
+// NEWNEW
 
-  if (docElmWithBrowsersFullScreenFunctions.requestFullscreen) {
-    docElmWithBrowsersFullScreenFunctions.requestFullscreen();
-  } else if (docElmWithBrowsersFullScreenFunctions.mozRequestFullScreen) {
-    /* Firefox */
-    docElmWithBrowsersFullScreenFunctions.mozRequestFullScreen();
-  } else if (docElmWithBrowsersFullScreenFunctions.webkitRequestFullscreen) {
-    /* Chrome, Safari and Opera */
-    docElmWithBrowsersFullScreenFunctions.webkitRequestFullscreen();
-  } else if (docElmWithBrowsersFullScreenFunctions.msRequestFullscreen) {
-    /* IE/Edge */
-    docElmWithBrowsersFullScreenFunctions.msRequestFullscreen();
+/**
+ * A `DashboardDocumentWidget` to host the dashboard and toolbar.
+ */
+export class NewDashboardDocumentWidget extends DocumentWidget<
+  DashboardPanel,
+  INotebookModel
+> {
+  /**
+   * Construct a `DashboardDocumentWidget`.
+   *
+   * @param options - The options to construct a `DashboardDocumentWidget`
+   */
+  constructor(options: NewDashboardDocumentWidget.IOptions) {
+    const { context, content, commands } = options;
+    super({ context, content });
+    this.id = '@jupytercalpoly/jupyterlab-interactive-dashboard-editor:widget';
+    this.title.label = context.localPath;
+    this.title.closable = true;
+    this.title.icon = DashboardIcons.tealDashboard;
+    this.title.iconClass = 'jp-MaterialIcon';
+    this.title.iconLabel = 'Dashboard';
+    console.log(commands); // silence unused warning. should be used to make toolbar in future.
+  }
+}
+
+export namespace NewDashboardDocumentWidget {
+  export interface IOptions {
+    /**
+     * The notebook context
+     */
+    context: DocumentRegistry.IContext<INotebookModel>;
+
+    /**
+     * The `DashboardPanel` to render
+     */
+    content: DashboardPanel;
+
+    /**
+     * The command registry to build the toolbar from
+     */
+    commands: CommandRegistry;
+  }
+}
+
+export type OutputRemove = {
+  type: 'remove';
+  id: string;
+};
+
+export type OutputAdd = {
+  type: 'add';
+  id: string;
+  info: dbformat.ICellView;
+};
+
+export type OutputModify = {
+  type: 'modify';
+  id: string;
+  info: Partial<dbformat.ICellView>;
+};
+
+export type OutputChange = OutputAdd | OutputRemove | OutputModify;
+
+export type OutputChangeType = 'remove' | 'add' | 'modify';
+
+/**
+ * A dashboard widget to host the `DashboardOutput`s.
+ */
+export class NewDashboard extends Widget {
+  /**
+   * Construct a `Dashboard`.
+   */
+  constructor(model: NewDashboardModel) {
+    super();
+    this.addClass(DASHBOARD_CLASS);
+    this._model = model;
+    this._inBatch = false;
+    this._changes = { do: [], undo: [] };
+
+    this._undoManager = new UndoManager(
+      this.handleDashboardChanges.bind(this),
+      20
+    );
+    this._canvas = document.createElement('canvas');
+    this._canvas.classList.add('pr-Canvas');
+    this._canvas.classList.add('pr-TiledLayout');
+    this.node.appendChild(this._canvas);
+
+    this.layout = new NewDashboardLayout(model, this._canvas);
+  }
+
+  /**
+   * Create click listeners on attach
+   */
+  onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    this.node.addEventListener('lm-dragenter', this, true);
+    this.node.addEventListener('lm-dragleave', this, true);
+    this.node.addEventListener('lm-dragover', this, true);
+    this.node.addEventListener('lm-drop', this, true);
+    this.node.addEventListener('scroll', this);
+  }
+
+  /**
+   * Remove click listeners on detach
+   */
+  onBeforeDetach(msg: Message): void {
+    super.onBeforeDetach(msg);
+    this.node.removeEventListener('lm-dragenter', this, true);
+    this.node.removeEventListener('lm-dragleave', this, true);
+    this.node.removeEventListener('lm-dragover', this, true);
+    this.node.removeEventListener('lm-drop', this, true);
+    this.node.removeEventListener('scroll', this);
+  }
+
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'scroll':
+        this._evtScroll(event);
+        break;
+      case 'lm-dragenter':
+        this._evtDragEnter(event as IDragEvent);
+        break;
+      case 'lm-dragleave':
+        this._evtDragLeave(event as IDragEvent);
+        break;
+      case 'lm-dragover':
+        this._evtDragOver(event as IDragEvent);
+        break;
+      case 'lm-drop':
+        this._evtDrop(event as IDragEvent);
+        break;
+    }
+  }
+
+  private _evtScroll(_event: Event): void {
+    // no-op for now
+  }
+
+  /**
+   * Handle the `'lm-dragenter'` event for the widget.
+   */
+  private _evtDragEnter(event: IDragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /**
+   * Handle the `'lm-dragleave'` event for the widget.
+   */
+  private _evtDragLeave(event: IDragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /**
+   * Gets the `WidgetPosition` contained in an `ICellView` in terms of absolute pixel positions.
+   *
+   * @param info - The `ICellView` containing the position data.
+   */
+  public getPixelPos(info: dbformat.ICellView): WidgetPosition {
+    const { pos, snapToGrid } = info;
+    if (!snapToGrid) {
+      return pos;
+    }
+
+    const { cellWidth, cellHeight } = this.model.info;
+    let { left, top, width, height } = pos;
+
+    left *= cellWidth;
+    top *= cellHeight;
+    width *= cellWidth;
+    height *= cellHeight;
+    return { left, top, width, height };
+  }
+
+  /**
+   * Gets the `WidgetPosition` contained in an `ICellView` in terms of grid positions.
+   *
+   * @param info - The `ICellView` containing the position data.
+   *
+   * @param round - Whether to round the cell positions `up`, `down`, or to the `nearest` number.
+   * Default `nearest`.
+   */
+  public getGridPos(
+    info: dbformat.ICellView,
+    round: 'up' | 'down' | 'nearest' = 'nearest'
+  ): WidgetPosition {
+    const { pos, snapToGrid } = info;
+    if (snapToGrid) {
+      return pos;
+    }
+
+    const { cellWidth, cellHeight } = this.model.info;
+    const { left, top, width, height } = pos;
+
+    let roundFn: (n: number) => number;
+    switch (round) {
+      case 'nearest':
+        roundFn = Math.round;
+        break;
+      case 'up':
+        roundFn = Math.ceil;
+        break;
+      case 'down':
+        roundFn = Math.floor;
+        break;
+    }
+
+    return {
+      left: roundFn(left / cellWidth),
+      top: roundFn(top / cellHeight),
+      width: roundFn(width / cellWidth),
+      height: roundFn(height / cellHeight)
+    };
+  }
+
+  /**
+   * Handle the `'lm-dragover'` event for the widget.
+   */
+  private _evtDragOver(event: IDragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    event.dropAction = 'copy';
+    const widget = event.source as OutputWidget;
+
+    if (widget.viewId == null) {
+      return;
+    }
+
+    const cellModel = this._model.getCellModel(widget.cellId);
+    const metadata = cellModel.metadata.get('presto') as Record<string, any>;
+    const info = metadata.views[widget.viewId];
+    const { pos, snapToGrid } = info;
+
+    if (pos != null && snapToGrid) {
+      const pixelPos = this.getPixelPos(info);
+      pixelPos.left = event.offsetX + this.node.scrollLeft;
+      pixelPos.top = event.offsetY + this.node.scrollTop;
+      console.log('pos', pixelPos);
+      this.drawDropZone(pixelPos, snapToGrid);
+    }
+  }
+
+  public clearCanvas(): CanvasRenderingContext2D {
+    const canvas = this._canvas;
+    const context = canvas.getContext('2d');
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    return context;
+  }
+
+  public drawDropZone(pos: WidgetPosition, alignToGrid: boolean): void {
+    const context = this.clearCanvas();
+
+    context.setLineDash([5]);
+    context.strokeStyle = '#2b98f0';
+    context.fillStyle = '#2b98f066';
+
+    let { left, top, width, height } = pos;
+    const { cellWidth, cellHeight } = this._model.info;
+
+    if (alignToGrid) {
+      left = Private.mround(left, cellWidth);
+      top = Private.mround(top, cellHeight);
+      width = Math.max(Private.mround(width, cellWidth), cellWidth);
+      height = Math.max(Private.mround(height, cellHeight), cellHeight);
+    }
+
+    context.strokeRect(left, top, width, height);
+    context.fillRect(left, top, width, height);
+  }
+
+  /**
+   * Handle the `'lm-drop'` event for the widget.
+   */
+  private _evtDrop(event: IDragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const left = event.offsetX + this.node.scrollLeft;
+    const top = event.offsetY + this.node.scrollTop;
+
+    if (event.proposedAction === 'move') {
+      const widget = event.source as OutputWidget;
+      const { cellWidth, cellHeight } = this.model.info;
+      const { pos, snapToGrid } = this.model.getCellInfo(widget.cellId);
+      if (snapToGrid) {
+        pos.left = Math.round(left / cellWidth);
+        pos.top = Math.round(top / cellHeight);
+      }
+      this.modifyOutput({ pos, hidden: false }, widget.cellId);
+    } else if (event.proposedAction === 'copy') {
+      const notebook = event.source.parent as NotebookPanel;
+      // if (notebook.model !== this._model.context.model) {
+      //   console.warn('Outputs can only be added from the same notebook');
+      //   return;
+      // }
+      const cellModel = notebook.content.activeCell.model;
+      const { name, cellHeight, cellWidth } = this._model.info;
+      const pos = {
+        left: Math.round(left / cellWidth),
+        top: Math.round(top / cellHeight),
+        width: 3,
+        height: 2
+      };
+
+      const info = {
+        name,
+        pos,
+        snapToGrid: true,
+        hidden: false
+      };
+
+      this.modifyOutput(info, cellModel.id);
+    } else {
+      return;
+    }
+  }
+
+  /**
+   * Whether or not the dashboard is in the middle of a batch of changes.
+   */
+  get inBatch(): boolean {
+    return this._inBatch;
+  }
+
+  /**
+   * Begin a batch of actions. Actions won't be performed until the batch ends.
+   */
+  public beginBatch(): void {
+    this._inBatch = true;
+  }
+
+  /**
+   * End a batch of actions and perform all actions queued since the batch began.
+   */
+  public endBatch(): void {
+    if (!this.inBatch) {
+      return;
+    }
+    this._inBatch = false;
+    this._doChanges();
+  }
+
+  /**
+   * Performs all queued actions.
+   */
+  private _doChanges(): void {
+    this._undoManager.do(this._changes);
+    this._changes = { do: [], undo: [] };
+  }
+
+  /**
+   * Self-explanatory (if wordy) function name.
+   *
+   * @param action - the action to push or peform.
+   */
+  private _pushActionAndDoIfNotBatch(
+    action: IUndoableAction<OutputChange>
+  ): void {
+    this._changes.do.push(action.do);
+    this._changes.undo.push(action.undo);
+    if (!this.inBatch) {
+      this._doChanges();
+    }
+  }
+
+  /**
+   * Performs the changes described in an array of `IDashboardChanges`.
+   * Meant to be passed to an `UndoManager`.
+   *
+   * @param actions - An array of actions to handle.
+   */
+  public handleDashboardChanges(changes: OutputChange[]): void {
+    this._model.beginBatch();
+    changes.forEach(change => this._handleDashboardChange(change));
+    this._model.endBatch();
+  }
+
+  /**
+   * Performs a change described in an `IDashboardChange`.
+   *
+   * @param action - An action to handle.
+   */
+  private _handleDashboardChange(change: OutputChange): void {
+    // Add overlap resolution
+    switch (change.type) {
+      case 'add':
+        this._model.setCellInfo(change.id, change.info);
+        break;
+      case 'remove':
+        this._model.hideCell(change.id);
+        break;
+      case 'modify':
+        this._model.setPartialCellInfo(change.id, change.info);
+        break;
+    }
+  }
+
+  modifyOutput(info: Partial<dbformat.ICellView>, id: string): void {
+    const oldInfo = this._model.getCellInfo(id);
+    const doChange: OutputModify = {
+      type: 'modify',
+      info,
+      id
+    };
+    const undoChange: OutputModify = {
+      type: 'modify',
+      info: oldInfo,
+      id
+    };
+    const action = {
+      do: doChange,
+      undo: undoChange
+    };
+    this._pushActionAndDoIfNotBatch(action);
+  }
+
+  removeOutput(id: string): void {
+    const info = this._model.getCellInfo(id);
+    const doChange: OutputRemove = {
+      type: 'remove',
+      id
+    };
+    const undoChange: OutputAdd = {
+      type: 'add',
+      id,
+      info
+    };
+    const action = {
+      do: doChange,
+      undo: undoChange
+    };
+    this._pushActionAndDoIfNotBatch(action);
+  }
+
+  addOutput(info: dbformat.ICellView, id: string): void {
+    const doChange: OutputAdd = {
+      type: 'add',
+      id,
+      info
+    };
+    const undoChange: OutputRemove = {
+      type: 'remove',
+      id
+    };
+    const action = {
+      do: doChange,
+      undo: undoChange
+    };
+    this._pushActionAndDoIfNotBatch(action);
+  }
+
+  /**
+   * Undo the last change made to the dashboard.
+   */
+  undo(): void {
+    this._undoManager.undo();
+  }
+
+  /**
+   * Redo the last undone change to the dashboard.
+   */
+  redo(): void {
+    this._undoManager.redo();
+  }
+
+  /**
+   * The model for the `Dashboard`.
+   */
+  get model(): NewDashboardModel {
+    return this._model;
+  }
+
+  private _model: NewDashboardModel;
+  private _undoManager: UndoManager<OutputChange[]>;
+  private _changes: IUndoableAction<OutputChange[]>;
+  private _inBatch: boolean;
+  private _canvas: HTMLCanvasElement;
+  // Using a public variable because `Widget`s have to have a layout of type `Layout`.
+  public layout: NewDashboardLayout;
+}
+
+/**
+ * A Widget to host a Dashboard
+ */
+export class DashboardPanel extends Panel {
+  /**
+   * Construct a new `Dashboard`
+   *
+   * @param options - The options to construct a `Dashboard`
+   */
+  constructor(options: DashboardPanel.IOptions) {
+    super();
+
+    const {
+      context,
+      rendermime,
+      contentFactory,
+      mimeTypeService,
+      editorConfig,
+      notebookConfig
+    } = options;
+
+    this._context = context;
+    this.rendermime = rendermime;
+    this.contentFactory = contentFactory;
+    this.mimeTypeService = mimeTypeService;
+    this._editorConfig = editorConfig;
+    this._notebookConfig = notebookConfig;
+
+    DashboardPanel.selectDashboard(context.model.metadata).then(dashboardId => {
+      const dashboardModel = new NewDashboardModel({
+        dashboardId,
+        context,
+        rendermime,
+        contentFactory,
+        mimeTypeService,
+        editorConfig,
+        notebookConfig
+      });
+      this._dashboard = new NewDashboard(dashboardModel);
+      this.addWidget(this._dashboard);
+    });
+  }
+
+  /**
+   * The rendermime instance for this context.
+   */
+  readonly rendermime: IRenderMimeRegistry;
+
+  /**
+   * A `NotebookPanel` content factory.
+   */
+  readonly contentFactory: NotebookPanel.IContentFactory;
+
+  /**
+   * The service used to look up mime types.
+   */
+  readonly mimeTypeService: IEditorMimeTypeService;
+
+  /**
+   * Getter for the notebook cell editor configuration.
+   */
+  get editorConfig(): StaticNotebook.IEditorConfig {
+    return this._editorConfig;
+  }
+  /**
+   * Setter for the notebook cell editor configuration.
+   *
+   * @param value - The `EditorConfig` of the notebook.
+   */
+  set editorConfig(value: StaticNotebook.IEditorConfig) {
+    this._editorConfig = value;
+  }
+  /**
+   * Getter for the notebook configuration.
+   */
+  get notebookConfig(): StaticNotebook.INotebookConfig {
+    return this._notebookConfig;
+  }
+  /**
+   * Setter for the notebook configuration.
+   *
+   * @param value - The configuration of the notebook.
+   */
+  set notebookConfig(value: StaticNotebook.INotebookConfig) {
+    this._notebookConfig = value;
+  }
+
+  /**
+   * Dispose of the resources held by the widget.
+   */
+  dispose(): void {
+    this._dashboard = undefined;
+    super.dispose();
+  }
+
+  /**
+   * Save the dashboard to the notebook metadata.
+   */
+  save(): void {
+    this._context.save();
+  }
+
+  /**
+   * The `Dashboard` hosted by the panel.
+   */
+  get dashboard(): NewDashboard {
+    return this._dashboard;
+  }
+
+  private _context: DocumentRegistry.IContext<INotebookModel>;
+  private _editorConfig: StaticNotebook.IEditorConfig;
+  private _notebookConfig: StaticNotebook.INotebookConfig;
+  private _dashboard: NewDashboard;
+}
+
+export namespace DashboardPanel {
+  export type IOptions = NewDashboardModel.IOptions;
+
+  /**
+   * Resolves which dashboard should be rendered from a notebook's metadata.
+   *
+   * @param metadata - the notebook metadata containing the dashboard info.
+   *
+   * @returns the selected dashboard id and name, or undefined if there are none or
+   * none are selected.
+   */
+  export async function selectDashboard(
+    metadata: IObservableJSON
+  ): Promise<string | undefined> {
+    const data = metadata.get('presto') as Record<string, any>;
+    if (data == null || data.views == null) {
+      return undefined;
+    }
+
+    const dashboardIds = Object.keys(data.views);
+    const dashboardMap = new Map<string, string>(
+      dashboardIds.map(id => [data.views[id].name, id])
+    );
+    console.log('dashboardMap', dashboardMap.entries());
+    if (dashboardIds.length === 1) {
+      return dashboardIds[0];
+    }
+
+    InputDialog.getItem({
+      title: 'Select a Dashboard',
+      current: 0,
+      items: Array.from(dashboardMap.keys())
+    }).then(v => {
+      if (v.value == null) {
+        return undefined;
+      }
+      return dashboardMap.get(v.value);
+    });
+  }
+}
+
+/**
+ * A namespace for private functionality
+ */
+namespace Private {
+  /**
+   * Rounds `num` to the nearest integer multiple of `roundTo`.
+   */
+  export function mround(num: number, roundTo: number): number {
+    return roundTo * Math.round(num / roundTo);
   }
 }

--- a/src/dbformat.ts
+++ b/src/dbformat.ts
@@ -60,14 +60,14 @@ export interface IOutputInfo extends PartialJSONObject {
 
 export interface ICellView {
   name: string;
-  pos: WidgetPosition,
-  hidden: boolean,
-  snapToGrid: boolean,
+  pos: WidgetPosition;
+  hidden: boolean;
+  snapToGrid: boolean;
 }
 
 export interface ICellMetadataFormat {
   id: string;
-  views: { [id: string]: ICellView }
+  views: { [id: string]: ICellView };
 }
 
 export interface IDashboardView {
@@ -78,8 +78,7 @@ export interface IDashboardView {
   dashboardHeight: number;
 }
 
-
 export interface INBMetadataFormat {
   id: string;
-  views: { [id: string]: IDashboardView }
+  views: { [id: string]: IDashboardView };
 }

--- a/src/dbformat.ts
+++ b/src/dbformat.ts
@@ -1,5 +1,7 @@
 import { PartialJSONObject } from '@lumino/coreutils';
 
+import { WidgetPosition } from './widgetstore';
+
 export const DASHBOARD_VERSION = 1;
 
 /**
@@ -54,4 +56,30 @@ export interface IOutputInfo extends PartialJSONObject {
     width: number;
     height: number;
   };
+}
+
+export interface ICellView {
+  name: string;
+  pos: WidgetPosition,
+  hidden: boolean,
+  snapToGrid: boolean,
+}
+
+export interface ICellMetadataFormat {
+  id: string;
+  views: { [id: string]: ICellView }
+}
+
+export interface IDashboardView {
+  name: string;
+  cellWidth: number;
+  cellHeight: number;
+  dashboardWidth: number;
+  dashboardHeight: number;
+}
+
+
+export interface INBMetadataFormat {
+  id: string;
+  views: { [id: string]: IDashboardView }
 }

--- a/src/dbformat.ts
+++ b/src/dbformat.ts
@@ -78,7 +78,42 @@ export interface IDashboardView {
   dashboardHeight: number;
 }
 
-export interface INBMetadataFormat {
+export interface IDBMetadata {
   id: string;
   views: { [id: string]: IDashboardView };
+}
+
+// Currently identical to verifyNVMetadata
+export function verifyCellMetadata(metadata: any): boolean {
+  return metadata && 'id' in metadata && 'views' in metadata;
+}
+
+// Currently identical to verifyCellMetadata
+export function verifyDBMetadata(metadata: any): boolean {
+  return metadata && 'id' in metadata && 'views' in metadata;
+}
+
+export function verifyCellView(view: any): boolean {
+  return (
+    view &&
+    'name' in view &&
+    'pos' in view &&
+    'top' in view.pos &&
+    'left' in view.pos &&
+    'width' in view.pos &&
+    'height' in view.pos &&
+    'hidden' in view &&
+    'snapToGrid' in view
+  );
+}
+
+export function verifyDashboardView(view: any): boolean {
+  return (
+    view &&
+    'name' in view &&
+    'cellWidth' in view &&
+    'cellHeight' in view &&
+    'dashboardWidth' in view &&
+    'dashboardHeight' in view
+  );
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,0 +1,148 @@
+import { DocumentRegistry, ABCWidgetFactory } from '@jupyterlab/docregistry';
+
+import { CommandRegistry } from '@lumino/commands';
+
+import { NewDashboardDocumentWidget, DashboardPanel } from './dashboard';
+
+import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
+
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
+import {
+  INotebookModel,
+  NotebookPanel,
+  StaticNotebook
+} from '@jupyterlab/notebook';
+
+/**
+ * A widget factory for `DashboardDocument` widgets.
+ */
+export class NewDashboardDocumentWidgetFactory extends ABCWidgetFactory<
+  NewDashboardDocumentWidget,
+  INotebookModel
+> {
+  constructor(
+    options: NewDashboardDocumentWidgetFactory.IOptions<
+      NewDashboardDocumentWidget
+    >
+  ) {
+    super(options);
+    this.commands = options.commands;
+    this.rendermime = options.rendermime;
+    this.contentFactory =
+      options.contentFactory || NotebookPanel.defaultContentFactory;
+    this.mimeTypeService = options.mimeTypeService;
+    this._editorConfig =
+      options.editorConfig || StaticNotebook.defaultEditorConfig;
+    this._notebookConfig =
+      options.notebookConfig || StaticNotebook.defaultNotebookConfig;
+  }
+
+  /**
+   * The `CommandRegistry` used to build the toolbar.
+   */
+  readonly commands: CommandRegistry;
+
+  /**
+   * The rendermime instance.
+   */
+  readonly rendermime: IRenderMimeRegistry;
+
+  /**
+   * The content factory used by the widget factory.
+   */
+  readonly contentFactory: NotebookPanel.IContentFactory;
+
+  /**
+   * The service used to look up mime types.
+   */
+  readonly mimeTypeService: IEditorMimeTypeService;
+
+  /**
+   * A configuration object for cell editor settings.
+   */
+  get editorConfig(): StaticNotebook.IEditorConfig {
+    return this._editorConfig;
+  }
+  set editorConfig(value: StaticNotebook.IEditorConfig) {
+    this._editorConfig = value;
+  }
+
+  /**
+   * A configuration object for notebook settings.
+   */
+  get notebookConfig(): StaticNotebook.INotebookConfig {
+    return this._notebookConfig;
+  }
+  set notebookConfig(value: StaticNotebook.INotebookConfig) {
+    this._notebookConfig = value;
+  }
+
+  /**
+   * Creates a new `DashboardDocumentWidget`.
+   *
+   * @param context - The `Notebook` context.
+   * @param source - An optional `DashboardDocumentWidget`.
+   */
+  protected createNewWidget(
+    context: DocumentRegistry.IContext<INotebookModel>,
+    source?: NewDashboardDocumentWidget
+  ): NewDashboardDocumentWidget {
+    const options = {
+      context: context,
+      rendermime: source
+        ? source.content.rendermime
+        : this.rendermime.clone({ resolver: context.urlResolver }),
+      contentFactory: this.contentFactory,
+      mimeTypeService: this.mimeTypeService,
+      editorConfig: source ? source.content.editorConfig : this._editorConfig,
+      notebookConfig: source
+        ? source.content.notebookConfig
+        : this._notebookConfig
+    };
+
+    return new NewDashboardDocumentWidget({
+      context,
+      content: new DashboardPanel(options),
+      commands: this.commands
+    });
+  }
+
+  private _editorConfig: StaticNotebook.IEditorConfig;
+  private _notebookConfig: StaticNotebook.INotebookConfig;
+}
+
+export namespace NewDashboardDocumentWidgetFactory {
+  export interface IOptions<T extends NewDashboardDocumentWidget>
+    extends DocumentRegistry.IWidgetFactoryOptions<T> {
+    /*
+     * A rendermime instance.
+     */
+    rendermime: IRenderMimeRegistry;
+
+    /**
+     * A notebook panel content factory.
+     */
+    contentFactory: NotebookPanel.IContentFactory;
+
+    /**
+     * The service used to look up mime types.
+     */
+    mimeTypeService: IEditorMimeTypeService;
+
+    /**
+     * A `CommandRegistry` containing commands used to the build the `DashboardDocumentWidget` toolbar.
+     */
+    commands: CommandRegistry;
+
+    /**
+     * The notebook cell editor configuration.
+     */
+    editorConfig?: StaticNotebook.IEditorConfig;
+
+    /**
+     * The notebook configuration.
+     */
+    notebookConfig?: StaticNotebook.INotebookConfig;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,8 +131,8 @@ const extension: JupyterFrontEndPlugin<IDashboardTracker> = {
       const model = widget.content.model;
       // TODO: Make scrollMode changable in JL. Default 'infinite' for now.
       model.scrollMode = 'infinite';
-      model.width = Dashboard.DEFAULT_WIDTH;
-      model.height = Dashboard.DEFAULT_HEIGHT;
+      model.width = (widget.content.layout as DashboardLayout).width;
+      model.height = (widget.content.layout as DashboardLayout).height;
     });
 
     // Add commands to context menus.
@@ -442,8 +442,8 @@ function addCommands(
     label: 'Set Dashboard Dimensions',
     execute: async args => {
       const model = dashboardTracker.currentWidget.model;
-      const width = model.width ? model.width : Dashboard.DEFAULT_WIDTH;
-      const height = model.height ? model.height : Dashboard.DEFAULT_HEIGHT;
+      const width = model.width ? model.width : window.innerWidth;
+      const height = model.height ? model.height : window.innerHeight;
       await showDialog({
         title: 'Enter Dimensions',
         body: new Private.ResizeHandler(width, height),
@@ -458,14 +458,14 @@ function addCommands(
         }
         if (!newWidth) {
           if (!model.width) {
-            newWidth = Dashboard.DEFAULT_WIDTH;
+            newWidth = window.innerWidth;
           } else {
             newWidth = model.width;
           }
         }
         if (!newHeight) {
           if (!model.height) {
-            newHeight = Dashboard.DEFAULT_HEIGHT;
+            newHeight = window.innerHeight;
           } else {
             newHeight = model.height;
           }
@@ -543,9 +543,15 @@ function addCommands(
 
   commands.addCommand(CommandIDs.saveToMetadata, {
     label: 'Save Dashboard To Notebook Metadata',
-    execute: args => {
-      const dashboard = dashboardTracker.currentWidget;
-      dashboard.saveToNotebookMetadata();
+    execute: async args => {
+      const name = await InputDialog.getText({
+        title: 'Dashboard name',
+        text: 'default'
+      });
+      if (name.value) {
+        const dashboard = dashboardTracker.currentWidget;
+        dashboard.saveToNotebookMetadata(name.value);
+      }
     }
   });
 
@@ -588,7 +594,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.openFromMetadata, {
     label: 'Open Metadata Dashboard',
-    execute: args => {
+    execute: async args => {
       const notebook = notebookTracker.currentWidget;
       const notebookMetadata = getMetadata(notebook);
       if (!('views' in notebookMetadata)) {
@@ -598,15 +604,40 @@ function addCommands(
       let dashboardId: string;
       if (args.id != null) {
         dashboardId = args.id as string;
-        if (!(notebookMetadata.views as Object).hasOwnProperty(dashboardId)) {
-          throw new Error(`Dashboard id ${dashboardId} doesn't exist in notebook ${notebookId}`);
+        if (
+          // eslint-disable-next-line no-prototype-builtins
+          !(notebookMetadata.views as Record<string, any>).hasOwnProperty(
+            dashboardId
+          )
+        ) {
+          throw new Error(
+            `Dashboard id ${dashboardId} doesn't exist in notebook ${notebookId}`
+          );
         }
       } else {
-        dashboardId = Object.keys(notebookMetadata.views)[0]
+        const dashboardIds = Object.keys(notebookMetadata.views);
+        const nameMap = new Map<string, string>(
+          dashboardIds.map(id => [notebookMetadata.views[id].name, id])
+        );
+        const dashboardName = await InputDialog.getItem({
+          title: 'Select a Dashboard',
+          current: 0,
+          items: Array.from(nameMap.keys())
+        });
+        if (dashboardName.value) {
+          dashboardId = nameMap.get(dashboardName.value);
+        } else {
+          return;
+        }
       }
 
       const dashboardView = notebookMetadata.views[dashboardId];
-      const { cellHeight, cellWidth, dashboardHeight, dashboardWidth } = dashboardView;
+      const {
+        cellHeight,
+        cellWidth,
+        dashboardHeight,
+        dashboardWidth
+      } = dashboardView;
 
       const cells = notebook.content.widgets;
 
@@ -617,15 +648,17 @@ function addCommands(
       for (const cell of cells) {
         const metadata = getMetadata(cell);
         if (metadata !== undefined && !metadata.views[dashboardId].hidden) {
-          let { pos, snapToGrid } = metadata.views[dashboardId];
-          let { left, top, width, height } = pos;
+          const { pos, snapToGrid } = metadata.views[dashboardId];
+          const { left, top, width, height } = pos;
 
-          let adjustedPos = !snapToGrid ? pos : {
-            left: left * cellWidth,
-            top: top * cellHeight,
-            width: width * cellWidth,
-            height: height * cellHeight
-          };
+          const adjustedPos = !snapToGrid
+            ? pos
+            : {
+                left: left * cellWidth,
+                top: top * cellHeight,
+                width: width * cellWidth,
+                height: height * cellHeight
+              };
 
           const widgetInfo: WidgetInfo = {
             widgetId: DashboardWidget.createDashboardWidgetId(),
@@ -663,7 +696,7 @@ function addCommands(
       const notebook = notebookTracker.currentWidget;
       const metadata = getMetadata(notebook);
       if (metadata !== undefined) {
-        return true
+        return true;
       }
       return false;
     }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -8,7 +8,7 @@ import { MessageLoop, Message } from '@lumino/messaging';
 
 import { DashboardWidget } from './widget';
 
-import { Widgetstore, WidgetSchema, WidgetPosition } from './widgetstore';
+import { Widgetstore, WidgetSchema, WidgetInfo, WidgetPosition } from './widgetstore';
 
 import { WidgetTracker } from '@jupyterlab/apputils';
 
@@ -240,12 +240,12 @@ export class DashboardLayout extends Layout {
       }
       this.attachWidget(widget);
 
-      const { id, notebookId, cellId } = widget;
+      const { id, notebookId, cellId, snapToGrid } = widget;
 
       const ignore = !this._signalChanges;
 
       widget.ready.connect(() => {
-        this._updateWidget(widget, widget.pos, false);
+        this._updateWidget(widget, { pos: widget.pos }, false);
         this.fixOverlaps(widget);
         this._outputTracker.add(widget);
 
@@ -255,6 +255,7 @@ export class DashboardLayout extends Layout {
           widgetId: id,
           notebookId,
           cellId,
+          snapToGrid,
           ignore
         };
 
@@ -275,14 +276,14 @@ export class DashboardLayout extends Layout {
    */
   updateWidget(
     widget: DashboardWidget,
-    pos: Widgetstore.WidgetPosition
+    newInfo: Partial<WidgetInfo>
   ): boolean {
     const wasInBatch = this.inBatch;
     if (!wasInBatch) {
       this.startBatch();
     }
 
-    const success = this._updateWidgetHelper(widget, pos);
+    const success = this._updateWidgetHelper(widget, newInfo);
 
     if (!wasInBatch) {
       this.endBatch();
@@ -308,14 +309,15 @@ export class DashboardLayout extends Layout {
    */
   private _updateWidgetHelper(
     widget: DashboardWidget,
-    pos: Widgetstore.WidgetPosition,
+    newInfo: Partial<WidgetInfo>,
     fixOverlaps = true
   ): boolean {
-    const success = this._updateWidget(widget, pos, fixOverlaps);
+    const success = this._updateWidget(widget, newInfo, fixOverlaps);
     if (success) {
       const change: IDashboardChange = {
-        type: 'move',
+        type: 'update',
         widgetId: widget.id,
+        snapToGrid: widget.snapToGrid,
         pos: widget.pos
       };
       this.signalChange(change);
@@ -341,7 +343,7 @@ export class DashboardLayout extends Layout {
    */
   private _updateWidget(
     widget: DashboardWidget,
-    pos: Widgetstore.WidgetPosition,
+    newInfo: Partial<WidgetInfo>,
     fixOverlaps = true
   ): boolean {
     // Get the item from the map.
@@ -352,7 +354,12 @@ export class DashboardLayout extends Layout {
       return false;
     }
 
-    let { left, top, width, height } = pos;
+    // Just changing snap-to-grid status.
+    if (newInfo.pos == null) {
+      return true
+    }
+
+    let { left, top, width, height } = newInfo.pos;
 
     // Constrain the widget to the dashboard dimensions.
     if (this._width !== 0 && left + width > this._width) {
@@ -499,7 +506,7 @@ export class DashboardLayout extends Layout {
       }
 
       // Widget was moved or resized; update.
-      this.updateWidget(item.widget as DashboardWidget, pos);
+      this.updateWidget(item.widget as DashboardWidget, { pos });
     }
   }
 
@@ -627,7 +634,7 @@ export class DashboardLayout extends Layout {
       this._expandCanvas(type, widthDiff);
     }
 
-    this._updateWidget(widget, newPos);
+    this._updateWidget(widget, { pos: newPos });
   }
 
   /**
@@ -682,7 +689,7 @@ export class DashboardLayout extends Layout {
           const widget = _widget as DashboardWidget;
           const pos = widget.pos;
           pos.left += amount;
-          this._updateWidgetHelper(widget, pos);
+          this._updateWidgetHelper(widget, { pos });
         });
         break;
       case 'right':
@@ -694,7 +701,7 @@ export class DashboardLayout extends Layout {
           const widget = _widget as DashboardWidget;
           const pos = widget.pos;
           pos.top += amount;
-          this._updateWidgetHelper(widget, pos);
+          this._updateWidgetHelper(widget, { pos });
         });
         break;
       case 'down':
@@ -878,7 +885,7 @@ export class DashboardLayout extends Layout {
     this.startBatch();
     each(this, _widget => {
       const widget = _widget as DashboardWidget;
-      this.updateWidget(widget, widget.pos);
+      this.updateWidget(widget, { pos: widget.pos });
     });
     this.endBatch();
   }
@@ -1016,7 +1023,7 @@ export namespace DashboardLayout {
 /**
  * A type for dashboard changes emitted by the changed signal.
  */
-export type DashboardChangeType = 'add' | 'remove' | 'move';
+export type DashboardChangeType = 'add' | 'remove' | 'update';
 
 /**
  * An interface describing a change that occurs to the dashboard.
@@ -1036,6 +1043,8 @@ export interface IDashboardChange {
   notebookId?: string;
 
   cellId?: string;
+
+  snapToGrid?: boolean;
 
   ignore?: boolean;
 }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -8,7 +8,12 @@ import { MessageLoop, Message } from '@lumino/messaging';
 
 import { DashboardWidget } from './widget';
 
-import { Widgetstore, WidgetSchema, WidgetInfo, WidgetPosition } from './widgetstore';
+import {
+  Widgetstore,
+  WidgetSchema,
+  WidgetInfo,
+  WidgetPosition
+} from './widgetstore';
 
 import { WidgetTracker } from '@jupyterlab/apputils';
 
@@ -274,10 +279,7 @@ export class DashboardLayout extends Layout {
    *
    * @returns - whether the update was successful.
    */
-  updateWidget(
-    widget: DashboardWidget,
-    newInfo: Partial<WidgetInfo>
-  ): boolean {
+  updateWidget(widget: DashboardWidget, newInfo: Partial<WidgetInfo>): boolean {
     const wasInBatch = this.inBatch;
     if (!wasInBatch) {
       this.startBatch();
@@ -356,7 +358,7 @@ export class DashboardLayout extends Layout {
 
     // Just changing snap-to-grid status.
     if (newInfo.pos == null) {
-      return true
+      return true;
     }
 
     let { left, top, width, height } = newInfo.pos;

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -1,0 +1,107 @@
+// import { CommandToolbarButton, Toolbar, ReactWidget } from '@jupyterlab/apputils';
+
+// import { Widget } from '@lumino/widgets';
+
+// import { CommandRegistry } from '@lumino/commands';
+
+// import { CommandIDs } from './commands';
+
+// import { DashboardPanel, NewDashboard } from './dashboard';
+
+// import { HTMLSelect } from '@jupyterlab/ui-components';
+
+// import * as React from 'react';
+
+// const TOOLBAR_MODE_SWITCHER_CLASS = 'pr-ToolbarModeSwitcher';
+// const TOOLBAR_SELECT_CLASS = 'pr-ToolbarSelector';
+
+// function makeToolbarButton(
+//   commands: CommandRegistry,
+//   dashboardId: string,
+//   commandId: string,
+//   tooltip: string
+// ): CommandToolbarButton {
+//   const args = {
+//     toolbar: true,
+//     dashboardId
+//   }
+//   const button = new CommandToolbarButton({ args, commands, id: commandId });
+//   button.node.title = tooltip;
+//   return button;
+// }
+
+// class DashboardModeSwitcher extends ReactWidget {
+//   constructor(dashboard: NewDashboard) {
+//     super();
+//     this.addClass(TOOLBAR_MODE_SWITCHER_CLASS);
+//     this._dashboard = dashboard;
+
+//     if (dashboard.model) {
+//       this.update();
+//     }
+
+//     dashboard.model.stateChanged.connect((_sender, change) => {
+//       if (change.name === 'mode') {
+//         this.update();
+//       }
+//     }, this);
+//   }
+
+//   private _handleChange(
+//     that: DashboardModeSwitcher
+//   ): (event: React.ChangeEvent<HTMLSelectElement>) => void {
+//     return (event: React.ChangeEvent<HTMLSelectElement>): void => {
+//       that.dashboard.model.mode = event.target.value as NewDashboard.Mode;
+//     };
+//   }
+
+//   render(): JSX.Element {
+//     const value = this._dashboard.model.mode;
+//     return (
+//       <HTMLSelect
+//         className={TOOLBAR_SELECT_CLASS}
+//         onChange={this._handleChange(this)}
+//         value={value}
+//         aria-label={'Mode'}
+//       >
+//         <option value="present">Present</option>
+//         <option value="grid-edit">Edit</option>
+//       </HTMLSelect>
+//     );
+//   }
+
+//   get dashboard(): NewDashboard {
+//     return this._dashboard;
+//   }
+
+//   private _dashboard: NewDashboard;
+// }
+
+// export function buildToolbar(
+//   toolbar: Toolbar<Widget>,
+//   commands: CommandRegistry,
+//   dashboardPanel: DashboardPanel
+// ): void {
+//   const dashboard = dashboardPanel.dashboard;
+//   const dashboardId = dashboard.id;
+//   const { save, undo, redo, cut, copy, paste } = CommandIDs;
+
+//   const commandPairs = [
+//     [save, 'Save'],
+//     [undo, 'Undo'],
+//     [redo, 'Redo'],
+//     [cut, 'Cut the selected outputs'],
+//     [copy, 'Cut the selected outputs'],
+//     [paste, 'Paste outputs from the clipboard'],
+//   ];
+
+//   for (const pair of commandPairs) {
+//     const [ commandId, tooltip ] = pair;
+//     const button = makeToolbarButton(commands, dashboardId, commandId, tooltip);
+//     toolbar.addItem(commandId, button);
+//   }
+
+//   toolbar.addItem('spacer', Toolbar.createSpacerItem());
+
+//   toolbar.addItem('switchMode', new DashboardModeSwitcher(dashboard));
+// }

--- a/src/undo.ts
+++ b/src/undo.ts
@@ -1,0 +1,112 @@
+export interface IUndoableAction<T> {
+  do: T;
+  undo: T;
+}
+
+export class UndoRedoList<T> {
+  constructor(size: number, content: IUndoableAction<T>[] = []) {
+    this._size = size;
+
+    if (content.length > size) {
+      console.warn(
+        `Size of provided content (${content.length}) is larger than the maximum provided size (${size}).`,
+        'Initializing content as empty.'
+      );
+      this._content = [];
+    } else {
+      this._content = content;
+    }
+  }
+
+  toString(): string {
+    return this._content.toString();
+  }
+
+  get size(): number {
+    return this._size;
+  }
+
+  get length(): number {
+    return this._content.length;
+  }
+
+  clear(): void {
+    this._content = [];
+  }
+
+  push(actions: IUndoableAction<T>): void {
+    if (this.length >= this.size) {
+      this._content.pop();
+    }
+    this._content.push(actions);
+  }
+
+  pop(): IUndoableAction<T> | undefined {
+    if (this.length === 0) {
+      return undefined;
+    }
+    return this._content.pop();
+  }
+
+  shift(): IUndoableAction<T> | undefined {
+    if (this.length === 0) {
+      return undefined;
+    }
+    return this._content.shift();
+  }
+
+  private _content: IUndoableAction<T>[];
+  private _size: number;
+}
+
+export class UndoManager<T> {
+  constructor(actionHandler: (action: T) => void, memory = 10) {
+    this._actionHandler = actionHandler;
+    this._memory = memory;
+    this._undoList = new UndoRedoList(memory);
+    this._redoList = new UndoRedoList(memory);
+  }
+
+  do(action: IUndoableAction<T>): void {
+    this._actionHandler(action.do);
+    this._redoList.clear();
+    this._undoList.push(action);
+  }
+
+  undo(): void {
+    if (!this.hasUndo) {
+      return;
+    }
+    const lastDoneAction = this._undoList.shift();
+    this._redoList.push(lastDoneAction);
+    this._actionHandler(lastDoneAction.undo);
+  }
+
+  redo(): void {
+    if (!this.hasRedo) {
+      return;
+    }
+    const lastUndoneAction = this._redoList.shift();
+    this._undoList.push(lastUndoneAction);
+    this._actionHandler(lastUndoneAction.do);
+  }
+
+  get memory(): number {
+    return this._memory;
+  }
+
+  get hasUndo(): boolean {
+    return this._undoList.length > 0;
+  }
+
+  get hasRedo(): boolean {
+    return this._redoList.length > 0;
+  }
+
+  private _undoList: UndoRedoList<T>;
+  private _redoList: UndoRedoList<T>;
+  private _actionHandler: (action: T) => void;
+  private _memory: number;
+}
+
+export default UndoManager;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,32 @@ export function updateMetadata(
     source.model.metadata.set('presto', newValues);
   }
 }
+
+export function addMetadataView(
+  source: NotebookPanel | Cell,
+  viewId: string,
+  view: ReadonlyPartialJSONObject
+): void {
+  const oldMetadata = getMetadata(source);
+  let newMetadata;
+
+  // This sets an ID for a cell without metadata--maybe not the desired behavior.
+  if (oldMetadata == null) {
+    newMetadata = {
+      id: UUID.uuid4(),
+      views: {}
+    };
+  } else {
+    newMetadata = { ...oldMetadata };
+  }
+
+  if (!(newMetadata as Object).hasOwnProperty('views')) {
+    newMetadata['views'] = {};
+  }
+  newMetadata.views[viewId] = view;
+
+  source.model.metadata.set('presto', newMetadata);
+}
 /**
  * Adds a random, unique ID to a notebook's metadata.
  *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,8 @@ export function addMetadataView(
     newMetadata = { ...oldMetadata };
   }
 
-  if (!(newMetadata as Object).hasOwnProperty('views')) {
+  // eslint-disable-next-line no-prototype-builtins
+  if (!(newMetadata as Record<string, any>).hasOwnProperty('views')) {
     newMetadata['views'] = {};
   }
   newMetadata.views[viewId] = view;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -267,7 +267,7 @@ export class DashboardWidget extends Widget {
     }
 
     if (pos !== oldPos) {
-      (this.parent as Dashboard).updateWidget(this, pos);
+      (this.parent as Dashboard).updateWidget(this, { pos });
     }
   }
 
@@ -541,7 +541,7 @@ export class DashboardWidget extends Widget {
 
     if (this._mouseMode === 'resize' && this.parent !== undefined) {
       const pos = this.pos;
-      (this.parent as Dashboard).updateWidget(this, pos);
+      (this.parent as Dashboard).updateWidget(this, { pos });
     }
 
     this._mouseMode = 'none';
@@ -584,7 +584,8 @@ export class DashboardWidget extends Widget {
       widgetId: this.id,
       cellId: this.cellId,
       notebookId: this.notebookId,
-      removed: false
+      removed: false,
+      snapToGrid: this.snapToGrid
     };
   }
 
@@ -653,15 +654,26 @@ export class DashboardWidget extends Widget {
   }
   set mode(newMode: Dashboard.Mode) {
     this._mode = newMode;
-    if (newMode === 'present') {
-      this.removeClass(EDITABLE_WIDGET_CLASS);
-    } else {
-      this.addClass(EDITABLE_WIDGET_CLASS);
-    }
-    if (newMode === 'grid-edit') {
-      if (this.parent) {
-        (this.parent as Dashboard).updateWidget(this, this.pos);
-      }
+
+
+    switch (newMode) {
+      case 'present':
+        this.removeClass(EDITABLE_WIDGET_CLASS);
+        break;
+      case 'free-edit':
+        this.addClass(EDITABLE_WIDGET_CLASS);
+        if (this.parent) {
+          (this.parent as Dashboard).updateWidget(this, { snapToGrid: false });
+        }
+        break;
+      case 'grid-edit':
+        this.addClass(EDITABLE_WIDGET_CLASS);
+        if (this.parent) {
+          (this.parent as Dashboard).updateWidget(this, {
+            pos: this.pos,
+            snapToGrid: true
+          });
+        }
     }
   }
 
@@ -691,6 +703,10 @@ export class DashboardWidget extends Widget {
   set content(newContent: Widget) {
     this._content.dispose();
     this._content = newContent;
+  }
+
+  get snapToGrid(): boolean {
+    return this.mode === 'grid-edit';
   }
 
   private _notebook: NotebookPanel;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -245,7 +245,12 @@ export class DashboardWidget extends Widget {
     const pos = this.pos;
     const oldPos = { ...pos };
 
-    const bumpDistance = event.altKey ? 1 : DashboardWidget.BUMP_DISTANCE;
+    let bumpDistance: number;
+    if (this._mode === 'grid-edit') {
+      bumpDistance = (this.parent.layout as DashboardLayout).tileSize;
+    } else {
+      bumpDistance = event.altKey ? 1 : DashboardWidget.BUMP_DISTANCE;
+    }
 
     switch (event.keyCode) {
       // Left arrow key
@@ -654,7 +659,6 @@ export class DashboardWidget extends Widget {
   }
   set mode(newMode: Dashboard.Mode) {
     this._mode = newMode;
-
 
     switch (newMode) {
       case 'present':

--- a/src/widgetstore.ts
+++ b/src/widgetstore.ts
@@ -94,7 +94,10 @@ export class Widgetstore extends Litestore {
           this.addWidget(change as WidgetInfo);
           break;
         case 'update':
-          this.updateWidget(widgetId, { pos: pos as WidgetPosition, snapToGrid });
+          this.updateWidget(widgetId, {
+            pos: pos as WidgetPosition,
+            snapToGrid
+          });
           break;
         case 'remove':
           this.deleteWidget(widgetId);

--- a/style/base.css
+++ b/style/base.css
@@ -4,6 +4,8 @@
 
 .pr-DashboardWidget {
   display: inline-flex;
+  align-items: flex-start;
+  justify-content: left;
 }
 
 .pr-DashboardWidget .pr-MarkdownOutput {
@@ -75,12 +77,11 @@
 }
 
 .pr-DashboardWidgetChild {
-  /* width: 100%;
-  height: 100%; */
+  max-width: 100%;
+  max-height: 100%;
   overflow: hidden;
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  justify-content: left;
 }
 
 .pr-EditableWidget:focus .pr-Resizer {


### PR DESCRIPTION
**TL;DR: Dashboards will now exist embedded in notebook metadata and be openable directly from the file menu. This means they're fully self-contained, have their own kernel, and don't require a  notebook from the same .ipynb file to be open. .dashboard files still exist for now but that may change.**

## What's new

### User-facing changes
- Dashboards with their own kernel can be saved to and opened from .ipynb files. Embedded dashboard functionality is currently very limited (can basically just add and move widgets).
- Multiple dashboards can be embedded in one notebook. If multiple embedded dashboards are present, the user will be prompted to pick one when opening the notebook as a dashboard.

### Code changes
- New dashboard widget, output widget, dashboard layout, dashboard model--almost everything has been re-written to support embedded dashboards.
- Undo/redo now handled by a much lighter `UndoManager` instead of the modified CRDT datastore.

## Todo
End goal is that embedded dashboards have all the functionality dashboards from .dashboard files do. This includes:
- Adding, removing, moving, and resizing outputs.
- Grid-based and absolute positioning of outputs.
- Edit and preview/present modes.
- The ability to change the grid and dashboard size.
- Overlap resolution.
- Undo/redo.