### PR TITLE
Use githubusercontent to fix display of GIFs on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Interactively create and customize dashboards in JupyterLab
 
-![presto-overview](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/overview.gif)
+![presto-overview](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/overview.gif)
 
 ## Additional Gifs
 
@@ -15,39 +15,39 @@ Interactively create and customize dashboards in JupyterLab
   <summary>Click to expand</summary>
   Add and rearrange outputs on dashboards right from your notebook.
 
-![add-move-resize](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/add_move_resize.gif)
+![add-move-resize](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/add_move_resize.gif)
 
 Add outputs from multiple notebooks.
 
-![add-multiple](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/multiple_notebooks.gif)
+![add-multiple](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/multiple_notebooks.gif)
 
 See changes immediately.
 
-![see-changes](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/update_cells.gif)
+![see-changes](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/update_cells.gif)
 
 Preview your dashboard and interact with widgets in present mode.
 
-![present-mode](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/present_edit.gif)
+![present-mode](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/present_edit.gif)
 
 Undo and redo.
 
-![undo-redo](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/undo_redo.gif)
+![undo-redo](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/undo_redo.gif)
 
 Add markdown too.
 
-![markdown-too](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/markdown_too.gif)
+![markdown-too](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/markdown_too.gif)
 
 Save dashboards to file,
 
-![save-dashboard](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/save.gif)
+![save-dashboard](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/save.gif)
 
 Load them up,
 
-![load-dashboard](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/load.gif)
+![load-dashboard](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/load.gif)
 
 And edit them again!
 
-![edit-again](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/blob/master/Design/gifs/edit_again.gif)
+![edit-again](https://raw.githubusercontent.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor/master/Design/gifs/edit_again.gif)
 
 </details>
 


### PR DESCRIPTION
## What's new

Fixes issue with images not showing up on https://pypi.org/project/jupyterlab-interactive-dashboard-editor/
The `overvierw.gif` will not load anyways as it is too large (>10 MB). You will need to compress it for PyPI.
